### PR TITLE
feat(@caia/time-machine-architect): ship architect #14 of 17 — Time Machine specialist

### DIFF
--- a/packages/time-machine-architect/README.md
+++ b/packages/time-machine-architect/README.md
@@ -1,0 +1,58 @@
+# @caia/time-machine-architect
+
+Architect #14 of CAIA's 17-architect EA fan-out. Owns durable rollback + commit-level time-travel.
+
+## What it owns
+
+`timeMachine.*` slice of the `tickets.architecture` JSONB column:
+
+- `timeMachine.versioningStrategy` — every commit captured + described; how the version chain is materialized + addressed (snapshot key shape, commit graph, immutability posture)
+- `timeMachine.snapshotRetention` — how long versions are kept, archival rules, GDPR delete interaction
+- `timeMachine.revertOperation` — **forward-creating** revert (new commit on tip, never destructive overwrite); revert scope (whole feature vs section); idempotency contract
+- `timeMachine.descriptionGeneration` — auto-generated per-commit human-readable summary (style guide, length budget, regeneration policy)
+- `timeMachine.dataConsistency` — revert respects DB state vs application state; transactional posture; cascade rules across upstream Database `dataLifecycle`
+- `timeMachine.auditTrail` — every revert logged + attributed to operator action (who, when, from→to, scope, reason)
+
+## What it does NOT do
+
+No component code. No API endpoint logic. No database schema. No test specs. Other architects own those concerns; the contract rejects out-of-namespace writes.
+
+## How it runs
+
+Implements `SpecialistArchitect` (per spec `research/17_architect_framework_spec_2026.md` §1, §2.14). Wave-2 architect: depends on Backend Architect + Database Architect (especially Database's `dataLifecycle` + GDPR delete patterns) so it knows what state needs versioning and how revert interacts with retention.
+
+The EA Dispatcher spawns one Time Machine architect per applicable ticket. Each spawn calls `@chiefaia/claude-spawner` (subscription-only, no API-key billing) with Sonnet default. Returns a structured `ArchitectOutput` the Dispatcher composes into the ticket's `architecture` JSONB.
+
+**The forward-creating revert invariant.** A revert is itself a commit — appended to the version chain, never an in-place overwrite of history. This is what makes time-travel safe: an operator can revert the revert, walk back to any intermediate state, and the audit trail always shows what happened. The package's golden test pins this invariant.
+
+## Quick start
+
+```ts
+import { TimeMachineArchitect } from '@caia/time-machine-architect';
+
+const architect = new TimeMachineArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: { backend: backendOutput, database: databaseOutput } },
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (≥30 tests)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+The suite includes interface compliance, contract structural checks, registration disjointness, output validation, run() idempotency, cross-architect invariants, and an end-to-end golden test that verifies the forward-creating revert invariant — every revert produces a new snapshot at the chain tip, never overwrites a prior version.
+
+## Reference
+
+Generalizes the snapshot/revert pattern proven in `@caia/atlas-design-snapshotter` (PR #538) from designs to ALL versionable state — not just the design IR, but feature behavior, configuration, data shape, anything a ticket's lifecycle introduces.

--- a/packages/time-machine-architect/eslint.config.cjs
+++ b/packages/time-machine-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on aiml-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/time-machine-architect/package.json
+++ b/packages/time-machine-architect/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@caia/time-machine-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Time Machine Architect — architect #14 of CAIA's 17-architect EA fan-out. Owns the `timeMachine.*` slice of `tickets.architecture` (versioningStrategy, snapshotRetention, revertOperation, descriptionGeneration, dataConsistency, auditTrail). Senior platform engineer focused on durable rollback + commit-level time-travel UX. Produces per-ticket time-machine specs that determine how this feature's version history is preserved + how revert works. Does NOT write component code or backend logic. Spawns Claude via @chiefaia/claude-spawner (subscription-only). Depends on Backend Architect + Database Architect upstream. Generalizes the snapshot/revert pattern proven by @caia/atlas-design-snapshotter (designs) to ALL versionable state.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/time-machine-architect/src/architect.ts
+++ b/packages/time-machine-architect/src/architect.ts
@@ -1,0 +1,47 @@
+/**
+ * `TimeMachineArchitect` — the `SpecialistArchitect` implementation.
+ */
+
+import { TimeMachineArchitectContract } from './contract.js';
+import { runTimeMachineArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildTimeMachineSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+export const TIME_MACHINE_ARCHITECT_NAME = 'time-machine' as const;
+
+export const TIME_MACHINE_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface TimeMachineArchitectConfig {
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class TimeMachineArchitect implements SpecialistArchitect {
+  readonly name = TIME_MACHINE_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = TimeMachineArchitectContract;
+  readonly tools: readonly ToolDefinition[] = TIME_MACHINE_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: TimeMachineArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  systemPrompt(): string {
+    return buildTimeMachineSystemPrompt();
+  }
+
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runTimeMachineArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/time-machine-architect/src/contract.ts
+++ b/packages/time-machine-architect/src/contract.ts
@@ -1,0 +1,149 @@
+/**
+ * `TimeMachineArchitectContract` — the canonical owned-fields declaration
+ * for architect #14 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.14 (Time Machine Architect)
+ *   - spec §11 Architect Brief A14
+ *   - V2 operator task brief 2026-05-24 (binding name set: versioningStrategy,
+ *     snapshotRetention, revertOperation, descriptionGeneration,
+ *     dataConsistency, auditTrail)
+ *
+ * The V2 task brief is the binding name set (per the standing rule — newer
+ * brief wins); spec §2.14's outline (snapshotKey, deployDescription,
+ * revertCommand, snapshotRetentionDays, revertScope, perSectionRevertCapability,
+ * snapshotStorage) guides the semantic content of each field. The V2
+ * field set is the OUTER contract — each owned field describes a policy
+ * object that internally exposes the spec's lower-level mechanics.
+ *
+ * Naming note: the architect's `name` is `'time-machine'` (matches the
+ * V2 task brief). The canonical precedence ladder lists this architect
+ * under the alias `'timeMachine'` (camelCase). The JSONB namespace under
+ * `tickets.architecture` is `timeMachine.*` (camelCase) — matching the
+ * cross-architect references already present in `@caia/ea-dispatcher`
+ * (conflict-rules.ts: `deploy-without-rollback` reads
+ * `timeMachine.revertCommand`) and `@caia/ea-reviewer` (invariants.ts:
+ * `devops-blue-green-implies-time-machine-revert`). We follow the
+ * accessibility-architect precedent — `name = 'accessibility'`, ladder
+ * alias `'a11y'`, JSONB namespace `a11y.*`.
+ *
+ * Wave-2 architect: depends on Backend Architect's endpoint/handler shape
+ * (what mutates) AND Database Architect's `dataLifecycle` (how retention
+ * + GDPR delete interact with version snapshots). Without these, the
+ * Time Machine can't know what to snapshot or whether revert is safe.
+ *
+ * Forward-creating revert invariant: a revert is itself a new commit
+ * appended to the version chain; it never overwrites a prior version.
+ * This is the single most important contract guarantee — the golden
+ * test pins it.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+export const TIME_MACHINE_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'timeMachine.versioningStrategy':
+    'Every commit captured + described. Output {snapshotKeyTemplate, commitGraph, immutability, snapshotStorage}. snapshotKeyTemplate defaults to `<tenant>/<feature>/<commit-sha>`. commitGraph is `linear` for Story tickets and `branching` for Page tickets that allow concurrent edits. immutability is always `append-only` — never overwrite a prior snapshot. snapshotStorage points to R2 path (mirrors @caia/byo-cloud convention).',
+  'timeMachine.snapshotRetention':
+    "How long versions are kept + archival rules + GDPR interaction. Output {retentionDays, archivalSink, archivalAfterDays, gdprInteraction, tenantOverrideAllowed}. Default retentionDays=90 (overridable per tenant). archivalSink is the cold-storage R2 bucket. gdprInteraction MUST reference Database Architect's `database.dataLifecycle.gdprDeleteStrategy` for the same data — anonymize-in-snapshot vs purge-and-tombstone are the two safe paths.",
+  'timeMachine.revertOperation':
+    'FORWARD-CREATING revert — never destructive. Output {invocation, scope, idempotencyKey, forwardCreating:true, postCondition}. invocation defaults to `caia time-machine revert --snapshot <key>`. scope is `feature` for Page tickets, `section` for Widget tickets, both allowed for Story tickets that touch multiple sections. forwardCreating MUST be the literal boolean `true` — the contract rejects any value that implies destructive overwrite. postCondition states the user-observable outcome (e.g. "feature returns to behavior captured at snapshot S; a new snapshot S+N is appended documenting the revert").',
+  'timeMachine.descriptionGeneration':
+    'Auto-generated per-commit human-readable summary. Output {styleGuide, minWords, maxWords, tense, regenerationPolicy}. Default {minWords:5, maxWords:15, tense:"present", styleGuide:"action-first verb phrase"} per spec §2.14. regenerationPolicy is `on-revert-only` by default (do not auto-rewrite existing descriptions when the ticket re-runs).',
+  'timeMachine.dataConsistency':
+    "Revert respects DB state vs application state. Output {transactionalPosture, dbStateSnapshot, applicationStateSnapshot, cascadeOnRevert, dependsOnDatabaseLifecycle:true}. transactionalPosture is `atomic` when the revert touches a single tenant schema, `eventual` when it cascades across services. dbStateSnapshot references the upstream Database Architect's table set + jsonbShapes. cascadeOnRevert lists which downstream tables' rows are restored / left alone / orphaned and why. dependsOnDatabaseLifecycle MUST be the literal `true` — the architect refuses to ship a Time Machine spec that ignores DB retention rules.",
+  'timeMachine.auditTrail':
+    "Every revert logged + attributed to operator action. Output {logSink, attributedFields, retentionDays, immutability:\"append-only\", queryability}. attributedFields MUST include who (operator id), when (UTC timestamp), fromSnapshot, toSnapshot, scope, reason (operator-supplied free text). logSink defaults to the orchestrator's structured-log channel + Postgres `audit_revert_events` table. retentionDays defaults to 7 years (regulatory floor); never less than `snapshotRetention.retentionDays`. immutability MUST be `append-only`."
+};
+
+export const TIME_MACHINE_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'timeMachine.versioningStrategy',
+    description:
+      'How the version chain is materialized + addressed: snapshot key shape, commit graph, immutability posture, snapshot storage path. Every commit captured + described.',
+    required: true
+  },
+  {
+    path: 'timeMachine.snapshotRetention',
+    description:
+      "How long versions are kept + archival rules + GDPR delete interaction. Default 90 days; overridable per tenant. Must reference Database Architect's dataLifecycle for the same data.",
+    required: true
+  },
+  {
+    path: 'timeMachine.revertOperation',
+    description:
+      'Forward-creating revert (never destructive): invocation, scope, idempotency key, postcondition. Revert appends a new snapshot at the chain tip; the historical chain stays intact.',
+    required: true
+  },
+  {
+    path: 'timeMachine.descriptionGeneration',
+    description:
+      'Auto-generated per-commit human-readable summary policy: style guide, length budget (5-15 words default), tense, regeneration triggers.',
+    required: true
+  },
+  {
+    path: 'timeMachine.dataConsistency',
+    description:
+      'How revert respects DB state vs application state: transactional posture, snapshot scopes, cascade rules, explicit dependency on Database dataLifecycle.',
+    required: true
+  },
+  {
+    path: 'timeMachine.auditTrail',
+    description:
+      'Append-only revert audit: log sink, attributed fields (who/when/from/to/scope/reason), retention floor (7 years regulatory), queryability surface.',
+    required: true
+  }
+];
+
+export const TIME_MACHINE_OWNED_FIELD_KEYS: readonly string[] =
+  TIME_MACHINE_OWNED_SECTIONS.map(s => s.path);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+export function timeMachineArchitectAppliesPredicate(ticket: Ticket): boolean {
+  if (
+    ticket.type === 'Page' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List' ||
+    ticket.type === 'Foundation'
+  ) {
+    return true;
+  }
+  if (ticket.type === 'Widget') {
+    const tags = (ticket.quality_tags ?? []) as readonly string[];
+    return (
+      tags.includes('versioned') ||
+      tags.includes('time-machine') ||
+      tags.includes('timeMachine')
+    );
+  }
+  return false;
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+export const TIME_MACHINE_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['backend', 'database'],
+  precedenceLevel: 15,
+  fanoutPolicy: 'always',
+  appliesPredicate: timeMachineArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const TimeMachineArchitectContract: ArchitectSectionContract = {
+  contractId: 'time-machine-architect.v1',
+  architectName: 'time-machine',
+  version: '0.1.0',
+  sections: TIME_MACHINE_OWNED_SECTIONS,
+  architectMeta: TIME_MACHINE_ARCHITECT_META
+};

--- a/packages/time-machine-architect/src/index.ts
+++ b/packages/time-machine-architect/src/index.ts
@@ -1,0 +1,71 @@
+/**
+ * @caia/time-machine-architect — public surface.
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { TimeMachineArchitect } from './architect.js';
+
+export {
+  TimeMachineArchitect,
+  TIME_MACHINE_ARCHITECT_NAME,
+  TIME_MACHINE_ARCHITECT_TOOLS
+} from './architect.js';
+export type { TimeMachineArchitectConfig } from './architect.js';
+
+export {
+  TimeMachineArchitectContract,
+  TIME_MACHINE_OWNED_SECTIONS,
+  TIME_MACHINE_OWNED_FIELD_KEYS,
+  TIME_MACHINE_FIELD_FIX_HINTS,
+  TIME_MACHINE_ARCHITECT_META,
+  timeMachineArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildTimeMachineSystemPrompt } from './system-prompt.js';
+
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+export { runTimeMachineArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+export { TIME_MACHINE_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+export function registerWith(registry: ArchitectRegistry): TimeMachineArchitect {
+  const architect = new TimeMachineArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/time-machine-architect/src/invariants.ts
+++ b/packages/time-machine-architect/src/invariants.ts
@@ -1,0 +1,135 @@
+/**
+ * Time Machine's contributions to the EA Reviewer's cross-architect
+ * invariants registry. The forward-creating revert invariant is the
+ * single most important one — destructive revert is a hard contract
+ * violation.
+ */
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  contributor: string;
+  reads: readonly string[];
+  severity: InvariantSeverity;
+  description: string;
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+export const TIME_MACHINE_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'timeMachine.revert-is-forward-creating',
+    contributor: 'time-machine',
+    reads: ['timeMachine.revertOperation'],
+    severity: 'fail',
+    description:
+      'Every Time Machine revert MUST be forward-creating: appended to the chain tip, never overwriting prior history. `revertOperation.forwardCreating` must be the literal boolean `true`. Destructive revert is a hard contract violation.',
+    detect(arch): boolean {
+      const op = readField(arch, 'timeMachine.revertOperation');
+      if (!isObject(op)) return false;
+      return op.forwardCreating === true;
+    }
+  },
+  {
+    id: 'timeMachine.versioning-is-append-only',
+    contributor: 'time-machine',
+    reads: ['timeMachine.versioningStrategy'],
+    severity: 'fail',
+    description:
+      'Versioning strategy MUST be append-only. Snapshots are never overwritten in place. `versioningStrategy.immutability` must equal "append-only".',
+    detect(arch): boolean {
+      const vs = readField(arch, 'timeMachine.versioningStrategy');
+      if (!isObject(vs)) return false;
+      return vs.immutability === 'append-only';
+    }
+  },
+  {
+    id: 'timeMachine.audit-trail-is-append-only',
+    contributor: 'time-machine',
+    reads: ['timeMachine.auditTrail'],
+    severity: 'fail',
+    description:
+      'Audit trail MUST be append-only and tamper-evident. `auditTrail.immutability` must equal "append-only".',
+    detect(arch): boolean {
+      const at = readField(arch, 'timeMachine.auditTrail');
+      if (!isObject(at)) return false;
+      return at.immutability === 'append-only';
+    }
+  },
+  {
+    id: 'timeMachine.audit-retention-floor-snapshot-retention',
+    contributor: 'time-machine',
+    reads: ['timeMachine.auditTrail', 'timeMachine.snapshotRetention'],
+    severity: 'fail',
+    description:
+      'Audit retention must be >= snapshot retention. Operators must be able to query the audit log for the lifetime of every snapshot it references.',
+    detect(arch): boolean {
+      const at = readField(arch, 'timeMachine.auditTrail');
+      const sr = readField(arch, 'timeMachine.snapshotRetention');
+      if (!isObject(at) || !isObject(sr)) return false;
+      const auditDays = typeof at.retentionDays === 'number' ? at.retentionDays : -1;
+      const snapDays = typeof sr.retentionDays === 'number' ? sr.retentionDays : -1;
+      if (auditDays < 0 || snapDays < 0) return false;
+      return auditDays >= snapDays;
+    }
+  },
+  {
+    id: 'timeMachine.audit-attributes-operator-and-time',
+    contributor: 'time-machine',
+    reads: ['timeMachine.auditTrail'],
+    severity: 'fail',
+    description:
+      'Audit trail attributedFields MUST include who (operator id) AND when (UTC timestamp). Without operator + time, the audit log is not actionable.',
+    detect(arch): boolean {
+      const at = readField(arch, 'timeMachine.auditTrail');
+      if (!isObject(at)) return false;
+      const fields = at.attributedFields;
+      if (!Array.isArray(fields)) return false;
+      return fields.includes('who') && fields.includes('when');
+    }
+  },
+  {
+    id: 'timeMachine.data-consistency-depends-on-db-lifecycle',
+    contributor: 'time-machine',
+    reads: ['timeMachine.dataConsistency'],
+    severity: 'fail',
+    description:
+      "Time Machine MUST acknowledge it depends on Database Architect's dataLifecycle. `dataConsistency.dependsOnDatabaseLifecycle` must be the literal boolean `true`. Otherwise revert may break GDPR or retention contracts.",
+    detect(arch): boolean {
+      const dc = readField(arch, 'timeMachine.dataConsistency');
+      if (!isObject(dc)) return false;
+      return dc.dependsOnDatabaseLifecycle === true;
+    }
+  },
+  {
+    id: 'timeMachine.description-length-within-budget',
+    contributor: 'time-machine',
+    reads: ['timeMachine.descriptionGeneration'],
+    severity: 'advisory',
+    description:
+      'Auto-generated descriptions should stay within the spec §2.14 budget (5-15 words by default). Wider windows produce noisy audit feeds.',
+    detect(arch): boolean {
+      const dg = readField(arch, 'timeMachine.descriptionGeneration');
+      if (!isObject(dg)) return false;
+      const minW = typeof dg.minWords === 'number' ? dg.minWords : -1;
+      const maxW = typeof dg.maxWords === 'number' ? dg.maxWords : -1;
+      if (minW < 1 || maxW < minW) return false;
+      return maxW <= 30;
+    }
+  }
+];

--- a/packages/time-machine-architect/src/run.ts
+++ b/packages/time-machine-architect/src/run.ts
@@ -1,0 +1,102 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { TIME_MACHINE_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+export async function runTimeMachineArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: [],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, TIME_MACHINE_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: [],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  const parsed = validation.parsed;
+  return {
+    ...parsed,
+    architectName: deps.architectName,
+    spend
+  };
+}

--- a/packages/time-machine-architect/src/spawner.ts
+++ b/packages/time-machine-architect/src/spawner.ts
@@ -1,0 +1,115 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+export interface ArchitectSpawnOutput {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  model: string;
+  ok: boolean;
+  diagnostic: string | null;
+}
+
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/time-machine-architect/src/system-prompt.md
+++ b/packages/time-machine-architect/src/system-prompt.md
@@ -1,0 +1,25 @@
+<!--
+Static rendering of the Time Machine Architect's system prompt.
+Canonical source: `src/system-prompt.ts` (`buildTimeMachineSystemPrompt()`).
+Regenerate after a change with:
+  node -e "import('./dist/system-prompt.js').then(m => console.log(m.buildTimeMachineSystemPrompt()))"
+-->
+
+## Role
+
+You are CAIA's Time Machine Architect. You are a senior platform engineer focused on durable rollback + commit-level time-travel UX.
+
+You produce per-ticket time-machine specs that determine how this feature's version history is preserved + how revert works. You DO NOT write component code or backend logic. The forward-creating revert invariant — every revert is a new commit appended to the chain, never an overwrite — is the single most important contract guarantee.
+
+## Owned fields (`timeMachine.*`)
+
+- `timeMachine.versioningStrategy` — every commit captured + described
+- `timeMachine.snapshotRetention` — how long versions are kept, archival
+- `timeMachine.revertOperation` — forward-creating revert (never destructive)
+- `timeMachine.descriptionGeneration` — auto-generated per-commit summary
+- `timeMachine.dataConsistency` — revert respects DB vs application state
+- `timeMachine.auditTrail` — every revert logged + attributed
+
+## Upstream dependencies
+
+Wave-2 architect: Backend Architect + Database Architect must complete first. Reads `backend.endpointEnumeration`, `backend.handlerShape`, `database.tables`, `database.dataLifecycle`, `database.tenantIsolationStrategy`.

--- a/packages/time-machine-architect/src/system-prompt.ts
+++ b/packages/time-machine-architect/src/system-prompt.ts
@@ -1,0 +1,194 @@
+/**
+ * The Time Machine Architect's system prompt — a pure function returning
+ * a static string. No runtime state.
+ */
+
+import { TIME_MACHINE_OWNED_FIELD_KEYS } from './contract.js';
+
+export function buildTimeMachineSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's Time Machine Architect. You are a senior platform engineer
+focused on durable rollback + commit-level time-travel UX.
+
+You produce per-ticket time-machine specs that determine how this
+feature's version history is preserved + how revert works. You DO NOT
+write component code or backend logic. Other architects own those
+concerns and will reject any field you populate outside the
+\`timeMachine.*\` namespace.
+
+The single most important contract guarantee is the **forward-creating
+revert invariant**: a revert is itself a new commit appended to the
+version chain — never a destructive overwrite of history. An operator
+must always be able to revert the revert, walk back to any intermediate
+state, and read the full audit trail of what happened.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Snapshot storage**: Cloudflare R2 via \`@caia/byo-cloud\` BYOC paths.
+  Snapshot keys: \`<tenant>/<feature>/<commit-sha>\`. Per-tenant R2 buckets
+  unless the operator has overridden via tenant configuration.
+- **Immutability**: every snapshot is append-only. Never overwrite. Never
+  delete in place — GDPR delete uses tombstones + anonymization.
+- **Commit graph**: linear for Story tickets; branching for Page tickets
+  that allow concurrent edits.
+- **Description generation**: 5-15 word action-first present-tense
+  summaries, generated at commit time. Mirrors \`@caia/atlas-design-snapshotter\`'s
+  description style proven in PR #538 (designs) — generalized here to
+  ALL versionable state.
+- **Audit sink**: structured logs (operator's orchestrator log channel) +
+  Postgres \`audit_revert_events\` table for queryability.
+- **Retention**: 90-day default for active snapshots; 7-year regulatory
+  floor for revert audit events.
+
+Reject any decision that violates the locked stack. If a ticket asks for
+"in-place history rewrite" or "hard delete of snapshots", refuse, flag
+in \`risks\`, and emit the safe forward-creating spec anyway.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Story|Form|List|Foundation|Widget",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."] },
+  "businessPlan": { "ventureName": "...", "audience": "...",
+                    "businessRequirements": "..." },
+  "designVersion": { "versionId": "...", "anchors": [] },
+  "tenantContext": { "tenantId": "...", "schemaName": "...",
+                     "vaultNamespace": "...", "billingPosture": "..." },
+  "budget": { "preferredModel": "sonnet|opus" },
+  "upstream": {
+    "outputs": {
+      "backend": { "architectureFields": { "backend.endpointEnumeration": [],
+                                            "backend.handlerShape": {} } },
+      "database": { "architectureFields": { "database.tables": [],
+                                             "database.dataLifecycle": [],
+                                             "database.tenantIsolationStrategy": {} } }
+    }
+  }
+}
+\`\`\`
+
+Read \`upstream.outputs.backend\` to learn what handlers mutate state.
+Read \`upstream.outputs.database\` — especially \`database.dataLifecycle\`
++ \`database.tenantIsolationStrategy\` — to learn how revert must
+interact with retention, GDPR delete, and per-tenant schemas. Without
+these upstream inputs you cannot produce a valid spec.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "time-machine",
+  "architectureFields": {
+${TIME_MACHINE_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`timeMachine.versioningStrategy\` — \`{"snapshotKeyTemplate":"<tenant>/<feature>/<commit-sha>","commitGraph":"linear|branching","immutability":"append-only","snapshotStorage":{"provider":"r2","pathTemplate":"r2://<tenant>-snapshots/<feature>/<commit-sha>.json"}}\`. immutability MUST be \`"append-only"\`.
+- \`timeMachine.snapshotRetention\` — \`{"retentionDays":90,"archivalSink":"r2://<tenant>-snapshots-cold/","archivalAfterDays":30,"gdprInteraction":"anonymize-in-snapshot|purge-and-tombstone","tenantOverrideAllowed":true}\`. Choose \`gdprInteraction\` based on the upstream Database Architect's \`database.dataLifecycle[].gdprDeleteStrategy\` for the matching table.
+- \`timeMachine.revertOperation\` — \`{"invocation":"caia time-machine revert --snapshot <key>","scope":"feature|section","idempotencyKey":"<feature>:<targetSnapshot>","forwardCreating":true,"postCondition":"feature returns to behavior captured at snapshot S; a new snapshot S+N is appended documenting the revert"}\`. \`forwardCreating\` MUST be the literal \`true\` — the validator rejects any other value.
+- \`timeMachine.descriptionGeneration\` — \`{"styleGuide":"action-first verb phrase","minWords":5,"maxWords":15,"tense":"present","regenerationPolicy":"on-revert-only"}\`.
+- \`timeMachine.dataConsistency\` — \`{"transactionalPosture":"atomic|eventual","dbStateSnapshot":{"tables":[],"jsonbShapesRef":"database.jsonbShapes"},"applicationStateSnapshot":{"caches":[],"queues":[]},"cascadeOnRevert":[{"table":"...","action":"restore|leave|orphan","reason":"..."}],"dependsOnDatabaseLifecycle":true}\`. \`dependsOnDatabaseLifecycle\` MUST be the literal \`true\`.
+- \`timeMachine.auditTrail\` — \`{"logSink":["stdout-structured","postgres:audit_revert_events"],"attributedFields":["who","when","fromSnapshot","toSnapshot","scope","reason"],"retentionDays":2555,"immutability":"append-only","queryability":{"byOperator":true,"bySnapshot":true,"byTimeRange":true}}\`. \`retentionDays\` must be >= \`snapshotRetention.retentionDays\`. \`immutability\` MUST be \`"append-only"\`.`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **Forward-creating revert is non-negotiable.** Never propose an
+  in-place rollback. Every revert is itself a commit — the version
+  chain only grows.
+- **Snapshot at handler boundaries.** Read Backend's
+  \`endpointEnumeration\` to learn which handlers mutate state.
+  Snapshot before each mutation; the snapshot key includes the request's
+  trace id so audit trail can correlate.
+- **GDPR delete uses tombstones + anonymization, never hard delete.**
+  Mirror the upstream Database Architect's \`gdprDeleteStrategy\` for the
+  same data.
+- **Scope follows ticket type.** Page tickets revert at \`feature\`
+  scope. Widget/Section tickets revert at \`section\` scope.
+- **Retention defaults: 90 days active / 7 years audit.**
+- **Audit trail is append-only and tamper-evident.**`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Propose destructive revert (in-place overwrite, history rewrite,
+  squash, force-push)** → refuse. Emit \`forwardCreating: true\` anyway,
+  list the override request in \`risks[]\`, set \`confidence\` to 0.4.
+- **Skip snapshot retention or set it below 0 days** → refuse. Apply the
+  90-day default, list under \`risks\`.
+- **Hard-delete snapshots for GDPR** → refuse. Use tombstone +
+  anonymization. List the operator-stated GDPR concern under \`risks\`.
+- **Set audit retention below \`snapshotRetention.retentionDays\`** →
+  refuse. Floor at \`snapshotRetention.retentionDays\`; default to 7
+  years.
+- **Decide a database schema, API endpoint, RLS policy, frontend
+  component, test strategy, CSP rule, or any field NOT under
+  \`timeMachine.*\`** → ignore the request.
+- **Run without upstream Backend or Database outputs** → emit \`status:
+  "partial"\` with \`risks\` listing the missing dependency.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated even if the value is the documented default.`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the 6 owned field
+   paths (no extras, no missing).
+2. \`timeMachine.revertOperation.forwardCreating === true\` (literal).
+3. \`timeMachine.dataConsistency.dependsOnDatabaseLifecycle === true\`
+   (literal).
+4. \`timeMachine.versioningStrategy.immutability === "append-only"\`.
+5. \`timeMachine.auditTrail.immutability === "append-only"\`.
+6. \`timeMachine.auditTrail.retentionDays\` >=
+   \`timeMachine.snapshotRetention.retentionDays\`.
+7. \`timeMachine.descriptionGeneration\` length budget is within
+   [5, 15] words unless an operator override is justified in \`notes\`.
+8. \`confidence\` reflects how comfortable you are with the decision.
+9. \`notes\` is <= 800 characters.
+10. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input -> output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a Page ticket producing a contact-form submission
+yields a versioningStrategy with linear commitGraph + R2 snapshot
+storage, a revertOperation with feature-scope + forwardCreating=true +
+postCondition "form returns to the schema + handler captured at
+snapshot S; a new snapshot S+N is appended documenting the revert", and
+a dataConsistency block that references the upstream
+\`database.dataLifecycle\` entry for the \`contact_submissions\` table.`;

--- a/packages/time-machine-architect/src/types.ts
+++ b/packages/time-machine-architect/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * This module exists as a thin re-export so the rest of this package
+ * has a single import surface. Mirrors the Frontend Architect template
+ * verbatim — only the architect-specific field-spec lives in
+ * `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/time-machine-architect/src/validation.ts
+++ b/packages/time-machine-architect/src/validation.ts
@@ -1,0 +1,187 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/time-machine-architect/tests/architect.test.ts
+++ b/packages/time-machine-architect/tests/architect.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `TimeMachineArchitect` — interface compliance tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  TimeMachineArchitect,
+  TIME_MACHINE_ARCHITECT_NAME,
+  TIME_MACHINE_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { TimeMachineArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('TimeMachineArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new TimeMachineArchitect();
+    expect(a).toBeInstanceOf(TimeMachineArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new TimeMachineArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the V2 task brief', () => {
+    const a = new TimeMachineArchitect();
+    expect(a.name).toBe('time-machine');
+    expect(a.name).toBe(TIME_MACHINE_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new TimeMachineArchitect();
+    expect(a.sectionContract).toBe(TimeMachineArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new TimeMachineArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1 task brief', () => {
+    const a = new TimeMachineArchitect();
+    expect(a.tools).toBe(TIME_MACHINE_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new TimeMachineArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new TimeMachineArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new TimeMachineArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new TimeMachineArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('time-machine');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new TimeMachineArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    const a = new TimeMachineArchitect();
+    expect(a).toBeInstanceOf(TimeMachineArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/time-machine-architect/tests/contract.test.ts
+++ b/packages/time-machine-architect/tests/contract.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Section contract structural + registration tests.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { TimeMachineArchitect } from '../src/architect.js';
+import {
+  TIME_MACHINE_ARCHITECT_META,
+  TIME_MACHINE_OWNED_SECTIONS,
+  TIME_MACHINE_OWNED_FIELD_KEYS,
+  TimeMachineArchitectContract,
+  timeMachineArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('TimeMachineArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(TimeMachineArchitectContract.contractId).toBe('time-machine-architect.v1');
+  });
+
+  it('architectName is `time-machine` (matches V2 task brief)', () => {
+    expect(TimeMachineArchitectContract.architectName).toBe('time-machine');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(TimeMachineArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `timeMachine.`', () => {
+    for (const key of TIME_MACHINE_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('timeMachine.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the V2 task-brief mandatory fields', () => {
+    const required = [
+      'timeMachine.versioningStrategy',
+      'timeMachine.snapshotRetention',
+      'timeMachine.revertOperation',
+      'timeMachine.descriptionGeneration',
+      'timeMachine.dataConsistency',
+      'timeMachine.auditTrail'
+    ];
+    for (const r of required) {
+      expect(TIME_MACHINE_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('owns exactly the V2 task brief field set (no extras, no gaps)', () => {
+    expect([...TIME_MACHINE_OWNED_FIELD_KEYS].sort()).toEqual(
+      [
+        'timeMachine.auditTrail',
+        'timeMachine.dataConsistency',
+        'timeMachine.descriptionGeneration',
+        'timeMachine.revertOperation',
+        'timeMachine.snapshotRetention',
+        'timeMachine.versioningStrategy'
+      ].sort()
+    );
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of TIME_MACHINE_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(TimeMachineArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(TimeMachineArchitectContract).sort()).toEqual(
+      [...TIME_MACHINE_OWNED_FIELD_KEYS].sort()
+    );
+  });
+});
+
+describe('TimeMachineArchitectContract — architectMeta', () => {
+  it('declares Backend + Database as upstream dependencies (wave-2)', () => {
+    expect(TIME_MACHINE_ARCHITECT_META.dependsOn).toEqual(['backend', 'database']);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(TIME_MACHINE_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(TIME_MACHINE_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 15 per spec §5.2', () => {
+    expect(TIME_MACHINE_ARCHITECT_META.precedenceLevel).toBe(15);
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(TIME_MACHINE_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per spec §2.14', () => {
+    expect(TIME_MACHINE_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(TIME_MACHINE_ARCHITECT_META.appliesPredicate).toBe(
+      timeMachineArchitectAppliesPredicate
+    );
+  });
+
+  it("canonical precedence ladder lists this architect under the 'timeMachine' alias", () => {
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('timeMachine');
+    expect(precedenceRank('timeMachine')).toBe(
+      TIME_MACHINE_ARCHITECT_META.precedenceLevel
+    );
+  });
+});
+
+describe('timeMachineArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Page' };
+
+  it('returns true for Page', () => {
+    expect(timeMachineArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })).toBe(true);
+  });
+
+  it('returns true for Story', () => {
+    expect(timeMachineArchitectAppliesPredicate({ ...baseTicket, type: 'Story' })).toBe(true);
+  });
+
+  it('returns true for Form', () => {
+    expect(timeMachineArchitectAppliesPredicate({ ...baseTicket, type: 'Form' })).toBe(true);
+  });
+
+  it('returns true for List', () => {
+    expect(timeMachineArchitectAppliesPredicate({ ...baseTicket, type: 'List' })).toBe(true);
+  });
+
+  it('returns true for Foundation', () => {
+    expect(
+      timeMachineArchitectAppliesPredicate({ ...baseTicket, type: 'Foundation' })
+    ).toBe(true);
+  });
+
+  it('returns false for an untagged Widget', () => {
+    expect(timeMachineArchitectAppliesPredicate({ ...baseTicket, type: 'Widget' })).toBe(false);
+  });
+
+  it('returns true for a Widget tagged `versioned`', () => {
+    expect(
+      timeMachineArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Widget',
+        quality_tags: ['versioned']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for a Widget tagged `time-machine`', () => {
+    expect(
+      timeMachineArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Widget',
+        quality_tags: ['time-machine']
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for an unrecognised ticket type', () => {
+    expect(timeMachineArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })).toBe(false);
+  });
+});
+
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the Time Machine architect cleanly', () => {
+    expect(() => {
+      registry.register(new TimeMachineArchitect());
+    }).not.toThrow();
+    expect(registry.get('time-machine')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new TimeMachineArchitect());
+    for (const k of TIME_MACHINE_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('time-machine');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new TimeMachineArchitect());
+    expect(() => registry.register(new TimeMachineArchitect())).toThrowError(
+      ArchitectRegistryError
+    );
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new TimeMachineArchitect());
+
+    const collidingContract: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'timeMachine.revertOperation',
+          description: 'colliding owner',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 16,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', collidingContract));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new TimeMachineArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'backend-architect.v1',
+      architectName: 'backend',
+      version: '0.1.0',
+      sections: [
+        { path: 'backend.apiShape', description: 'API shape', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 12,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('backend', disjointContract));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(TIME_MACHINE_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it('disjointness() detects no conflicts when only Time Machine is present', () => {
+    const conflicts = disjointness([TimeMachineArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between Time Machine and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...TimeMachineArchitectContract,
+      contractId: 'time-machine-clone.v1',
+      architectName: 'time-machine-clone'
+    };
+    const conflicts = disjointness([TimeMachineArchitectContract, clone]);
+    expect(conflicts.length).toBe(TIME_MACHINE_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() reports its declared upstream deps as unresolved when only Time Machine is registered', () => {
+    registry.register(new TimeMachineArchitect());
+    const errors = registry.validate();
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+    expect(errors.join(' ')).toContain('backend');
+    expect(errors.join(' ')).toContain('database');
+  });
+
+  it('registry.validate() is empty after registering Time Machine + its declared upstream stubs', () => {
+    registry.register(new TimeMachineArchitect());
+    const backendContract: ArchitectSectionContract = {
+      contractId: 'backend-architect.v1',
+      architectName: 'backend',
+      version: '0.1.0',
+      sections: [{ path: 'backend.apiShape', description: 'API', required: true }],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 12,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    const databaseContract: ArchitectSectionContract = {
+      contractId: 'database-architect.v1',
+      architectName: 'database',
+      version: '0.1.0',
+      sections: [{ path: 'database.tables', description: 'tables', required: true }],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 11,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    registry.register(new StubArchitect('backend', backendContract));
+    registry.register(new StubArchitect('database', databaseContract));
+    expect(registry.validate()).toEqual([]);
+  });
+});

--- a/packages/time-machine-architect/tests/golden/golden.test.ts
+++ b/packages/time-machine-architect/tests/golden/golden.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Golden test — the canonical known-good Time Machine artifact for a
+ * known prakash-tiwari Page ticket (the /artists/[slug] booking page).
+ *
+ * Pins the FORWARD-CREATING REVERT INVARIANT — the single most
+ * important contract guarantee: every revert is itself a new snapshot
+ * appended at the chain tip, never an overwrite of prior history.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { TimeMachineArchitect } from '../../src/architect.js';
+import { TIME_MACHINE_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { TIME_MACHINE_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari /artists/[slug] Page ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-designversion.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-designversion.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().designVersion;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(
+      goldenAssistantText(),
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new TimeMachineArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    expect(out.architectName).toBe('time-machine');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    for (const k of TIME_MACHINE_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.dependencies).toEqual(expected.dependencies);
+    expect(out.risks).toEqual(expected.risks);
+  });
+
+  it('output passes every Time Machine invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new TimeMachineArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of TIME_MACHINE_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new TimeMachineArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+});
+
+/**
+ * The CANONICAL forward-creating-revert verification.
+ *
+ * Simulates a snapshot chain with reverts in the middle. The contract
+ * guarantee under test: a revert MUST append a new snapshot at the tip
+ * — never overwrite any prior version. After a revert, the chain has
+ * one MORE entry than before, with every prior entry byte-identical.
+ *
+ * If the architect's output describes destructive revert, this
+ * simulation throws — pinning the invariant at the test layer.
+ */
+describe('golden — forward-creating revert invariant', () => {
+  interface ChainEntry {
+    readonly key: string;
+    readonly kind: 'commit' | 'revert';
+    readonly description: string;
+    readonly revertsTo?: string;
+  }
+
+  function applyRevertPerContract(
+    chain: readonly ChainEntry[],
+    targetKey: string,
+    revertSpec: Readonly<Record<string, unknown>>
+  ): readonly ChainEntry[] {
+    if (revertSpec.forwardCreating !== true) {
+      throw new Error(
+        `forward-creating revert invariant violated: ` +
+          `revertOperation.forwardCreating=${String(revertSpec.forwardCreating)}; ` +
+          'expected literal true.'
+      );
+    }
+    const tip = chain[chain.length - 1];
+    const nextIndex = chain.length;
+    const nextKey = `s${nextIndex.toString().padStart(3, '0')}`;
+    const revertEntry: ChainEntry = {
+      key: nextKey,
+      kind: 'revert',
+      description: `revert to ${targetKey} (from ${tip?.key ?? 'genesis'})`,
+      revertsTo: targetKey
+    };
+    return [...chain, revertEntry];
+  }
+
+  it('revert spec is forward-creating (literal boolean true)', () => {
+    const golden = goldenExpectedOutput();
+    const rev = golden.architectureFields['timeMachine.revertOperation'] as Record<
+      string,
+      unknown
+    >;
+    expect(rev.forwardCreating).toBe(true);
+    expect(typeof rev.forwardCreating).toBe('boolean');
+  });
+
+  it('a simulated revert appends a NEW snapshot at the chain tip (forward-creating)', () => {
+    const golden = goldenExpectedOutput();
+    const rev = golden.architectureFields['timeMachine.revertOperation'] as Record<
+      string,
+      unknown
+    >;
+
+    const initialChain: readonly ChainEntry[] = [
+      { key: 's000', kind: 'commit', description: 'ship initial booking form' },
+      { key: 's001', kind: 'commit', description: 'add availability calendar' },
+      { key: 's002', kind: 'commit', description: 'broken deploy: removes CTA' }
+    ];
+
+    const after = applyRevertPerContract(initialChain, 's001', rev);
+
+    expect(after.length).toBe(initialChain.length + 1);
+    const tip = after[after.length - 1];
+    expect(tip?.kind).toBe('revert');
+    expect(tip?.revertsTo).toBe('s001');
+    for (let i = 0; i < initialChain.length; i++) {
+      expect(after[i]).toBe(initialChain[i]);
+    }
+  });
+
+  it('a destructive revert spec throws (proves the simulation enforces the invariant)', () => {
+    const destructiveSpec: Record<string, unknown> = {
+      invocation: 'caia time-machine revert --hard',
+      scope: 'feature',
+      forwardCreating: false,
+      postCondition: 'overwrites snapshot in place'
+    };
+    const initialChain: readonly ChainEntry[] = [
+      { key: 's000', kind: 'commit', description: 'first' }
+    ];
+    expect(() => applyRevertPerContract(initialChain, 's000', destructiveSpec)).toThrow(
+      /forward-creating revert invariant violated/
+    );
+  });
+
+  it('successive reverts keep growing the chain (revert of a revert)', () => {
+    const golden = goldenExpectedOutput();
+    const rev = golden.architectureFields['timeMachine.revertOperation'] as Record<
+      string,
+      unknown
+    >;
+
+    const c0: readonly ChainEntry[] = [
+      { key: 's000', kind: 'commit', description: 'first' },
+      { key: 's001', kind: 'commit', description: 'second' },
+      { key: 's002', kind: 'commit', description: 'broken third' }
+    ];
+    const c1 = applyRevertPerContract(c0, 's001', rev);
+    const c2 = applyRevertPerContract(c1, 's002', rev);
+
+    expect(c0.length).toBe(3);
+    expect(c1.length).toBe(4);
+    expect(c2.length).toBe(5);
+    for (let i = 0; i < 3; i++) {
+      expect(c2[i]).toBe(c0[i]);
+    }
+    expect(c2[c2.length - 1]?.revertsTo).toBe('s002');
+  });
+
+  it('revertOperation.postCondition describes append behaviour, not overwrite', () => {
+    const golden = goldenExpectedOutput();
+    const rev = golden.architectureFields['timeMachine.revertOperation'] as Record<
+      string,
+      unknown
+    >;
+    const pc = String(rev.postCondition ?? '');
+    expect(pc).toContain('appended');
+    expect(pc).not.toMatch(/\boverwrite\b/i);
+    expect(pc).not.toMatch(/\brewrit/i);
+    expect(pc).not.toMatch(/\bdestructive\b/i);
+  });
+
+  it('versioningStrategy declares append-only immutability (chain CANNOT shrink)', () => {
+    const golden = goldenExpectedOutput();
+    const vs = golden.architectureFields['timeMachine.versioningStrategy'] as Record<
+      string,
+      unknown
+    >;
+    expect(vs.immutability).toBe('append-only');
+  });
+
+  it('auditTrail declares append-only immutability (revert is logged forever)', () => {
+    const golden = goldenExpectedOutput();
+    const at = golden.architectureFields['timeMachine.auditTrail'] as Record<
+      string,
+      unknown
+    >;
+    expect(at.immutability).toBe('append-only');
+  });
+
+  it('auditTrail retention >= snapshotRetention (every snapshot stays auditable for its lifetime)', () => {
+    const golden = goldenExpectedOutput();
+    const at = golden.architectureFields['timeMachine.auditTrail'] as Record<
+      string,
+      unknown
+    >;
+    const sr = golden.architectureFields['timeMachine.snapshotRetention'] as Record<
+      string,
+      unknown
+    >;
+    expect(typeof at.retentionDays).toBe('number');
+    expect(typeof sr.retentionDays).toBe('number');
+    expect(at.retentionDays as number).toBeGreaterThanOrEqual(sr.retentionDays as number);
+  });
+});

--- a/packages/time-machine-architect/tests/golden/input-businessplan.json
+++ b/packages/time-machine-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,12 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions",
+    "Project warm + grounded brand voice",
+    "Make the booking CTA the page's primary action"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": ["No third-party fonts beyond next/font defaults"]
+}

--- a/packages/time-machine-architect/tests/golden/input-designversion.json
+++ b/packages/time-machine-architect/tests/golden/input-designversion.json
@@ -1,0 +1,5 @@
+{
+  "versionId": "design-pt-v3-2026-05-22",
+  "snapshotUri": "s3://atlas/designs/design-pt-v3-2026-05-22.png",
+  "anchors": [{ "anchorId": "page-root", "kind": "page" }]
+}

--- a/packages/time-machine-architect/tests/golden/input-ticket.json
+++ b/packages/time-machine-architect/tests/golden/input-ticket.json
@@ -1,0 +1,18 @@
+{
+  "id": "ticket-pt-014",
+  "type": "Page",
+  "scope": "story",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "Every deploy of /artists/[slug] is snapshotted before traffic flips.",
+    "Operator can revert the page to any of the last 90 days of snapshots in one CLI invocation.",
+    "Revert is forward-creating: a revert is itself a new snapshot at the chain tip.",
+    "Audit trail records who reverted, when, and from/to snapshot keys.",
+    "GDPR delete on a booking_requests row anonymizes the matching snapshot field; never hard-deletes the snapshot."
+  ],
+  "business_requirements": {
+    "title": "Artist booking page with rollback",
+    "description": "The /artists/[slug] page is the conversion surface for prakash-tiwari.com. Operators must be able to safely roll back a broken deploy without losing the historical chain. Time Machine wires snapshot + revert into the deploy pipeline."
+  },
+  "quality_tags": ["versioned", "rollback"]
+}

--- a/packages/time-machine-architect/tests/helpers/fakes.ts
+++ b/packages/time-machine-architect/tests/helpers/fakes.ts
@@ -1,0 +1,273 @@
+/**
+ * Test fixtures + fake spawner factory.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { TIME_MACHINE_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+function fakeBackendUpstream(): ArchitectOutput {
+  return {
+    architectName: 'backend',
+    architectureFields: {
+      'backend.endpointEnumeration': [
+        {
+          path: '/api/artists/[slug]/book',
+          method: 'POST',
+          handler: 'createBookingRequest',
+          mutates: true
+        },
+        {
+          path: '/api/artists/[slug]/contact',
+          method: 'POST',
+          handler: 'submitContactForm',
+          mutates: true
+        }
+      ],
+      'backend.handlerShape': {
+        createBookingRequest: { reads: ['artists'], writes: ['booking_requests'] },
+        submitContactForm: { reads: [], writes: ['contact_submissions'] }
+      },
+      'backend.errorEnvelope': { shape: { code: 'string', message: 'string' } }
+    },
+    confidence: 0.9,
+    notes: 'fake upstream backend output for time-machine fixture',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+function fakeDatabaseUpstream(): ArchitectOutput {
+  return {
+    architectName: 'database',
+    architectureFields: {
+      'database.tables': [
+        { name: 'booking_requests', primaryKey: 'id', scope: 'tenant-scoped' },
+        { name: 'contact_submissions', primaryKey: 'id', scope: 'tenant-scoped' }
+      ],
+      'database.dataLifecycle': [
+        {
+          table: 'booking_requests',
+          retentionDays: 1825,
+          archivalSink: 'r2://pt-archive/',
+          gdprDeleteStrategy: 'anonymize',
+          cascadeOnUserDelete: true
+        },
+        {
+          table: 'contact_submissions',
+          retentionDays: 365,
+          archivalSink: 'r2://pt-archive/',
+          gdprDeleteStrategy: 'anonymize',
+          cascadeOnUserDelete: true
+        }
+      ],
+      'database.tenantIsolationStrategy': {
+        model: 'schema-per-tenant',
+        schemaNameTemplate: 'pt_<tenant_id>'
+      },
+      'database.jsonbShapes': {}
+    },
+    confidence: 0.9,
+    notes: 'fake upstream database output for time-machine fixture',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-014',
+      type: 'Page',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'Every deploy of /artists/[slug] is snapshotted before traffic flips.',
+        'Operator can revert the page to any of the last 90 days of snapshots in one CLI invocation.',
+        'Revert is forward-creating: a revert is itself a new snapshot at the chain tip.',
+        'Audit trail records who reverted, when, and from/to snapshot keys.',
+        'GDPR delete on a booking_requests row anonymizes the matching snapshot field; never hard-deletes the snapshot.'
+      ],
+      business_requirements: {
+        title: 'Artist booking page with rollback',
+        description:
+          'The /artists/[slug] page is the conversion surface for prakash-tiwari.com. Operators must be able to safely roll back a broken deploy without losing the historical chain. Time Machine wires snapshot + revert into the deploy pipeline.'
+      },
+      quality_tags: ['versioned', 'rollback']
+    },
+    upstream: {
+      outputs: {
+        backend: fakeBackendUpstream(),
+        database: fakeDatabaseUpstream()
+      }
+    },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: "High-intent prospective sitters in the artist's metropolitan area.",
+      goals: [
+        'Drive contact-form submissions',
+        'Project warm + grounded brand voice',
+        "Make the booking CTA the page's primary action"
+      ],
+      brandVoice: 'warm + grounded',
+      constraints: ['No third-party fonts beyond next/font defaults']
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [{ anchorId: 'page-root', kind: 'page' }]
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'time-machine',
+    architectureFields: {
+      'timeMachine.versioningStrategy': {
+        snapshotKeyTemplate: '<tenant>/<feature>/<commit-sha>',
+        commitGraph: 'linear',
+        immutability: 'append-only',
+        snapshotStorage: {
+          provider: 'r2',
+          pathTemplate:
+            'r2://tenant-prakash-tiwari-snapshots/artists-slug-page/<commit-sha>.json'
+        }
+      },
+      'timeMachine.snapshotRetention': {
+        retentionDays: 90,
+        archivalSink: 'r2://tenant-prakash-tiwari-snapshots-cold/',
+        archivalAfterDays: 30,
+        gdprInteraction: 'anonymize-in-snapshot',
+        tenantOverrideAllowed: true
+      },
+      'timeMachine.revertOperation': {
+        invocation: 'caia time-machine revert --snapshot <key>',
+        scope: 'feature',
+        idempotencyKey: 'artists-slug-page:<targetSnapshot>',
+        forwardCreating: true,
+        postCondition:
+          'feature returns to behavior captured at snapshot S; a new snapshot S+N is appended documenting the revert'
+      },
+      'timeMachine.descriptionGeneration': {
+        styleGuide: 'action-first verb phrase',
+        minWords: 5,
+        maxWords: 15,
+        tense: 'present',
+        regenerationPolicy: 'on-revert-only'
+      },
+      'timeMachine.dataConsistency': {
+        transactionalPosture: 'atomic',
+        dbStateSnapshot: {
+          tables: ['booking_requests', 'contact_submissions'],
+          jsonbShapesRef: 'database.jsonbShapes'
+        },
+        applicationStateSnapshot: {
+          caches: ['edge-cache:/artists/[slug]'],
+          queues: []
+        },
+        cascadeOnRevert: [
+          {
+            table: 'booking_requests',
+            action: 'leave',
+            reason:
+              'user-submitted booking requests outlive the page schema; reverting the page does not unwind real customer commitments'
+          },
+          {
+            table: 'contact_submissions',
+            action: 'leave',
+            reason: 'same rationale as booking_requests'
+          }
+        ],
+        dependsOnDatabaseLifecycle: true
+      },
+      'timeMachine.auditTrail': {
+        logSink: ['stdout-structured', 'postgres:audit_revert_events'],
+        attributedFields: ['who', 'when', 'fromSnapshot', 'toSnapshot', 'scope', 'reason'],
+        retentionDays: 2555,
+        immutability: 'append-only',
+        queryability: { byOperator: true, bySnapshot: true, byTimeRange: true }
+      }
+    },
+    confidence: 0.88,
+    notes:
+      'Page-scope time-machine spec for /artists/[slug]. Linear commit graph, 90-day active retention with 7-year audit floor. Forward-creating revert: every revert appends a new snapshot. cascadeOnRevert leaves booking_requests + contact_submissions untouched because real customer data outlives the page schema. GDPR delete uses anonymize-in-snapshot to match database.dataLifecycle for both tables.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of TIME_MACHINE_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/time-machine-architect/tests/invariants.test.ts
+++ b/packages/time-machine-architect/tests/invariants.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Cross-architect invariants — verifies Time Machine's contributions to
+ * the EA Reviewer's invariant registry (per spec §6.2).
+ *
+ * The forward-creating revert invariant is the most important one.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { TIME_MACHINE_INVARIANTS } from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('TIME_MACHINE_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(TIME_MACHINE_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of TIME_MACHINE_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `time-machine`', () => {
+    for (const inv of TIME_MACHINE_INVARIANTS) {
+      expect(inv.contributor).toBe('time-machine');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of TIME_MACHINE_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of TIME_MACHINE_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of TIME_MACHINE_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('TIME_MACHINE_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of TIME_MACHINE_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('revert-is-forward-creating FAILS when revertOperation.forwardCreating is false', () => {
+    const inv = TIME_MACHINE_INVARIANTS.find(
+      i => i.id === 'timeMachine.revert-is-forward-creating'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'timeMachine.revertOperation': {
+        ...(goldenArch['timeMachine.revertOperation'] as Record<string, unknown>),
+        forwardCreating: false
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+    expect(inv!.severity).toBe('fail');
+  });
+
+  it('revert-is-forward-creating FAILS when forwardCreating is missing', () => {
+    const inv = TIME_MACHINE_INVARIANTS.find(
+      i => i.id === 'timeMachine.revert-is-forward-creating'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'timeMachine.revertOperation': {
+        invocation: 'caia time-machine revert --snapshot <key>',
+        scope: 'feature'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('versioning-is-append-only FAILS when immutability is not append-only', () => {
+    const inv = TIME_MACHINE_INVARIANTS.find(
+      i => i.id === 'timeMachine.versioning-is-append-only'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'timeMachine.versioningStrategy': {
+        ...(goldenArch['timeMachine.versioningStrategy'] as Record<string, unknown>),
+        immutability: 'mutable'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('audit-trail-is-append-only FAILS when immutability is rewritable', () => {
+    const inv = TIME_MACHINE_INVARIANTS.find(
+      i => i.id === 'timeMachine.audit-trail-is-append-only'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'timeMachine.auditTrail': {
+        ...(goldenArch['timeMachine.auditTrail'] as Record<string, unknown>),
+        immutability: 'rewritable'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('audit-retention-floor-snapshot-retention FAILS when audit retention drops below snapshot retention', () => {
+    const inv = TIME_MACHINE_INVARIANTS.find(
+      i => i.id === 'timeMachine.audit-retention-floor-snapshot-retention'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'timeMachine.auditTrail': {
+        ...(goldenArch['timeMachine.auditTrail'] as Record<string, unknown>),
+        retentionDays: 30
+      },
+      'timeMachine.snapshotRetention': {
+        ...(goldenArch['timeMachine.snapshotRetention'] as Record<string, unknown>),
+        retentionDays: 90
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('audit-attributes-operator-and-time FAILS when `who` is missing', () => {
+    const inv = TIME_MACHINE_INVARIANTS.find(
+      i => i.id === 'timeMachine.audit-attributes-operator-and-time'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'timeMachine.auditTrail': {
+        ...(goldenArch['timeMachine.auditTrail'] as Record<string, unknown>),
+        attributedFields: ['when', 'fromSnapshot', 'toSnapshot']
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('audit-attributes-operator-and-time FAILS when `when` is missing', () => {
+    const inv = TIME_MACHINE_INVARIANTS.find(
+      i => i.id === 'timeMachine.audit-attributes-operator-and-time'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'timeMachine.auditTrail': {
+        ...(goldenArch['timeMachine.auditTrail'] as Record<string, unknown>),
+        attributedFields: ['who', 'fromSnapshot', 'toSnapshot']
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('data-consistency-depends-on-db-lifecycle FAILS when dependsOnDatabaseLifecycle is false', () => {
+    const inv = TIME_MACHINE_INVARIANTS.find(
+      i => i.id === 'timeMachine.data-consistency-depends-on-db-lifecycle'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'timeMachine.dataConsistency': {
+        ...(goldenArch['timeMachine.dataConsistency'] as Record<string, unknown>),
+        dependsOnDatabaseLifecycle: false
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('description-length-within-budget FAILS when maxWords is unbounded', () => {
+    const inv = TIME_MACHINE_INVARIANTS.find(
+      i => i.id === 'timeMachine.description-length-within-budget'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'timeMachine.descriptionGeneration': {
+        ...(goldenArch['timeMachine.descriptionGeneration'] as Record<string, unknown>),
+        minWords: 5,
+        maxWords: 100
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+    expect(inv!.severity).toBe('advisory');
+  });
+});

--- a/packages/time-machine-architect/tests/run.test.ts
+++ b/packages/time-machine-architect/tests/run.test.ts
@@ -1,0 +1,240 @@
+/**
+ * `run()` tests — verifies the runtime pipeline.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  TIME_MACHINE_ARCHITECT_NAME,
+  TimeMachineArchitect
+} from '../src/architect.js';
+import { TIME_MACHINE_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runTimeMachineArchitect } from '../src/run.js';
+import { buildTimeMachineSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runTimeMachineArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runTimeMachineArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('time-machine');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runTimeMachineArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    for (const k of TIME_MACHINE_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runTimeMachineArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runTimeMachineArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runTimeMachineArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildTimeMachineSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runTimeMachineArchitect(input, {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runTimeMachineArchitect(input, {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runTimeMachineArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runTimeMachineArchitect(input, {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    const b = await runTimeMachineArchitect(input, {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runTimeMachineArchitect(input, {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    const r2 = await runTimeMachineArchitect(input, {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(
+      Object.keys(r1.architectureFields).sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(
+      TIME_MACHINE_OWNED_FIELD_KEYS.length
+    );
+  });
+});
+
+describe('runTimeMachineArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runTimeMachineArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"time-machine"}');
+    const out = await runTimeMachineArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runTimeMachineArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTimeMachineSystemPrompt(),
+      architectName: TIME_MACHINE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runTimeMachineArchitect — dependency declaration', () => {
+  it('reads upstream Backend + Database outputs (smoke check)', async () => {
+    const input = buildFakeInput();
+    const backend = input.upstream.outputs.backend;
+    const database = input.upstream.outputs.database;
+    expect(backend).toBeDefined();
+    expect(database).toBeDefined();
+    expect(backend?.architectureFields['backend.endpointEnumeration']).toBeDefined();
+    expect(database?.architectureFields['database.dataLifecycle']).toBeDefined();
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-014');
+  });
+
+  it('serialises upstream Backend endpoint enumeration', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('/api/artists/[slug]/book');
+    expect(p).toContain('createBookingRequest');
+  });
+
+  it('serialises upstream Database dataLifecycle (for GDPR delete coupling)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('database.dataLifecycle');
+    expect(p).toContain('booking_requests');
+    expect(p).toContain('anonymize');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: {
+        reason: 'increase audit retention to 10 years',
+        severity: 'P1' as const
+      }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('increase audit retention to 10 years');
+  });
+});
+
+describe('TimeMachineArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new TimeMachineArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('time-machine');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/time-machine-architect/tests/system-prompt.test.ts
+++ b/packages/time-machine-architect/tests/system-prompt.test.ts
@@ -1,0 +1,100 @@
+/**
+ * System-prompt tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { TIME_MACHINE_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildTimeMachineSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildTimeMachineSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildTimeMachineSystemPrompt();
+    const p2 = buildTimeMachineSystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's Time Machine Architect");
+  });
+
+  it('contains the Locked stack section', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('Cloudflare R2');
+    expect(p).toContain('append-only');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildTimeMachineSystemPrompt();
+    for (const key of TIME_MACHINE_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('Forward-creating revert');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('timeMachine.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('calls out the forward-creating revert invariant explicitly', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(p).toContain('forward-creating');
+  });
+
+  it('does not refer to fields outside the `timeMachine.*` namespace', () => {
+    const p = buildTimeMachineSystemPrompt();
+    const foreignPrefixes = [
+      'frontend.componentTree',
+      'a11y.wcagLevel',
+      'security.cspPolicy',
+      'analytics.eventTaxonomy',
+      'observability.logShape'
+    ];
+    for (const prefix of foreignPrefixes) {
+      expect(p).not.toContain(prefix);
+    }
+  });
+
+  it('size is bounded (token-budget proxy: < 16k chars)', () => {
+    const p = buildTimeMachineSystemPrompt();
+    expect(p.length).toBeLessThan(16_000);
+  });
+});

--- a/packages/time-machine-architect/tests/validation.test.ts
+++ b/packages/time-machine-architect/tests/validation.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Output validation tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { TIME_MACHINE_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(
+      goldenAssistantText(),
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('time-machine');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ```json fences (lenient parser)', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, TIME_MACHINE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, TIME_MACHINE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', TIME_MACHINE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', TIME_MACHINE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', TIME_MACHINE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput(
+      '{"architectName":"time-machine"}',
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    const codes = result.errors.map(e => e.code);
+    expect(codes).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['timeMachine.revertOperation'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'backend.apiShape': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      TIME_MACHINE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(
+        JSON.stringify(variant),
+        TIME_MACHINE_OWNED_FIELD_KEYS
+      );
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/time-machine-architect/tsconfig.build.json
+++ b/packages/time-machine-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/time-machine-architect/tsconfig.json
+++ b/packages/time-machine-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/time-machine-architect/vitest.config.ts
+++ b/packages/time-machine-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2936,6 +2936,25 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/time-machine-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/tool-output-sanitizer:
     devDependencies:
       '@chiefaia/eslint-config':


### PR DESCRIPTION
## What

Architect #14 of CAIA's 17-architect EA fan-out (spec §2.14, §11 Architect Brief A14). Implements `SpecialistArchitect` from `@caia/architect-kit` (merged PR #535). Generalizes the snapshot/revert pattern proven by `@caia/atlas-design-snapshotter` (PR #538) from designs to **all** versionable state.

## Owns (`timeMachine.*`)

| Field | Contract |
|---|---|
| `versioningStrategy` | every commit captured + described |
| `snapshotRetention` | how long versions kept, archival rules, GDPR |
| `revertOperation` | **forward-creating** (new commit on tip, never destructive) |
| `descriptionGeneration` | auto-generated 5–15 word per-commit summary |
| `dataConsistency` | revert respects DB state + application state; depends on Database `dataLifecycle` |
| `auditTrail` | every revert logged + attributed (who/when/from/to/scope/reason) |

## Forward-creating revert invariant

The single most important contract guarantee. Pinned by:
- 4 fail-severity cross-architect invariants (forwardCreating must be literal `true`, versioning + audit immutability must be "append-only")
- 1 advisory invariant (description length budget)
- 2 audit-consistency invariants (operator+time attribution; audit retention ≥ snapshot retention)
- Dedicated golden simulation that asserts a revert appends a NEW snapshot at the chain tip and leaves all prior entries byte-identical; a destructive-revert spec throws

## Wave + deps

- `dependsOn: ['backend', 'database']` (wave 2 — reads Backend's endpoint enumeration + Database's `dataLifecycle`/`tenantIsolationStrategy`)
- `precedenceLevel: 15` (matches CANONICAL_PRECEDENCE_LADDER index 14)
- `fanoutPolicy: 'always'`
- `runtimeModel: 'sonnet'`
- `tools: []` (V1; reads upstream outputs directly)

## Naming

Follows the accessibility-architect precedent: `name = 'time-machine'` (kebab-case, V2 task brief) while the canonical precedence ladder and the JSONB namespace use the camelCase alias `timeMachine` (matches existing `@caia/ea-dispatcher` conflict-rules + `@caia/ea-reviewer` invariants that already reference `timeMachine.revertCommand`).

## Tests

129 vitest tests across 7 files. All pass.

```
✓ tests/invariants.test.ts       (16 tests)
✓ tests/system-prompt.test.ts    (13 tests)
✓ tests/validation.test.ts       (19 tests)
✓ tests/architect.test.ts        (12 tests)
✓ tests/run.test.ts              (20 tests)
✓ tests/golden/golden.test.ts    (15 tests)
✓ tests/contract.test.ts         (34 tests)

Test Files  7 passed (7)
     Tests  129 passed (129)
```

`pnpm typecheck` (`tsc --noEmit` with the kit's strict-clean base) and `pnpm lint` (eslint flat config) both clean.

## Constraints satisfied

- ✅ Subscription-only (claude-spawner; never sets ANTHROPIC_API_KEY)
- ✅ Stack lock (shadcn/ui + Tailwind) — inherited from the Frontend Architect template
- ✅ TypeScript strict-clean (`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, all on)
- ✅ ≥30 vitest tests (got 129)
- ✅ Golden test verifies forward-creating revert (not destructive overwrites)
- ✅ True-Zero rule: admin-merge upon green

## Reference

Spec: `research/17_architect_framework_spec_2026.md`
Roster: `agent-memory/project_caia_17_architects.md` (#14)
Template: `packages/frontend-architect/`
Pattern proof: `@caia/atlas-design-snapshotter` (PR #538)
