### PR TITLE
feat(@caia/ab-testing-architect): ship architect #13 of 17 — A/B Testing specialist

### DIFF
--- a/packages/ab-testing-architect/README.md
+++ b/packages/ab-testing-architect/README.md
@@ -1,0 +1,67 @@
+# @caia/ab-testing-architect
+
+Architect #13 of CAIA's 17-architect EA fan-out. Senior experimentation engineer focused on **A/B testing rigor** — hypothesis framing, sample-size power calculations, sequential/Bayesian/frequentist readout, variant routing, holdout analysis.
+
+## What it owns
+
+`abTesting.*` slice of the `tickets.architecture` JSONB column:
+
+- `abTesting.experimentDesign` — hypothesis statement + primary metric + guardrail metric IDs + expected effect size + minimum-detectable-effect + baseline conversion rate + direction.
+- `abTesting.variantRoutingStrategy` — sticky-by-user-id (default), sticky-session, percentage, or geographic. Includes hash seed + salt + stickiness key + per-variant allocations.
+- `abTesting.sampleSizeRequirements` — perVariantN + totalN + power-calc method + alpha + power + MDE + baseline + estimated duration days.
+- `abTesting.randomizationUnit` — user (default), session, or pageview.
+- `abTesting.holdoutAnalysisPlan` — holdout group definition + percentage (default 5%) + duration + analysis cadence + success criteria.
+- `abTesting.statisticalReadoutMethod` — frequentist (default), Bayesian, or sequential (O'Brien-Fleming / Pocock).
+- `abTesting.experimentLifecycle` — state machine draft → running → analysis → decided → archived, with per-transition gate checks.
+- `abTesting.featureFlagDependencies` — forward-references to Feature Flagging Architect: flag key, expected shape, required variants, kill switch, default variant on disable.
+- `abTesting.primaryMetric` — eventId (must exist in upstream `analytics.eventTaxonomy`), metric type, aggregation, success direction.
+- `abTesting.secondaryMetrics` — non-blocking metrics tracked alongside the primary.
+- `abTesting.guardrailMetrics` — guardrails that BLOCK winner promotion if violated (latency, error rate, core engagement).
+- `abTesting.allocation` — traffic allocation (default 50/50). Sum MUST equal 100.
+- `abTesting.winnerPromotionPolicy` — auto-promote only when ALL of {p<α, SRM pass, min duration met, guardrails respected, sample-size floor reached}.
+- `abTesting.durationCap` — 28-day hard-stop per spec §2.13.
+- `abTesting.srmCheck` — Sample-Ratio-Mismatch check (always enabled, α=0.001, daily).
+
+## What it does NOT do
+
+**No component code.** Frontend Architect writes JSX. **No backend logic.** Backend Architect owns API endpoints; A/B Testing declares how experiments are designed, sized, and analyzed. **No event taxonomy.** Analytics Architect owns events; A/B Testing picks metric IDs from the existing taxonomy. **No flag schema.** Feature Flagging Architect owns the flag store; A/B Testing forward-references flag keys. Out-of-namespace writes are rejected.
+
+## How it runs
+
+Implements `SpecialistArchitect` (per spec `research/17_architect_framework_spec_2026.md` §1 + §2.13). **Wave 3 — the lone wave-3 architect** — depends on Analytics's `eventTaxonomy` + `funnelDefinitions` + `conversionGoals` AND Feature Flagging's `flagsSchema`. Sonnet by default. Tools empty for V1 (the `caia-power-calc` MCP tool is a planned V2 addition).
+
+The architect leverages patterns from the existing `@caia/analytics` and `@caia/feature-registry` packages — see V2 §2 "wrap" verdict. Those packages are the runtime; this architect is the design surface.
+
+## Quick start
+
+```ts
+import { ABTestingArchitect, ABTestingArchitectContract } from '@caia/ab-testing-architect';
+
+const architect = new ABTestingArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: {
+    analytics: analyticsOutput,            // REQUIRED — provides eventTaxonomy
+    featureFlagging: featureFlaggingOutput // REQUIRED — provides flagsSchema
+  } },
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Statistical defaults
+
+- **Test**: two-proportion z-test (α=0.05 two-tailed, power=0.8).
+- **Variant router**: sticky-by-user-id via stable hash (FNV-1a / MurmurHash3) seeded per experiment.
+- **Sample-Ratio-Mismatch (SRM)**: always enabled, α=0.001, daily, halt-and-alert on failure.
+- **Holdout**: 5% global, never exposed to the winning variant, 90-day post-promotion analysis.
+- **Duration cap**: 28 days hard-stop.
+- **Auto-promote**: ALL of {p < α, SRM pass, min duration met, guardrails respected, sample-size floor reached}.
+- **Randomization unit**: user (default), session for anonymous flows, pageview for cosmetic-only experiments.
+
+## Owned by
+
+CAIA EA fan-out — wave-3 — precedence rank 6 (statistical correctness outranks operability; ranks below security/devops/a11y/seo/performance because incorrect-but-significant experiment results are recoverable while a security breach is not).

--- a/packages/ab-testing-architect/eslint.config.cjs
+++ b/packages/ab-testing-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on analytics-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/ab-testing-architect/package.json
+++ b/packages/ab-testing-architect/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@caia/ab-testing-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "A/B Testing Architect — architect #13 of CAIA's 17-architect EA fan-out. Owns the `abTesting.*` slice of `tickets.architecture`. Wave-3 architect — depends on Analytics + Feature Flagging upstream. Spawns Claude via @chiefaia/claude-spawner (subscription-only).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/ab-testing-architect/src/architect.ts
+++ b/packages/ab-testing-architect/src/architect.ts
@@ -1,0 +1,53 @@
+/**
+ * `ABTestingArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. Tools empty for V1
+ * (the `caia-power-calc` MCP tool is a planned V2 addition).
+ */
+
+import { ABTestingArchitectContract } from './contract.js';
+import { runABTestingArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildABTestingSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches `@caia/ab-testing-architect` minus the suffix. Canonical ladder entry: `abTesting`. */
+export const AB_TESTING_ARCHITECT_NAME = 'abTesting' as const;
+
+/** V1: no architect-specific tools. `caia-power-calc` MCP tool is V2 per spec §2.13. */
+export const AB_TESTING_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface ABTestingArchitectConfig {
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class ABTestingArchitect implements SpecialistArchitect {
+  readonly name = AB_TESTING_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = ABTestingArchitectContract;
+  readonly tools: readonly ToolDefinition[] = AB_TESTING_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: ABTestingArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  systemPrompt(): string {
+    return buildABTestingSystemPrompt();
+  }
+
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runABTestingArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/ab-testing-architect/src/contract.ts
+++ b/packages/ab-testing-architect/src/contract.ts
@@ -1,0 +1,249 @@
+/**
+ * `ABTestingArchitectContract` — the canonical owned-fields declaration
+ * for architect #13 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.13 (A/B Testing Architect owns `abTesting.*`)
+ *   - spec §5.2 / §11.A13 (precedenceLevel=6, dependsOn=[analytics, featureFlagging])
+ *   - task brief (experimentDesign — hypothesis, primary metric, guardrail metrics,
+ *     expected effect size, minimum-detectable-effect; variantRoutingStrategy —
+ *     sticky-by-user-id, percentage split, geographic; sampleSizeRequirements
+ *     per power-calc; randomizationUnit — user / session / pageview;
+ *     holdoutAnalysisPlan; statisticalReadoutMethod — sequential testing,
+ *     Bayesian, frequentist; experimentLifecycle — draft → running → analysis
+ *     → decided → archived; featureFlagDependencies — forward-refs the
+ *     Feature Flagging architect)
+ *
+ * The reconciled superset below combines the spec §2.13 stack-lock fields
+ * (variantRouter, allocation, primaryMetric, secondaryMetrics, sampleSizeFloor,
+ * winnerPromotionPolicy, statisticalTest, holdoutPercent, durationCap, srmCheck)
+ * AND the task brief's per-ticket-structure fields. Every field is marked
+ * `required: true` because the EA Reviewer's statistical-correctness lens
+ * cascades on missing fields and the Feature Flagging architect reads
+ * `featureFlagDependencies` to know which flag keys to provision.
+ *
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces. The chosen keys all live under the `abTesting.*`
+ * namespace and do not collide with any sibling architect's namespace.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+/**
+ * Per-field operator fix-hints. The kit's `ArchitectSectionSpec` is
+ * intentionally minimal (`path`, `description`, `required`); the fix-hint
+ * dictionary lives next to the contract so the system-prompt builder and
+ * the future EA Reviewer can surface it without changing kit shape.
+ */
+export const AB_TESTING_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'abTesting.experimentDesign':
+    'Output {hypothesis, primaryMetricId, guardrailMetricIds, expectedEffectSizePct, minimumDetectableEffectPct, baselineConversionRatePct, direction}. Hypothesis MUST be a falsifiable one-sentence claim. MDE drives sample-size; default 10% relative if no interview answer.',
+  'abTesting.variantRoutingStrategy':
+    'Output {kind:"sticky-user"|"sticky-session"|"percentage"|"geographic", hashSeed, salt, stickinessKey, variants:[{id,name,allocationPct}]}. Sticky-by-user-id is the safe default. Geographic only when the experiment is region-specific.',
+  'abTesting.sampleSizeRequirements':
+    'Output {perVariantN, totalN, powerCalcMethod:"two-proportion-z-test"|"welch-t"|"bayesian-rope", alpha:0.05, power:0.8, mdePct, baselinePct, estimatedDurationDays}. Compute via @caia/power-calc when available; otherwise emit the closed-form two-proportion-z-test result.',
+  'abTesting.randomizationUnit':
+    'Output {unit:"user"|"session"|"pageview", reason}. User is the default (interference-free); session for ephemeral/anonymous flows; pageview only for cosmetic experiments where carryover is impossible.',
+  'abTesting.holdoutAnalysisPlan':
+    'Output {holdoutPct:5, holdoutGroupId, durationDays, analysisCadence:"weekly"|"monthly", successCriteria}. Default 5% global holdout never exposed to the winning variant; used to estimate true lift over time.',
+  'abTesting.statisticalReadoutMethod':
+    'Output {kind:"frequentist"|"bayesian"|"sequential", alpha:0.05, power:0.8, sequentialBoundary?:"obrien-fleming"|"pocock", priorDistribution?, multipleComparisonsCorrection?:"bonferroni"|"benjamini-hochberg"|"none"}. Frequentist two-proportion z-test is the locked default per spec §2.13.',
+  'abTesting.experimentLifecycle':
+    'Output {currentPhase:"draft"|"running"|"analysis"|"decided"|"archived", transitions, gateChecks}. The state machine is fixed: draft → running → analysis → decided → archived (with archived being terminal). Gate checks must fire before each transition.',
+  'abTesting.featureFlagDependencies':
+    'Output {flagKey, expectedFlagShape, requiredVariants, killSwitchKey, defaultVariantOnDisable}. Forward-references Feature Flagging Architect (`featureFlagging.flagsSchema`); flag key naming follows `exp_<short-id>_<yyyy_mm>` convention.',
+  'abTesting.primaryMetric':
+    'Output {eventId, metricType:"conversion"|"continuous"|"count", aggregation:"sum"|"mean"|"unique-users"|"rate", successDirection:"increase"|"decrease"}. eventId MUST exist in upstream `analytics.eventTaxonomy` and SHOULD match `analytics.conversionGoals.primary`.',
+  'abTesting.secondaryMetrics':
+    'Output [{eventId, metricType, aggregation, successDirection, guardrail:false}]. Each eventId MUST exist in upstream `analytics.eventTaxonomy`. Include at least one engagement + one retention metric where possible.',
+  'abTesting.guardrailMetrics':
+    'Output [{eventId, metricType, aggregation, direction:"non-decrease"|"non-increase", tolerancePct}]. Guardrails block winner promotion if violated. Default: latency, error rate, key engagement events. eventIds MUST exist in `analytics.eventTaxonomy`.',
+  'abTesting.allocation':
+    'Output {control:50, treatment:50, additionalVariants?}. 50/50 is the default. Three-way: 34/33/33. Allocations MUST sum to 100. The control variant MUST always be first and labeled "control".',
+  'abTesting.winnerPromotionPolicy':
+    'Output {auto:true|false, criteria:{pValueBelow:0.05, srmPass:true, minDurationDays, guardrailsRespected:true, sampleSizeFloorReached:true}, fallback:"manual-review"|"keep-control"}. Auto-promote only when ALL criteria pass.',
+  'abTesting.durationCap':
+    'Output {maxDays:28, hardStop:true, reasonForCap}. 4-week cap per spec §2.13. Hard-stop means the experiment auto-terminates regardless of significance — prevents indefinite running on a tied outcome.',
+  'abTesting.srmCheck':
+    'Output {enabled:true, alpha:0.001, schedule:"daily", actionOnFail:"halt-and-alert"}. Sample-Ratio-Mismatch check is mandatory; a failed SRM means the variant router is broken and the experiment data is invalid.'
+};
+
+/**
+ * The owned section specs in stable order.
+ */
+export const AB_TESTING_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'abTesting.experimentDesign',
+    description:
+      'Hypothesis statement + primary metric + guardrail metric IDs + expected effect size + MDE + baseline conversion rate + direction. The single source of truth for "what are we testing and what would we accept as evidence".',
+    required: true
+  },
+  {
+    path: 'abTesting.variantRoutingStrategy',
+    description:
+      'Variant assignment strategy: sticky-by-user-id (default), sticky-by-session, percentage split, or geographic. Includes hash seed + salt + the stickiness key + per-variant allocations.',
+    required: true
+  },
+  {
+    path: 'abTesting.sampleSizeRequirements',
+    description:
+      'Per-variant N + total N + power-calc method + alpha + power + MDE + baseline + estimated duration days. Computed via deterministic power calc; the EA Reviewer cross-checks against expected effect size.',
+    required: true
+  },
+  {
+    path: 'abTesting.randomizationUnit',
+    description:
+      'Unit of randomization: user (default), session, or pageview. Drives the variant-router stickiness key and the analysis unit. User is interference-free for most product changes.',
+    required: true
+  },
+  {
+    path: 'abTesting.holdoutAnalysisPlan',
+    description:
+      'Holdout-group definition + percentage (default 5%) + holdout duration + analysis cadence + success criteria. The holdout never sees the winning variant; used to measure true long-tail lift.',
+    required: true
+  },
+  {
+    path: 'abTesting.statisticalReadoutMethod',
+    description:
+      'Statistical method: frequentist (default two-proportion z-test), Bayesian, or sequential testing with O\'Brien-Fleming/Pocock boundaries. Includes alpha, power, multiple-comparisons correction, and prior (Bayesian only).',
+    required: true
+  },
+  {
+    path: 'abTesting.experimentLifecycle',
+    description:
+      'Lifecycle state machine: draft → running → analysis → decided → archived. Includes per-transition gate checks (SRM passing, sample-size reached, duration cap not hit, guardrails respected).',
+    required: true
+  },
+  {
+    path: 'abTesting.featureFlagDependencies',
+    description:
+      'Forward-references to Feature Flagging Architect: which flag keys this experiment expects, the variants the flag must expose, the kill-switch flag, and the default variant when the flag is disabled.',
+    required: true
+  },
+  {
+    path: 'abTesting.primaryMetric',
+    description:
+      'Primary success metric: eventId (must exist in upstream `analytics.eventTaxonomy`), metric type (conversion / continuous / count), aggregation, and success direction. Drives sample-size and winner-promotion logic.',
+    required: true
+  },
+  {
+    path: 'abTesting.secondaryMetrics',
+    description:
+      'Secondary metrics tracked alongside the primary (engagement, retention, downstream conversions). Each eventId must exist in upstream `analytics.eventTaxonomy`. Non-blocking — informational only.',
+    required: true
+  },
+  {
+    path: 'abTesting.guardrailMetrics',
+    description:
+      'Guardrail metrics that BLOCK winner promotion if violated: latency, error rate, core engagement. Each guardrail declares a tolerance percentage and direction (non-decrease / non-increase).',
+    required: true
+  },
+  {
+    path: 'abTesting.allocation',
+    description:
+      'Variant traffic allocation. Default 50/50 control vs. treatment. Multi-variant allocations must sum to 100 and the control variant must always be first.',
+    required: true
+  },
+  {
+    path: 'abTesting.winnerPromotionPolicy',
+    description:
+      'Auto-promotion policy: auto-promote only when p < alpha AND SRM passes AND minimum duration met AND guardrails respected AND sample-size floor reached. Fallback to manual review or keep-control on any failure.',
+    required: true
+  },
+  {
+    path: 'abTesting.durationCap',
+    description:
+      'Maximum experiment duration (default 28 days per spec §2.13) with hard-stop flag. Hard-stop prevents indefinite running on tied outcomes; reason-for-cap is operator-facing.',
+    required: true
+  },
+  {
+    path: 'abTesting.srmCheck',
+    description:
+      'Sample-Ratio-Mismatch check: enabled by default with alpha=0.001 and daily schedule. A failed SRM signals a broken variant router and halts the experiment with an operator alert.',
+    required: true
+  }
+];
+
+/**
+ * Flat list of owned field paths. Used by `run()` to validate the
+ * subagent's output and by the conformance test suite.
+ */
+export const AB_TESTING_OWNED_FIELD_KEYS: readonly string[] = AB_TESTING_OWNED_SECTIONS.map(
+  s => s.path
+);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §3.4 + §2.13 — A/B Testing runs only on tickets explicitly marked
+ * for experimentation: either `quality_tags` contains `ab-test` /
+ * `experiment` / `ab` / `experimental`, OR `business_requirements`
+ * mentions A/B / experiment / variant / treatment / control / lift,
+ * OR `ticket.experimental === true`. This keeps the wave-3 cost off
+ * tickets that don't need it.
+ */
+export function abTestingArchitectAppliesPredicate(ticket: Ticket): boolean {
+  if (ticket.experimental === true) return true;
+
+  const tags = ticket.quality_tags;
+  if (Array.isArray(tags)) {
+    const tagSet = new Set(tags.map(t => String(t).toLowerCase()));
+    if (tagSet.has('ab-test') || tagSet.has('experiment') || tagSet.has('ab') ||
+        tagSet.has('experimental') || tagSet.has('a/b-test') || tagSet.has('a/b')) {
+      return true;
+    }
+  }
+
+  const br = ticket.business_requirements;
+  if (br && typeof br === 'object') {
+    const haystack = JSON.stringify(br).toLowerCase();
+    if (/\ba\/?b[- ]?test/.test(haystack) ||
+        /\bexperiment\b/.test(haystack) ||
+        /\bvariant\b/.test(haystack) ||
+        /\btreatment\b/.test(haystack) ||
+        /\bcontrol\s+(group|arm|variant)/.test(haystack) ||
+        /\blift\b/.test(haystack) ||
+        /minimum[- ]detectable[- ]effect/.test(haystack)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+/**
+ * A/B Testing is a wave-3 architect — the lone wave-3 entry per spec §3.3.
+ * Depends on Analytics (`eventTaxonomy`, `funnelDefinitions`,
+ * `conversionGoals`) and Feature Flagging (`flagsSchema`) per spec §2.13.
+ * Precedence rank 6 per the canonical ladder — statistical-correctness
+ * outranks operability concerns but sits below security, devops,
+ * accessibility, SEO, and performance because incorrect-but-significant
+ * experiment results are recoverable while a security/legal breach is not.
+ */
+export const AB_TESTING_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['analytics', 'featureFlagging'],
+  precedenceLevel: 6,
+  fanoutPolicy: 'conditional',
+  appliesPredicate: abTestingArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const ABTestingArchitectContract: ArchitectSectionContract = {
+  contractId: 'ab-testing-architect.v1',
+  architectName: 'abTesting',
+  version: '0.1.0',
+  sections: AB_TESTING_OWNED_SECTIONS,
+  architectMeta: AB_TESTING_ARCHITECT_META
+};

--- a/packages/ab-testing-architect/src/index.ts
+++ b/packages/ab-testing-architect/src/index.ts
@@ -1,0 +1,79 @@
+/**
+ * @caia/ab-testing-architect — public surface.
+ *
+ * Architect #13 of CAIA's 17-architect EA fan-out. Senior experimentation
+ * engineer focused on A/B testing rigor — hypothesis framing, sample-size
+ * power calculations, sequential/Bayesian/frequentist readout, variant
+ * routing, and holdout analysis. Wave-3 architect (the lone wave-3
+ * entry per spec §3.3) — depends on Analytics's `eventTaxonomy` +
+ * `funnelDefinitions` + `conversionGoals` AND Feature Flagging's
+ * `flagsSchema`.
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { ABTestingArchitect } from './architect.js';
+
+export {
+  ABTestingArchitect,
+  AB_TESTING_ARCHITECT_NAME,
+  AB_TESTING_ARCHITECT_TOOLS
+} from './architect.js';
+export type { ABTestingArchitectConfig } from './architect.js';
+
+export {
+  ABTestingArchitectContract,
+  AB_TESTING_OWNED_SECTIONS,
+  AB_TESTING_OWNED_FIELD_KEYS,
+  AB_TESTING_FIELD_FIX_HINTS,
+  AB_TESTING_ARCHITECT_META,
+  abTestingArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildABTestingSystemPrompt } from './system-prompt.js';
+
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+export { runABTestingArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+export { AB_TESTING_INVARIANTS, computeReferenceSampleSize } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+export function registerWith(registry: ArchitectRegistry): ABTestingArchitect {
+  const architect = new ABTestingArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/ab-testing-architect/src/invariants.ts
+++ b/packages/ab-testing-architect/src/invariants.ts
@@ -1,0 +1,424 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * Cross-architect invariants (those that read fields owned by another
+ * architect) treat absent foreign data as "cannot verify" and pass
+ * trivially. The Reviewer's composed-output pass will exercise the
+ * real check; the per-architect test pass exercises only the local
+ * checks.
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ */
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  contributor: string;
+  reads: readonly string[];
+  severity: InvariantSeverity;
+  description: string;
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+/**
+ * Closed-form sample size per variant for a two-proportion z-test.
+ *
+ *   n ≈ ((Z_{α/2} + Z_β)^2 · (p1(1-p1) + p2(1-p2))) / (p1 - p2)^2
+ *
+ * For α=0.05 two-tailed, Z_{α/2} ≈ 1.96; for power=0.8, Z_β ≈ 0.8416.
+ * (1.96 + 0.8416)^2 ≈ 7.85. With p1 = baseline and p2 = baseline·(1+mde),
+ * delta = p1·mde.
+ *
+ * We accept any value within ±20% of the closed-form result. The wide
+ * tolerance accommodates Wald vs. Wilson vs. continuity-corrected etc.
+ * False-positives on this invariant are worse than false-negatives.
+ */
+export function computeReferenceSampleSize(
+  baselinePct: number,
+  mdePct: number,
+  alpha = 0.05,
+  power = 0.8
+): number {
+  // Z lookup tables for common values.
+  const zAlpha =
+    alpha <= 0.011 ? 2.5758
+    : alpha <= 0.051 ? 1.96
+    : 1.6449;
+  const zBeta =
+    power >= 0.945 ? 1.6449
+    : power >= 0.895 ? 1.2816
+    : 0.8416;
+  const leading = Math.pow(zAlpha + zBeta, 2);
+
+  const p1 = baselinePct / 100;
+  const p2 = p1 * (1 + mdePct / 100);
+  const delta = Math.abs(p1 - p2);
+  if (delta <= 0) return Infinity;
+  const variance = p1 * (1 - p1) + p2 * (1 - p2);
+  return Math.ceil((leading * variance) / (delta * delta));
+}
+
+export const AB_TESTING_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'abTesting.srmCheck-enabled',
+    contributor: 'abTesting',
+    reads: ['abTesting.srmCheck'],
+    severity: 'fail',
+    description:
+      'Sample-Ratio-Mismatch check MUST be enabled. A disabled SRM lets a broken variant router silently contaminate the dataset.',
+    detect(arch): boolean {
+      const srm = readField(arch, 'abTesting.srmCheck');
+      if (typeof srm !== 'object' || srm === null) return false;
+      return (srm as Record<string, unknown>).enabled === true;
+    }
+  },
+  {
+    id: 'abTesting.allocation-sums-to-100',
+    contributor: 'abTesting',
+    reads: ['abTesting.allocation'],
+    severity: 'fail',
+    description:
+      'Variant allocation percentages MUST sum to exactly 100. Otherwise the variant router cannot deterministically partition traffic.',
+    detect(arch): boolean {
+      const alloc = readField(arch, 'abTesting.allocation');
+      if (typeof alloc !== 'object' || alloc === null) return false;
+      let sum = 0;
+      for (const v of Object.values(alloc as Record<string, unknown>)) {
+        if (typeof v !== 'number' || Number.isNaN(v)) return false;
+        sum += v;
+      }
+      return Math.abs(sum - 100) < 0.0001;
+    }
+  },
+  {
+    id: 'abTesting.variantRouting-allocations-sum-to-100',
+    contributor: 'abTesting',
+    reads: ['abTesting.variantRoutingStrategy'],
+    severity: 'fail',
+    description:
+      'Per-variant allocations within `variantRoutingStrategy.variants` MUST sum to 100.',
+    detect(arch): boolean {
+      const route = readField(arch, 'abTesting.variantRoutingStrategy');
+      if (typeof route !== 'object' || route === null) return false;
+      const variants = (route as Record<string, unknown>).variants;
+      if (!Array.isArray(variants)) return false;
+      let sum = 0;
+      for (const v of variants) {
+        if (typeof v !== 'object' || v === null) return false;
+        const a = (v as Record<string, unknown>).allocationPct;
+        if (typeof a !== 'number' || Number.isNaN(a)) return false;
+        sum += a;
+      }
+      return Math.abs(sum - 100) < 0.0001;
+    }
+  },
+  {
+    id: 'abTesting.variantRouting-control-first',
+    contributor: 'abTesting',
+    reads: ['abTesting.variantRoutingStrategy'],
+    severity: 'fail',
+    description:
+      'The first variant in `variantRoutingStrategy.variants` MUST be the control. Downstream readout assumes index-0 = baseline.',
+    detect(arch): boolean {
+      const route = readField(arch, 'abTesting.variantRoutingStrategy');
+      if (typeof route !== 'object' || route === null) return false;
+      const variants = (route as Record<string, unknown>).variants;
+      if (!Array.isArray(variants) || variants.length === 0) return false;
+      const first = variants[0];
+      if (typeof first !== 'object' || first === null) return false;
+      const id = (first as Record<string, unknown>).id;
+      return id === 'control';
+    }
+  },
+  {
+    id: 'abTesting.holdout-nonzero',
+    contributor: 'abTesting',
+    reads: ['abTesting.holdoutAnalysisPlan'],
+    severity: 'fail',
+    description:
+      'Holdout percentage MUST be ≥ 1. Zero holdout means no long-tail / novelty-effect estimation is possible.',
+    detect(arch): boolean {
+      const hop = readField(arch, 'abTesting.holdoutAnalysisPlan');
+      if (typeof hop !== 'object' || hop === null) return false;
+      const pct = (hop as Record<string, unknown>).holdoutPct;
+      return typeof pct === 'number' && pct >= 1;
+    }
+  },
+  {
+    id: 'abTesting.durationCap-under-28d',
+    contributor: 'abTesting',
+    reads: ['abTesting.durationCap'],
+    severity: 'fail',
+    description:
+      'Duration cap MUST be ≤ 28 days per spec §2.13. Prevents indefinite running on tied outcomes.',
+    detect(arch): boolean {
+      const dc = readField(arch, 'abTesting.durationCap');
+      if (typeof dc !== 'object' || dc === null) return false;
+      const m = (dc as Record<string, unknown>).maxDays;
+      return typeof m === 'number' && m <= 28;
+    }
+  },
+  {
+    id: 'abTesting.durationCap-hardstop',
+    contributor: 'abTesting',
+    reads: ['abTesting.durationCap'],
+    severity: 'fail',
+    description:
+      'Duration cap MUST have `hardStop: true`. Otherwise the cap is advisory and the experiment can run indefinitely.',
+    detect(arch): boolean {
+      const dc = readField(arch, 'abTesting.durationCap');
+      if (typeof dc !== 'object' || dc === null) return false;
+      return (dc as Record<string, unknown>).hardStop === true;
+    }
+  },
+  {
+    id: 'abTesting.winnerPromotion-all-criteria',
+    contributor: 'abTesting',
+    reads: ['abTesting.winnerPromotionPolicy'],
+    severity: 'fail',
+    description:
+      'Auto-promotion policy MUST declare all five criteria: pValueBelow, srmPass, minDurationDays, guardrailsRespected, sampleSizeFloorReached. Missing criteria mean unsafe auto-promotion.',
+    detect(arch): boolean {
+      const wpp = readField(arch, 'abTesting.winnerPromotionPolicy');
+      if (typeof wpp !== 'object' || wpp === null) return false;
+      const criteria = (wpp as Record<string, unknown>).criteria;
+      if (typeof criteria !== 'object' || criteria === null) return false;
+      const req = [
+        'pValueBelow',
+        'srmPass',
+        'minDurationDays',
+        'guardrailsRespected',
+        'sampleSizeFloorReached'
+      ];
+      const got = new Set(Object.keys(criteria as Record<string, unknown>));
+      for (const r of req) if (!got.has(r)) return false;
+      return true;
+    }
+  },
+  {
+    id: 'abTesting.sampleSize-matches-mde',
+    contributor: 'abTesting',
+    reads: ['abTesting.sampleSizeRequirements', 'abTesting.experimentDesign'],
+    severity: 'fail',
+    description:
+      'Per-variant sample size MUST agree with the closed-form two-proportion z-test result (within ±20%) given the declared baseline + MDE + α + power. This is the GOLDEN statistical-rigor invariant.',
+    detect(arch): boolean {
+      const ssr = readField(arch, 'abTesting.sampleSizeRequirements');
+      if (typeof ssr !== 'object' || ssr === null) return false;
+      const o = ssr as Record<string, unknown>;
+      const perVariantN = o.perVariantN;
+      const mdePct = o.mdePct;
+      const baselinePct = o.baselinePct;
+      const alpha = typeof o.alpha === 'number' ? o.alpha : 0.05;
+      const power = typeof o.power === 'number' ? o.power : 0.8;
+      if (typeof perVariantN !== 'number' || perVariantN <= 0) return false;
+      if (typeof mdePct !== 'number' || mdePct <= 0) return false;
+      if (typeof baselinePct !== 'number' || baselinePct <= 0) return false;
+      const reference = computeReferenceSampleSize(baselinePct, mdePct, alpha, power);
+      if (!Number.isFinite(reference)) return false;
+      const lower = reference * 0.8;
+      const upper = reference * 1.2;
+      return perVariantN >= lower && perVariantN <= upper;
+    }
+  },
+  {
+    id: 'abTesting.sampleSize-totalN-matches-perVariant',
+    contributor: 'abTesting',
+    reads: ['abTesting.sampleSizeRequirements', 'abTesting.variantRoutingStrategy'],
+    severity: 'fail',
+    description:
+      '`sampleSizeRequirements.totalN` MUST equal `perVariantN × number-of-variants`. Total mismatch signals the calc is detached from the routing strategy.',
+    detect(arch): boolean {
+      const ssr = readField(arch, 'abTesting.sampleSizeRequirements');
+      const route = readField(arch, 'abTesting.variantRoutingStrategy');
+      if (typeof ssr !== 'object' || ssr === null) return false;
+      if (typeof route !== 'object' || route === null) return true;
+      const perVariantN = (ssr as Record<string, unknown>).perVariantN;
+      const totalN = (ssr as Record<string, unknown>).totalN;
+      const variants = (route as Record<string, unknown>).variants;
+      if (typeof perVariantN !== 'number' || typeof totalN !== 'number') return false;
+      if (!Array.isArray(variants) || variants.length === 0) return false;
+      const expected = perVariantN * variants.length;
+      return Math.abs(totalN - expected) <= variants.length;
+    }
+  },
+  {
+    id: 'abTesting.experimentLifecycle-valid-state',
+    contributor: 'abTesting',
+    reads: ['abTesting.experimentLifecycle'],
+    severity: 'fail',
+    description:
+      'Current lifecycle phase MUST be one of {draft, running, analysis, decided, archived}. Other values mean the state machine is broken.',
+    detect(arch): boolean {
+      const lc = readField(arch, 'abTesting.experimentLifecycle');
+      if (typeof lc !== 'object' || lc === null) return false;
+      const phase = (lc as Record<string, unknown>).currentPhase;
+      const allowed = new Set(['draft', 'running', 'analysis', 'decided', 'archived']);
+      return typeof phase === 'string' && allowed.has(phase);
+    }
+  },
+  {
+    id: 'abTesting.experimentDesign-falsifiable-hypothesis',
+    contributor: 'abTesting',
+    reads: ['abTesting.experimentDesign'],
+    severity: 'advisory',
+    description:
+      'Hypothesis SHOULD contain a direction word (increase / decrease / lift / drop / improve / reduce / raise / lower / by X%). Vague hypotheses degrade readout interpretability.',
+    detect(arch): boolean {
+      const ed = readField(arch, 'abTesting.experimentDesign');
+      if (typeof ed !== 'object' || ed === null) return false;
+      const h = (ed as Record<string, unknown>).hypothesis;
+      if (typeof h !== 'string' || h.length < 5) return false;
+      return /\b(increase|decrease|lift|drop|improve|reduce|raise|lower|grow|shrink|boost|cut|by\s+\d)/i.test(h);
+    }
+  },
+  {
+    id: 'abTesting.primaryMetric-exists-in-analytics',
+    contributor: 'abTesting',
+    reads: ['abTesting.primaryMetric', 'analytics.eventTaxonomy'],
+    severity: 'fail',
+    description:
+      'Primary metric eventId MUST exist in upstream `analytics.eventTaxonomy`. Otherwise the runtime tracker has no event to read. Trivially passes if analytics upstream is absent.',
+    detect(arch): boolean {
+      const pm = readField(arch, 'abTesting.primaryMetric');
+      const tax = readField(arch, 'analytics.eventTaxonomy');
+      if (typeof pm !== 'object' || pm === null) return false;
+      const eventId = (pm as Record<string, unknown>).eventId;
+      if (typeof eventId !== 'string') return false;
+      if (typeof tax !== 'object' || tax === null) return true;
+      const eventIds = new Set(Object.keys(tax as Record<string, unknown>));
+      return eventIds.has(eventId);
+    }
+  },
+  {
+    id: 'abTesting.secondaryMetrics-exist-in-analytics',
+    contributor: 'abTesting',
+    reads: ['abTesting.secondaryMetrics', 'analytics.eventTaxonomy'],
+    severity: 'fail',
+    description:
+      'Every secondary metric eventId MUST exist in upstream `analytics.eventTaxonomy`. Trivially passes if analytics upstream is absent.',
+    detect(arch): boolean {
+      const sm = readField(arch, 'abTesting.secondaryMetrics');
+      const tax = readField(arch, 'analytics.eventTaxonomy');
+      if (!Array.isArray(sm)) return false;
+      if (typeof tax !== 'object' || tax === null) return true;
+      const eventIds = new Set(Object.keys(tax as Record<string, unknown>));
+      for (const entry of sm) {
+        if (typeof entry !== 'object' || entry === null) return false;
+        const eventId = (entry as Record<string, unknown>).eventId;
+        if (typeof eventId !== 'string' || !eventIds.has(eventId)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'abTesting.guardrailMetrics-exist-in-analytics',
+    contributor: 'abTesting',
+    reads: ['abTesting.guardrailMetrics', 'analytics.eventTaxonomy'],
+    severity: 'fail',
+    description:
+      'Every guardrail metric eventId MUST exist in upstream `analytics.eventTaxonomy`. Trivially passes if analytics upstream is absent.',
+    detect(arch): boolean {
+      const gm = readField(arch, 'abTesting.guardrailMetrics');
+      const tax = readField(arch, 'analytics.eventTaxonomy');
+      if (!Array.isArray(gm)) return false;
+      if (typeof tax !== 'object' || tax === null) return true;
+      const eventIds = new Set(Object.keys(tax as Record<string, unknown>));
+      for (const entry of gm) {
+        if (typeof entry !== 'object' || entry === null) return false;
+        const eventId = (entry as Record<string, unknown>).eventId;
+        if (typeof eventId !== 'string' || !eventIds.has(eventId)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'abTesting.guardrails-non-empty',
+    contributor: 'abTesting',
+    reads: ['abTesting.guardrailMetrics'],
+    severity: 'fail',
+    description:
+      'At least one guardrail metric MUST be declared. A treatment with zero guardrails can promote despite degrading latency, errors, or core engagement.',
+    detect(arch): boolean {
+      const gm = readField(arch, 'abTesting.guardrailMetrics');
+      return Array.isArray(gm) && gm.length > 0;
+    }
+  },
+  {
+    id: 'abTesting.featureFlagDependencies-key-naming',
+    contributor: 'abTesting',
+    reads: ['abTesting.featureFlagDependencies'],
+    severity: 'advisory',
+    description:
+      'Feature-flag key SHOULD match the `exp_<id>_<yyyy_mm>` convention. Mismatched keys make experiment provenance hard to audit.',
+    detect(arch): boolean {
+      const ffd = readField(arch, 'abTesting.featureFlagDependencies');
+      if (typeof ffd !== 'object' || ffd === null) return false;
+      const key = (ffd as Record<string, unknown>).flagKey;
+      if (typeof key !== 'string') return false;
+      return /^exp_[a-z0-9_]+_\d{4}_\d{2}$/.test(key);
+    }
+  },
+  {
+    id: 'abTesting.featureFlagDependencies-control-default',
+    contributor: 'abTesting',
+    reads: ['abTesting.featureFlagDependencies'],
+    severity: 'fail',
+    description:
+      'When the flag is disabled, the default variant MUST be `control`. Defaulting to the treatment on flag-off exposes users to an untested arm during outages.',
+    detect(arch): boolean {
+      const ffd = readField(arch, 'abTesting.featureFlagDependencies');
+      if (typeof ffd !== 'object' || ffd === null) return false;
+      return (ffd as Record<string, unknown>).defaultVariantOnDisable === 'control';
+    }
+  },
+  {
+    id: 'abTesting.featureFlag-bound-to-existing-flag',
+    contributor: 'abTesting',
+    reads: ['abTesting.featureFlagDependencies', 'featureFlagging.flagsSchema'],
+    severity: 'advisory',
+    description:
+      'The `featureFlagDependencies.flagKey` SHOULD exist in upstream `featureFlagging.flagsSchema`. Trivially passes if Feature Flagging upstream is absent — common during forward-ref builds.',
+    detect(arch): boolean {
+      const ffd = readField(arch, 'abTesting.featureFlagDependencies');
+      const schema = readField(arch, 'featureFlagging.flagsSchema');
+      if (typeof ffd !== 'object' || ffd === null) return false;
+      const key = (ffd as Record<string, unknown>).flagKey;
+      if (typeof key !== 'string') return false;
+      if (typeof schema !== 'object' || schema === null) return true;
+      const flagKeys = new Set(Object.keys(schema as Record<string, unknown>));
+      return flagKeys.has(key);
+    }
+  },
+  {
+    id: 'abTesting.statisticalReadout-alpha-power-sane',
+    contributor: 'abTesting',
+    reads: ['abTesting.statisticalReadoutMethod'],
+    severity: 'fail',
+    description:
+      'Statistical-readout alpha MUST be in (0, 0.1] and power MUST be in [0.7, 0.99]. Otherwise the test is either under-powered or accepts unreasonable Type-I error.',
+    detect(arch): boolean {
+      const srm = readField(arch, 'abTesting.statisticalReadoutMethod');
+      if (typeof srm !== 'object' || srm === null) return false;
+      const o = srm as Record<string, unknown>;
+      const alpha = o.alpha;
+      const power = o.power;
+      if (typeof alpha !== 'number' || alpha <= 0 || alpha > 0.1) return false;
+      if (typeof power !== 'number' || power < 0.7 || power > 0.99) return false;
+      return true;
+    }
+  }
+];

--- a/packages/ab-testing-architect/src/run.ts
+++ b/packages/ab-testing-architect/src/run.ts
@@ -1,0 +1,114 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Dependency note: A/B Testing depends on Analytics's
+ * `eventTaxonomy` + `funnelDefinitions` + `conversionGoals` AND Feature
+ * Flagging's `flagsSchema`. If either is absent we still call the
+ * spawner — the system prompt instructs the model to emit best-effort
+ * specs and surface the missing-upstream condition under `risks[]`.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { AB_TESTING_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+/**
+ * Project the input down to the JSON body the architect prompt expects.
+ * Privacy-sensitive tenant fields (schemaName, vaultNamespace) are
+ * omitted. Full `upstream.outputs` is passed through.
+ */
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture,
+      compliance: input.tenantContext.compliance ?? null
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+export async function runABTestingArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: [],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, AB_TESTING_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: [],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  const parsed = validation.parsed;
+  return {
+    ...parsed,
+    architectName: deps.architectName,
+    spend
+  };
+}

--- a/packages/ab-testing-architect/src/spawner.ts
+++ b/packages/ab-testing-architect/src/spawner.ts
@@ -1,0 +1,119 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * Mirrors `@caia/analytics-architect`'s spawner.ts verbatim — the shape
+ * is intentionally identical across all 17 architects so the Dispatcher
+ * can inject a single shared spawner factory.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+export interface ArchitectSpawnOutput {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  model: string;
+  ok: boolean;
+  diagnostic: string | null;
+}
+
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/ab-testing-architect/src/system-prompt.ts
+++ b/packages/ab-testing-architect/src/system-prompt.ts
@@ -1,0 +1,304 @@
+/**
+ * The A/B Testing Architect's system prompt — a pure function returning
+ * a static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic; the briefing is what turns generic Claude
+ * into this specialist.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked stack (two-proportion z-test default; α=0.05; power=0.8)
+ *   3. Input format (depends on Analytics + Feature Flagging upstream)
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples (terse — golden test fixture is the canonical example)
+ *
+ * The system-prompt test asserts each `abTesting.*` field name appears
+ * at least once in the body. Keep that invariant true if you add fields.
+ */
+
+import { AB_TESTING_OWNED_FIELD_KEYS } from './contract.js';
+
+export function buildABTestingSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's A/B Testing Architect. You are a senior experimentation
+engineer focused on A/B testing rigor — hypothesis framing, sample-size
+power calculations, sequential/Bayesian/frequentist statistical readout,
+variant routing, and holdout analysis.
+
+You produce per-ticket A/B test specs. You DO NOT write component code
+or backend logic. You DO specify how experiments are designed, sized,
+and analyzed.
+
+Your output is consumed by (a) the Feature Flagging Architect — which
+provisions the flag whose variants your router consumes, (b) the
+runtime experiment engine that reads \`variantRoutingStrategy\` to
+assign users, (c) the EA Reviewer's statistical-correctness lens
+(sample-size matches MDE, SRM enabled, guardrails declared), and (d)
+the dashboards that read \`primaryMetric\` + \`secondaryMetrics\` from
+your output. Any field outside the \`abTesting.*\` namespace is another
+architect's territory and will be rejected.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Statistical default**: frequentist two-proportion z-test with
+  α=0.05 (two-tailed) and power=0.8. Sequential testing
+  (O'Brien-Fleming or Pocock) is acceptable when ramp speed matters;
+  Bayesian (Beta-Binomial conjugate prior) acceptable when uninformative
+  priors aren't available.
+- **Variant router**: sticky-by-user-id via stable hash (FNV-1a or
+  MurmurHash3) seeded per experiment. Sticky-by-session only for
+  anonymous flows. Pageview-level routing ONLY for cosmetic experiments
+  where carryover is impossible.
+- **Default allocation**: 50/50 control vs. treatment. Multi-variant
+  (3-way) defaults to 34/33/33. Allocations MUST sum to 100.
+- **Sample-Ratio-Mismatch check**: ALWAYS enabled, α=0.001, daily.
+  A failed SRM halts the experiment immediately — broken router = invalid
+  data.
+- **Holdout**: 5% global holdout never exposed to the winning variant.
+  Used to estimate true long-tail lift (Hawthorne / novelty effects).
+- **Duration cap**: 28 days hard-stop. Per spec §2.13 — prevents
+  indefinite running on tied outcomes.
+- **Auto-promote criteria**: ALL of {p < α, SRM pass, min duration met,
+  guardrails respected, sample-size floor reached}. Failure of any
+  criterion drops to manual review.
+- **Randomization unit**: user (default). Session for ephemeral
+  anonymous flows. Pageview for cosmetic-only experiments.
+- **MDE**: derived from the interview answer when present, else 10%
+  relative MDE. Sample size is COMPUTED from MDE + baseline +
+  α + power, not picked.
+- **Naming**: experiment IDs follow \`exp_<short-id>_<yyyy_mm>\` (e.g.
+  \`exp_hero_cta_2026_05\`). Flag keys mirror experiment IDs.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."],
+              "experimental": true,
+              "quality_tags": ["ab-test", "experiment", ...] },
+  "businessPlan": { "ventureName": "...", "goals": [...],
+                    "growthStrategy": "..." },
+  "designVersion": { "designVersionId": "...", "anchors": [...] },
+  "tenantContext": { "tenantId": "...", "billingPosture": "..." },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {
+    "analytics": {
+      "architectureFields": {
+        "analytics.eventTaxonomy": { "<eventId>": {...} },
+        "analytics.funnelDefinitions": {...},
+        "analytics.conversionGoals": { "primary": "<eventId>",
+                                       "secondary": ["<eventId>"] }
+      }
+    },
+    "featureFlagging": {
+      "architectureFields": {
+        "featureFlagging.flagsSchema": { "<flagKey>": {...} }
+      }
+    }
+  } }
+}
+\`\`\`
+
+You MUST read \`upstream.outputs.analytics.architectureFields\` first.
+The \`analytics.eventTaxonomy\` is your authoritative list of measurable
+events; every metric ID you pick MUST exist there. The
+\`analytics.conversionGoals.primary\` is the FIRST candidate for your
+\`abTesting.primaryMetric.eventId\` — only override on strong evidence.
+
+You MUST also read \`upstream.outputs.featureFlagging.architectureFields\`
+to bind your \`abTesting.featureFlagDependencies.flagKey\` to an existing
+flag schema. If \`featureFlagging\` upstream is absent, emit a
+forward-reference flag key following \`exp_<id>_<yyyy_mm>\` and surface
+"featureFlagging upstream missing" under \`risks[]\`.
+
+The ticket's \`business_requirements\` may include an explicit interview
+answer for MDE (e.g. "we'd consider 5% lift meaningful"). Use it as your
+MDE if present; otherwise default to 10% relative MDE.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "abTesting",
+  "architectureFields": {
+${AB_TESTING_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "costUsd": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`abTesting.experimentDesign\` — \`{"hypothesis":"Treatment X will lift Y by Z%","primaryMetricId":"<eventId>","guardrailMetricIds":["<eventId>","<eventId>"],"expectedEffectSizePct":10,"minimumDetectableEffectPct":10,"baselineConversionRatePct":12,"direction":"increase"}\`. Hypothesis MUST be falsifiable. MDE is the smallest lift you'd be willing to act on.
+- \`abTesting.variantRoutingStrategy\` — \`{"kind":"sticky-user","hashSeed":"<experimentId>","salt":"<random>","stickinessKey":"userId","variants":[{"id":"control","name":"Control","allocationPct":50},{"id":"treatment","name":"Treatment","allocationPct":50}]}\`. Sticky-by-user is the default. Hash seed = experiment ID so re-running gives identical assignments.
+- \`abTesting.sampleSizeRequirements\` — \`{"perVariantN":<int>,"totalN":<int>,"powerCalcMethod":"two-proportion-z-test","alpha":0.05,"power":0.8,"mdePct":10,"baselinePct":12,"estimatedDurationDays":<int>}\`. Compute perVariantN via the closed-form two-proportion z-test (≈ 7.85 · (p1(1-p1) + p2(1-p2)) / (p1·mde/100)^2 at α=0.05, power=0.8).
+- \`abTesting.randomizationUnit\` — \`{"unit":"user","reason":"prevents within-user interference"}\`. User default; session for anonymous; pageview only for cosmetic.
+- \`abTesting.holdoutAnalysisPlan\` — \`{"holdoutPct":5,"holdoutGroupId":"holdout_<expId>","durationDays":90,"analysisCadence":"monthly","successCriteria":"lift persists vs. holdout at p<0.05"}\`. 5% is the locked default.
+- \`abTesting.statisticalReadoutMethod\` — \`{"kind":"frequentist","alpha":0.05,"power":0.8,"multipleComparisonsCorrection":"none"}\`. Use sequential testing (O'Brien-Fleming) when ramp speed matters; Bayesian (Beta-Binomial conjugate prior) when an informative prior exists.
+- \`abTesting.experimentLifecycle\` — \`{"currentPhase":"draft","transitions":[{"from":"draft","to":"running","gateChecks":["srm-enabled","sampleSize-computed","guardrails-defined","flag-provisioned"]},{"from":"running","to":"analysis","gateChecks":["sampleSizeFloor-reached","srm-passing","duration-not-capped"]},{"from":"analysis","to":"decided","gateChecks":["primary-metric-significant","guardrails-respected"]},{"from":"decided","to":"archived","gateChecks":["promotion-applied","flag-archived"]}],"gateChecks":{"srm-enabled":"daily SRM check active"}}\`.
+- \`abTesting.featureFlagDependencies\` — \`{"flagKey":"exp_<id>_<yyyy_mm>","expectedFlagShape":"string-variant","requiredVariants":["control","treatment"],"killSwitchKey":"exp_<id>_kill","defaultVariantOnDisable":"control"}\`. Forward-references the Feature Flagging architect. Flag key follows the \`exp_<id>_<yyyy_mm>\` convention.
+- \`abTesting.primaryMetric\` — \`{"eventId":"<eventId>","metricType":"conversion","aggregation":"unique-users","successDirection":"increase"}\`. eventId MUST exist in upstream \`analytics.eventTaxonomy\`.
+- \`abTesting.secondaryMetrics\` — \`[{"eventId":"<eventId>","metricType":"engagement","aggregation":"sum","successDirection":"increase","guardrail":false}]\`. Each eventId MUST exist in upstream \`analytics.eventTaxonomy\`.
+- \`abTesting.guardrailMetrics\` — \`[{"eventId":"page_load_time","metricType":"continuous","aggregation":"mean","direction":"non-increase","tolerancePct":5},{"eventId":"error_emitted","metricType":"count","aggregation":"sum","direction":"non-increase","tolerancePct":10}]\`. Guardrails BLOCK winner promotion.
+- \`abTesting.allocation\` — \`{"control":50,"treatment":50}\`. Sum MUST equal 100. Control MUST be first.
+- \`abTesting.winnerPromotionPolicy\` — \`{"auto":true,"criteria":{"pValueBelow":0.05,"srmPass":true,"minDurationDays":7,"guardrailsRespected":true,"sampleSizeFloorReached":true},"fallback":"manual-review"}\`. ALL criteria must pass for auto-promotion.
+- \`abTesting.durationCap\` — \`{"maxDays":28,"hardStop":true,"reasonForCap":"prevents indefinite running on tied outcome"}\`. 28-day cap per spec.
+- \`abTesting.srmCheck\` — \`{"enabled":true,"alpha":0.001,"schedule":"daily","actionOnFail":"halt-and-alert"}\`. ALWAYS enabled.`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **Hypothesis is falsifiable.** "Treatment will improve UX" is not
+  falsifiable. "Treatment will lift signup conversion by ≥5% relative"
+  IS falsifiable. The hypothesis dictates the primary metric and the
+  direction.
+- **Sample size matches MDE.** The smaller the MDE, the larger the N.
+  Closed-form for two-proportion z-test at α=0.05, power=0.8:
+  perVariantN ≈ 7.85 · (p1(1-p1) + p2(1-p2)) / (p1 · mdePct/100)^2
+  where p1 is the baseline conversion rate and
+  p2 = p1 · (1 + mdePct/100). If estimatedDurationDays exceeds 28
+  (the cap), raise MDE and surface "experiment underpowered" under
+  \`risks[]\`.
+- **Primary metric MUST exist upstream.** Read
+  \`upstream.outputs.analytics.architectureFields["analytics.eventTaxonomy"]\`
+  and pick an eventId that already exists. Inventing a new event ID
+  means the runtime tracker won't emit it.
+- **Guardrails are non-negotiable.** At minimum: latency, error rate,
+  and one core engagement event. A winning treatment that degrades any
+  guardrail past tolerance does NOT promote.
+- **Randomization unit defaults to user.** Switch to session only for
+  anonymous-first flows; switch to pageview only for cosmetic
+  experiments where carryover is impossible (e.g. font color test).
+- **Variant router is sticky-by-user-id with a stable hash.** Same user
+  → same variant for the entire experiment. Hash seed = experiment ID.
+- **SRM is non-negotiable.** Daily SRM at α=0.001 catches broken
+  routers within a day. Failed SRM halts immediately — the data is
+  contaminated.
+- **Holdout is 5% global.** Never exposed to the winning variant. Used
+  to measure long-tail lift (novelty wears off).
+- **Auto-promote requires ALL gates.** p<α + SRM pass + min duration
+  + guardrails respected + sample-size floor. ANY failure drops to
+  manual review.
+- **Multiple comparisons.** When testing >1 metric, apply
+  Bonferroni or Benjamini-Hochberg correction. Default is "none" only
+  when there is a single primary metric.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Run an experiment without a falsifiable hypothesis** → refuse.
+  List the request under \`risks[]\`, set \`confidence\` to 0.5, output
+  a placeholder hypothesis ("Treatment will change <metric> by
+  <unknown>%") and request operator clarification.
+- **Pick a primary metric that doesn't exist in upstream
+  \`analytics.eventTaxonomy\`** → refuse. The runtime tracker won't
+  emit unknown events. List under \`risks[]\` and either select an
+  existing event or surface "primary metric not in eventTaxonomy".
+- **Skip the SRM check** → refuse. Output \`srmCheck.enabled: true\`
+  regardless of operator preference. List the request under
+  \`risks[]\`.
+- **Skip the holdout group** → refuse. Output \`holdoutPct: 5\` (the
+  default) unless the operator provided a strong rationale; if they
+  did, output the requested holdout but never \`holdoutPct: 0\`.
+- **Allocate >2 variants without justification** → accept but require
+  multiple-comparisons correction (Bonferroni or Benjamini-Hochberg).
+- **Run an experiment past 28 days** → refuse. Output
+  \`durationCap.maxDays: 28\`, \`hardStop: true\`. List the request
+  under \`risks[]\`.
+- **Auto-promote on p<α alone** (no SRM, no guardrails, no min
+  duration) → refuse. Output the full ALL-criteria gate; list the
+  request under \`risks[]\`.
+- **Use a continuous metric (revenue, time-on-page) with a
+  two-proportion z-test** → refuse. Continuous metrics need Welch's
+  t-test or bootstrap CI. Switch \`statisticalReadoutMethod.kind\`
+  accordingly and note the change in \`notes\`.
+- **Decide an event taxonomy, flag schema, route, or any field NOT
+  under \`abTesting.*\`** → ignore the request. Do not populate fields
+  outside your owned namespace. Other architects own those concerns.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated, even if the value is a documented default.`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the 15 owned field
+   paths (no extras, no missing).
+2. \`abTesting.experimentDesign.hypothesis\` is a falsifiable sentence
+   containing a direction word (increase / decrease / lift / drop).
+3. \`abTesting.primaryMetric.eventId\` exists in
+   \`upstream.outputs.analytics.architectureFields["analytics.eventTaxonomy"]\`.
+4. Every \`abTesting.secondaryMetrics[].eventId\` exists in
+   \`upstream.outputs.analytics.architectureFields["analytics.eventTaxonomy"]\`.
+5. Every \`abTesting.guardrailMetrics[].eventId\` exists in
+   \`upstream.outputs.analytics.architectureFields["analytics.eventTaxonomy"]\`.
+6. \`abTesting.sampleSizeRequirements.perVariantN\` is computed (NOT
+   guessed) from \`mdePct\`, \`baselinePct\`, \`alpha\`, and \`power\` via
+   the two-proportion z-test closed form. Cross-check with the formula
+   in the decision heuristics.
+7. \`abTesting.sampleSizeRequirements.estimatedDurationDays\` ≤ 28
+   (the duration cap). If not, raise MDE and surface under \`risks\`.
+8. \`abTesting.allocation\` values sum to exactly 100. Control variant
+   is FIRST.
+9. \`abTesting.variantRoutingStrategy.variants\` allocations sum to 100
+   AND match \`abTesting.allocation\` totals exactly.
+10. \`abTesting.srmCheck.enabled\` === \`true\`. ALWAYS.
+11. \`abTesting.holdoutAnalysisPlan.holdoutPct\` ≥ 1.
+12. \`abTesting.durationCap.maxDays\` ≤ 28. \`hardStop\` === \`true\`.
+13. \`abTesting.winnerPromotionPolicy.criteria\` includes ALL of
+    {pValueBelow, srmPass, minDurationDays, guardrailsRespected,
+    sampleSizeFloorReached}.
+14. \`abTesting.featureFlagDependencies.flagKey\` matches the
+    \`exp_<id>_<yyyy_mm>\` naming convention.
+15. \`confidence\` reflects how comfortable you are with the decision —
+    sub-0.6 triggers the EA Reviewer to scrutinize.
+16. \`notes\` is ≤ 800 characters.
+17. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a hero-CTA experiment with baseline 12% conversion
+and 10% relative MDE yields perVariantN ≈ 12,000 (via the
+two-proportion z-test closed form at α=0.05, power=0.8). At 1,000
+qualified visitors per day per variant, the experiment runs ~12 days
+— well under the 28-day cap. Primary metric: \`booking_started\`.
+Guardrails: \`page_load_time\` (non-increase, 5% tolerance) +
+\`error_emitted\` (non-increase, 10% tolerance). Auto-promote when
+p<0.05 AND SRM passes AND duration ≥ 7 days AND guardrails respected
+AND sample-size floor reached. Holdout 5%, 90-day analysis. Flag key
+\`exp_hero_cta_2026_05\`.`;

--- a/packages/ab-testing-architect/src/types.ts
+++ b/packages/ab-testing-architect/src/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`.
+ * Mirrors frontend/analytics architect templates verbatim.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/ab-testing-architect/src/validation.ts
+++ b/packages/ab-testing-architect/src/validation.ts
@@ -1,0 +1,204 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Two layers:
+ *
+ *   1. **Structural** — does the JSON parse, and does it have the
+ *      required top-level keys (`architectName`, `architectureFields`,
+ *      `confidence`, `notes`, `dependencies`, `risks`, `toolCalls`,
+ *      `spend`, `status`)?
+ *
+ *   2. **Contract** — does `architectureFields` contain exactly the keys
+ *      this architect owns (no extras, no missing)? This is the
+ *      Dispatcher's first invariant per spec §3.4.
+ *
+ * The validator is pure + synchronous. Failures return a structured
+ * `ValidationResult.errors[]` array — the architect's `run()` decides
+ * whether to retry, mark partial, or mark failed.
+ *
+ * Mirrors the analytics-architect template verbatim.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/ab-testing-architect/tests/architect.test.ts
+++ b/packages/ab-testing-architect/tests/architect.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `ABTestingArchitect` — interface compliance tests.
+ *
+ * Verifies the class adheres to `SpecialistArchitect` per spec §1.1.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  ABTestingArchitect,
+  AB_TESTING_ARCHITECT_NAME,
+  AB_TESTING_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { ABTestingArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('ABTestingArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new ABTestingArchitect();
+    expect(a).toBeInstanceOf(ABTestingArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new ABTestingArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the architect-kit canonical entry', () => {
+    const a = new ABTestingArchitect();
+    expect(a.name).toBe('abTesting');
+    expect(a.name).toBe(AB_TESTING_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new ABTestingArchitect();
+    expect(a.sectionContract).toBe(ABTestingArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new ABTestingArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1 spec §2.13', () => {
+    const a = new ABTestingArchitect();
+    expect(a.tools).toBe(AB_TESTING_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new ABTestingArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new ABTestingArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new ABTestingArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new ABTestingArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('abTesting');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new ABTestingArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    const a = new ABTestingArchitect();
+    expect(a).toBeInstanceOf(ABTestingArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/ab-testing-architect/tests/contract.test.ts
+++ b/packages/ab-testing-architect/tests/contract.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Section contract structural + registration tests.
+ *
+ * Verifies per spec §1.3:
+ *   - All declared fields use the `abTesting.*` namespace.
+ *   - Every owned field has a non-empty description and is required.
+ *   - `architectMeta` is well-formed (precedence in [1,17], etc).
+ *   - The architect registers cleanly against the ArchitectRegistry.
+ *   - A second architect with overlapping paths is rejected.
+ *   - The canonical precedence ladder lists `abTesting` at rank 6.
+ *   - The `appliesPredicate` correctly opts in on experiment markers.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { ABTestingArchitect } from '../src/architect.js';
+import {
+  AB_TESTING_ARCHITECT_META,
+  AB_TESTING_OWNED_SECTIONS,
+  AB_TESTING_OWNED_FIELD_KEYS,
+  ABTestingArchitectContract,
+  abTestingArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('ABTestingArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(ABTestingArchitectContract.contractId).toBe('ab-testing-architect.v1');
+  });
+
+  it('architectName is `abTesting` (matches canonical ladder entry)', () => {
+    expect(ABTestingArchitectContract.architectName).toBe('abTesting');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(ABTestingArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `abTesting.`', () => {
+    for (const key of AB_TESTING_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('abTesting.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the task-brief mandatory fields', () => {
+    const required = [
+      'abTesting.experimentDesign',
+      'abTesting.variantRoutingStrategy',
+      'abTesting.sampleSizeRequirements',
+      'abTesting.randomizationUnit',
+      'abTesting.holdoutAnalysisPlan',
+      'abTesting.statisticalReadoutMethod',
+      'abTesting.experimentLifecycle',
+      'abTesting.featureFlagDependencies'
+    ];
+    for (const r of required) {
+      expect(AB_TESTING_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('owned-field set covers spec §2.13 mandatory fields', () => {
+    const specMandatory = [
+      'abTesting.primaryMetric',
+      'abTesting.secondaryMetrics',
+      'abTesting.allocation',
+      'abTesting.winnerPromotionPolicy',
+      'abTesting.durationCap',
+      'abTesting.srmCheck'
+    ];
+    for (const k of specMandatory) {
+      expect(AB_TESTING_OWNED_FIELD_KEYS).toContain(k);
+    }
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of AB_TESTING_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(ABTestingArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(ABTestingArchitectContract).slice().sort()).toEqual(
+      [...AB_TESTING_OWNED_FIELD_KEYS].sort()
+    );
+  });
+
+  it('declares the 15 owned sections (no fewer)', () => {
+    expect(AB_TESTING_OWNED_FIELD_KEYS.length).toBe(15);
+  });
+});
+
+describe('ABTestingArchitectContract — architectMeta', () => {
+  it('declares Analytics + Feature Flagging as upstream dependencies (wave-3 architect)', () => {
+    expect(AB_TESTING_ARCHITECT_META.dependsOn).toEqual(['analytics', 'featureFlagging']);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(AB_TESTING_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(AB_TESTING_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 6 per spec §2.13 + canonical ladder', () => {
+    expect(AB_TESTING_ARCHITECT_META.precedenceLevel).toBe(6);
+  });
+
+  it('fanoutPolicy is `conditional` — only runs on experiment-marked tickets', () => {
+    expect(AB_TESTING_ARCHITECT_META.fanoutPolicy).toBe('conditional');
+  });
+
+  it('runtimeModel is `sonnet` per spec', () => {
+    expect(AB_TESTING_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(AB_TESTING_ARCHITECT_META.appliesPredicate).toBe(abTestingArchitectAppliesPredicate);
+  });
+
+  it('matches the canonical precedence ladder for `abTesting`', () => {
+    expect(precedenceRank('abTesting')).toBe(AB_TESTING_ARCHITECT_META.precedenceLevel);
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('abTesting');
+  });
+});
+
+describe('abTestingArchitectAppliesPredicate', () => {
+  it('returns true when ticket.experimental is true', () => {
+    expect(abTestingArchitectAppliesPredicate({ id: 't1', type: 'Page', experimental: true })).toBe(
+      true
+    );
+  });
+
+  it('returns true when quality_tags contains "ab-test"', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Page',
+        quality_tags: ['ui', 'ab-test']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when quality_tags contains "experiment"', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Widget',
+        quality_tags: ['experiment']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when quality_tags contains "experimental"', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Story',
+        quality_tags: ['experimental']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when business_requirements mention "A/B test"', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Page',
+        business_requirements: { description: 'run an A/B test on the hero CTA' }
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when business_requirements mention "experiment"', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Page',
+        business_requirements: { description: 'we want an experiment on copy' }
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when business_requirements mention "variant"', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Widget',
+        business_requirements: { description: 'show variant copy for the CTA' }
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when business_requirements mention "treatment"', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Widget',
+        business_requirements: { description: 'compare treatment against baseline' }
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when business_requirements mention "lift"', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Widget',
+        business_requirements: { description: 'we want to measure lift on conversion' }
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for a plain Page ticket with no experimental markers', () => {
+    expect(abTestingArchitectAppliesPredicate({ id: 't1', type: 'Page' })).toBe(false);
+  });
+
+  it('returns false for a Widget with unrelated quality_tags', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Widget',
+        quality_tags: ['ui', 'analytics']
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when business_requirements has no relevant keywords', () => {
+    expect(
+      abTestingArchitectAppliesPredicate({
+        id: 't1',
+        type: 'Page',
+        business_requirements: { description: 'a simple marketing page' }
+      })
+    ).toBe(false);
+  });
+
+  it('returns false for Foundation tickets without explicit marker', () => {
+    expect(abTestingArchitectAppliesPredicate({ id: 't1', type: 'Foundation' })).toBe(false);
+  });
+});
+
+/**
+ * Minimal stub architect used to test disjointness rejection.
+ */
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the A/B Testing architect cleanly', () => {
+    expect(() => {
+      registry.register(new ABTestingArchitect());
+    }).not.toThrow();
+    expect(registry.get('abTesting')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new ABTestingArchitect());
+    for (const k of AB_TESTING_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('abTesting');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new ABTestingArchitect());
+    expect(() => registry.register(new ABTestingArchitect())).toThrowError(
+      ArchitectRegistryError
+    );
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new ABTestingArchitect());
+
+    const collidingContract: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'abTesting.experimentDesign',
+          description: 'colliding owner',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 15,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', collidingContract));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new ABTestingArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'analytics-architect.v1',
+      architectName: 'analytics',
+      version: '0.1.0',
+      sections: [
+        { path: 'analytics.eventTaxonomy', description: 'event taxonomy', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 10,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('analytics', disjointContract));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(AB_TESTING_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it('disjointness() detects no conflicts when only A/B Testing is present', () => {
+    const conflicts = disjointness([ABTestingArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between A/B Testing and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...ABTestingArchitectContract,
+      contractId: 'ab-testing-clone.v1',
+      architectName: 'abTesting-clone'
+    };
+    const conflicts = disjointness([ABTestingArchitectContract, clone]);
+    expect(conflicts.length).toBe(AB_TESTING_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() reports the missing analytics + featureFlagging deps when alone', () => {
+    registry.register(new ABTestingArchitect());
+    const errors = registry.validate();
+    expect(errors.some(e => e.includes('analytics'))).toBe(true);
+    expect(errors.some(e => e.includes('featureFlagging'))).toBe(true);
+  });
+
+  it('registry.validate() is clean when analytics + featureFlagging are also registered', () => {
+    registry.register(new ABTestingArchitect());
+    const analyticsContract: ArchitectSectionContract = {
+      contractId: 'analytics-architect.v1',
+      architectName: 'analytics',
+      version: '0.1.0',
+      sections: [
+        { path: 'analytics.eventTaxonomy', description: 'event taxonomy', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 10,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    const featureFlaggingContract: ArchitectSectionContract = {
+      contractId: 'feature-flagging-architect.v1',
+      architectName: 'featureFlagging',
+      version: '0.1.0',
+      sections: [
+        { path: 'featureFlagging.flagsSchema', description: 'flag schema', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 7,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    registry.register(new StubArchitect('analytics', analyticsContract));
+    registry.register(new StubArchitect('featureFlagging', featureFlaggingContract));
+    expect(registry.validate()).toEqual([]);
+  });
+});

--- a/packages/ab-testing-architect/tests/golden/golden.test.ts
+++ b/packages/ab-testing-architect/tests/golden/golden.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Golden test — the canonical known-good A/B-Testing-architect artifact
+ * for a known prakash-tiwari Widget ticket. Includes the
+ * **golden experiment-design rigor test** (sample size matches expected
+ * effect size, falsifiable hypothesis, all-criteria auto-promotion gate,
+ * mandatory SRM + holdout + duration cap).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { ABTestingArchitect } from '../../src/architect.js';
+import { AB_TESTING_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { AB_TESTING_INVARIANTS, computeReferenceSampleSize } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari hero-CTA A/B test Widget ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8'));
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-designversion.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-designversion.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().designVersion;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), AB_TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new ABTestingArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    expect(out.architectName).toBe('abTesting');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    for (const k of AB_TESTING_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.dependencies).toEqual(expected.dependencies);
+    expect(out.risks).toEqual(expected.risks);
+  });
+
+  it('output passes every A/B Testing invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new ABTestingArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of AB_TESTING_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new ABTestingArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+});
+
+/**
+ * Golden experiment-design rigor lens — locks the EA Reviewer's
+ * statistical-correctness invariants against the canonical fixture.
+ * This is the test the operator referenced in the task brief
+ * ("golden test verifying experiment design rigor (e.g., sample size
+ * matches expected effect size)").
+ */
+describe('GOLDEN EXPERIMENT-DESIGN RIGOR LENS', () => {
+  const arch = goldenExpectedOutput().architectureFields;
+  const design = arch['abTesting.experimentDesign'] as Record<string, unknown>;
+  const sampleSize = arch['abTesting.sampleSizeRequirements'] as Record<string, unknown>;
+  const routing = arch['abTesting.variantRoutingStrategy'] as Record<string, unknown>;
+  const allocation = arch['abTesting.allocation'] as Record<string, number>;
+  const wpp = arch['abTesting.winnerPromotionPolicy'] as Record<string, unknown>;
+  const dc = arch['abTesting.durationCap'] as Record<string, unknown>;
+  const srm = arch['abTesting.srmCheck'] as Record<string, unknown>;
+  const hop = arch['abTesting.holdoutAnalysisPlan'] as Record<string, unknown>;
+  const lifecycle = arch['abTesting.experimentLifecycle'] as Record<string, unknown>;
+  const ffd = arch['abTesting.featureFlagDependencies'] as Record<string, unknown>;
+  const primary = arch['abTesting.primaryMetric'] as Record<string, unknown>;
+  const guardrails = arch['abTesting.guardrailMetrics'] as Array<Record<string, unknown>>;
+  const readout = arch['abTesting.statisticalReadoutMethod'] as Record<string, unknown>;
+
+  it('hypothesis is a falsifiable sentence with a direction word', () => {
+    const h = design.hypothesis as string;
+    expect(typeof h).toBe('string');
+    expect(h.length).toBeGreaterThan(40);
+    expect(h).toMatch(/\b(increase|decrease|lift|drop|improve|reduce|by\s+\d)/i);
+  });
+
+  it('hypothesis names a quantified effect size', () => {
+    const h = design.hypothesis as string;
+    expect(h).toMatch(/\d+\s*%/);
+  });
+
+  it('sample size matches the closed-form two-proportion z-test (±20% tolerance)', () => {
+    const baseline = sampleSize.baselinePct as number;
+    const mde = sampleSize.mdePct as number;
+    const alpha = sampleSize.alpha as number;
+    const power = sampleSize.power as number;
+    const declared = sampleSize.perVariantN as number;
+    const reference = computeReferenceSampleSize(baseline, mde, alpha, power);
+    expect(declared).toBeGreaterThanOrEqual(reference * 0.8);
+    expect(declared).toBeLessThanOrEqual(reference * 1.2);
+  });
+
+  it('sample size shrinks as MDE grows (sanity)', () => {
+    const small = computeReferenceSampleSize(12, 5, 0.05, 0.8);
+    const big = computeReferenceSampleSize(12, 20, 0.05, 0.8);
+    expect(small).toBeGreaterThan(big);
+  });
+
+  it('sample size grows as power grows (sanity)', () => {
+    const low = computeReferenceSampleSize(12, 10, 0.05, 0.8);
+    const high = computeReferenceSampleSize(12, 10, 0.05, 0.9);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('totalN equals perVariantN × number of variants', () => {
+    const variants = (routing.variants as Array<unknown>).length;
+    const perVariantN = sampleSize.perVariantN as number;
+    const totalN = sampleSize.totalN as number;
+    expect(totalN).toBe(perVariantN * variants);
+  });
+
+  it('estimated duration is within the 28-day hard cap', () => {
+    expect(sampleSize.estimatedDurationDays as number).toBeLessThanOrEqual(28);
+  });
+
+  it('allocation sums to exactly 100', () => {
+    const sum = Object.values(allocation).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(100);
+  });
+
+  it('variant-routing allocations sum to exactly 100', () => {
+    const variants = routing.variants as Array<Record<string, unknown>>;
+    const sum = variants.reduce((a, v) => a + (v.allocationPct as number), 0);
+    expect(sum).toBe(100);
+  });
+
+  it('control variant is first', () => {
+    const variants = routing.variants as Array<Record<string, unknown>>;
+    expect(variants[0]?.id).toBe('control');
+  });
+
+  it('routing strategy is sticky-by-user by default', () => {
+    expect(routing.kind).toBe('sticky-user');
+    expect(routing.stickinessKey).toBe('userId');
+  });
+
+  it('SRM check is enabled at α=0.001 with daily schedule', () => {
+    expect(srm.enabled).toBe(true);
+    expect(srm.alpha).toBe(0.001);
+    expect(srm.schedule).toBe('daily');
+    expect(srm.actionOnFail).toBe('halt-and-alert');
+  });
+
+  it('holdout is ≥ 5% (non-zero by construction)', () => {
+    expect(hop.holdoutPct as number).toBeGreaterThanOrEqual(5);
+  });
+
+  it('duration cap is 28 days with hard-stop', () => {
+    expect(dc.maxDays).toBe(28);
+    expect(dc.hardStop).toBe(true);
+  });
+
+  it('auto-promotion requires ALL five criteria (no shortcuts)', () => {
+    expect(wpp.auto).toBe(true);
+    const criteria = wpp.criteria as Record<string, unknown>;
+    expect(criteria.pValueBelow).toBe(0.05);
+    expect(criteria.srmPass).toBe(true);
+    expect(criteria.minDurationDays).toBeGreaterThanOrEqual(1);
+    expect(criteria.guardrailsRespected).toBe(true);
+    expect(criteria.sampleSizeFloorReached).toBe(true);
+    expect(wpp.fallback).toBe('manual-review');
+  });
+
+  it('lifecycle starts in draft and includes all five canonical phases', () => {
+    expect(lifecycle.currentPhase).toBe('draft');
+    const transitions = lifecycle.transitions as Array<Record<string, unknown>>;
+    const allFroms = new Set(transitions.map(t => t.from));
+    const allTos = new Set(transitions.map(t => t.to));
+    expect(allFroms).toContain('draft');
+    expect(allFroms).toContain('running');
+    expect(allFroms).toContain('analysis');
+    expect(allFroms).toContain('decided');
+    expect(allTos).toContain('archived');
+  });
+
+  it('feature-flag dependency follows the `exp_<id>_<yyyy_mm>` naming convention', () => {
+    expect(ffd.flagKey as string).toMatch(/^exp_[a-z0-9_]+_\d{4}_\d{2}$/);
+  });
+
+  it('default variant on flag-disable is control (safe fallback)', () => {
+    expect(ffd.defaultVariantOnDisable).toBe('control');
+  });
+
+  it('primary metric eventId exists in the upstream Analytics taxonomy', () => {
+    const input = buildFakeInput();
+    const taxonomy = (input.upstream.outputs.analytics.architectureFields[
+      'analytics.eventTaxonomy'
+    ] as Record<string, unknown>);
+    expect(taxonomy).toHaveProperty(primary.eventId as string);
+  });
+
+  it('every guardrail metric eventId exists in the upstream Analytics taxonomy', () => {
+    const input = buildFakeInput();
+    const taxonomy = (input.upstream.outputs.analytics.architectureFields[
+      'analytics.eventTaxonomy'
+    ] as Record<string, unknown>);
+    for (const g of guardrails) {
+      expect(taxonomy).toHaveProperty(g.eventId as string);
+    }
+  });
+
+  it('every secondary metric eventId exists in the upstream Analytics taxonomy', () => {
+    const input = buildFakeInput();
+    const taxonomy = (input.upstream.outputs.analytics.architectureFields[
+      'analytics.eventTaxonomy'
+    ] as Record<string, unknown>);
+    const secondaries = arch['abTesting.secondaryMetrics'] as Array<Record<string, unknown>>;
+    for (const s of secondaries) {
+      expect(taxonomy).toHaveProperty(s.eventId as string);
+    }
+  });
+
+  it('guardrails are non-empty (at least one declared)', () => {
+    expect(Array.isArray(guardrails)).toBe(true);
+    expect(guardrails.length).toBeGreaterThan(0);
+  });
+
+  it('every guardrail declares a tolerance and a non-decrease/non-increase direction', () => {
+    for (const g of guardrails) {
+      expect(typeof g.tolerancePct).toBe('number');
+      expect(['non-increase', 'non-decrease']).toContain(g.direction);
+    }
+  });
+
+  it('statistical readout uses sensible alpha + power', () => {
+    expect(readout.alpha as number).toBeGreaterThan(0);
+    expect(readout.alpha as number).toBeLessThanOrEqual(0.05);
+    expect(readout.power as number).toBeGreaterThanOrEqual(0.8);
+    expect(readout.power as number).toBeLessThanOrEqual(0.99);
+  });
+
+  it('expected effect size matches the MDE (no over/under-claim)', () => {
+    expect(design.expectedEffectSizePct).toBe(design.minimumDetectableEffectPct);
+  });
+
+  it('baseline conversion rate is declared in design AND sample-size requirements (consistent)', () => {
+    expect(design.baselineConversionRatePct).toBe(sampleSize.baselinePct);
+  });
+
+  it('MDE is declared in design AND sample-size requirements (consistent)', () => {
+    expect(design.minimumDetectableEffectPct).toBe(sampleSize.mdePct);
+  });
+});

--- a/packages/ab-testing-architect/tests/golden/input-businessplan.json
+++ b/packages/ab-testing-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,12 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions",
+    "Project warm + grounded brand voice",
+    "Make the booking CTA the page's primary action"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": ["No third-party fonts beyond next/font defaults"]
+}

--- a/packages/ab-testing-architect/tests/golden/input-designversion.json
+++ b/packages/ab-testing-architect/tests/golden/input-designversion.json
@@ -1,0 +1,23 @@
+{
+  "versionId": "design-pt-v3-2026-05-22",
+  "snapshotUri": "s3://atlas/designs/design-pt-v3-2026-05-22.png",
+  "anchors": [
+    {
+      "anchorId": "hero",
+      "kind": "section",
+      "bbox": { "x": 0, "y": 0, "w": 1440, "h": 720 },
+      "meta": { "variant": "hero", "breakpoints": ["sm", "md", "lg", "xl"] }
+    },
+    {
+      "anchorId": "hero-cta-primary",
+      "kind": "button",
+      "bbox": { "x": 600, "y": 320, "w": 200, "h": 56 },
+      "meta": { "variant": "primary" }
+    }
+  ],
+  "tokens": {
+    "color.brand.primary": "#0f3057",
+    "color.brand.accent": "#e8c547"
+  },
+  "breakpoints": ["sm", "md", "lg", "xl"]
+}

--- a/packages/ab-testing-architect/tests/golden/input-ticket.json
+++ b/packages/ab-testing-architect/tests/golden/input-ticket.json
@@ -1,0 +1,22 @@
+{
+  "id": "ticket-pt-ab-001",
+  "type": "Widget",
+  "scope": "story",
+  "parent_id": null,
+  "experimental": true,
+  "quality_tags": ["ui", "analytics", "ab-test", "experiment"],
+  "acceptance_criteria": [
+    "Treatment CTA copy lifts booking_started conversion by ≥5% relative vs. control.",
+    "Variant assignment is sticky per user across sessions.",
+    "Experiment auto-terminates at 28 days regardless of significance.",
+    "SRM check is active and halts the experiment on failure.",
+    "Holdout group is preserved across the entire experiment lifecycle."
+  ],
+  "business_requirements": {
+    "title": "A/B test hero CTA copy variants",
+    "description": "Experiment: does treatment CTA copy (\"Book a session\") drive more bookings than control (\"Reserve your slot\")? Baseline conversion rate ~12%. Interview answer: 10% relative lift would be meaningful.",
+    "experimentMetric": "booking_started",
+    "mdePct": 10,
+    "baselineConversionRatePct": 12
+  }
+}

--- a/packages/ab-testing-architect/tests/helpers/fakes.ts
+++ b/packages/ab-testing-architect/tests/helpers/fakes.ts
@@ -1,0 +1,487 @@
+/**
+ * Test fixtures + fake spawner factory.
+ *
+ *   - `buildFakeInput()` — produces a deterministic `ArchitectInput` for
+ *     a known prakash-tiwari Widget ticket WITH synthesised Analytics +
+ *     Feature Flagging upstream outputs.
+ *
+ *   - `fakeSpawnerReturning(text)` — fabricates an `ArchitectSpawnerFn`
+ *     that returns the given text deterministically.
+ *
+ *   - `goldenExpectedOutput()` — the canonical known-good
+ *     `ArchitectOutput` for the prakash-tiwari Widget fixture.
+ *
+ *   - `composedArchitectureForInvariants()` — combines the Analytics +
+ *     Feature Flagging + A/B Testing slices into the composed view the
+ *     EA Reviewer sees post-Dispatcher, exercising the cross-architect
+ *     invariants.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { AB_TESTING_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+/**
+ * The known-good Analytics upstream output. The eventTaxonomy contains
+ * page_view, cta_clicked_primary, cta_clicked_secondary, booking_started
+ * PLUS page_load_time + error_emitted (added here so we have
+ * guardrail-eligible events).
+ */
+function buildAnalyticsUpstreamOutput(): ArchitectOutput {
+  return {
+    architectName: 'analytics',
+    architectureFields: {
+      'analytics.eventTaxonomy': {
+        page_view: {
+          eventName: 'page_view',
+          trigger: 'router:navigate',
+          payloadSchema: { path: 'string', referrer: 'string?' },
+          consentRequired: 'none',
+          noPii: true,
+          category: 'page'
+        },
+        cta_clicked_primary: {
+          eventName: 'cta_clicked',
+          trigger: 'hero-cta-primary:click',
+          payloadSchema: { componentId: 'string', variant: 'string', destination: 'string' },
+          consentRequired: 'none',
+          noPii: true,
+          category: 'cta'
+        },
+        cta_clicked_secondary: {
+          eventName: 'cta_clicked',
+          trigger: 'hero-cta-secondary:click',
+          payloadSchema: { componentId: 'string', variant: 'string', destination: 'string' },
+          consentRequired: 'none',
+          noPii: true,
+          category: 'cta'
+        },
+        booking_started: {
+          eventName: 'booking_started',
+          trigger: 'hero-cta-primary:downstream-route-loaded',
+          payloadSchema: { entrySurface: 'string' },
+          consentRequired: 'analytics_storage',
+          noPii: true,
+          category: 'conversion'
+        },
+        page_load_time: {
+          eventName: 'page_load_time',
+          trigger: 'navigation:complete',
+          payloadSchema: { ms: 'number', path: 'string' },
+          consentRequired: 'none',
+          noPii: true,
+          category: 'page'
+        },
+        error_emitted: {
+          eventName: 'error_emitted',
+          trigger: 'window:error',
+          payloadSchema: { kind: 'string', count: 'number' },
+          consentRequired: 'none',
+          noPii: true,
+          category: 'engagement'
+        }
+      },
+      'analytics.funnelDefinitions': {
+        booking_funnel: {
+          name: 'Booking conversion',
+          steps: ['page_view', 'cta_clicked_primary', 'booking_started'],
+          window: '7d'
+        }
+      },
+      'analytics.conversionGoals': {
+        primary: 'booking_started',
+        secondary: ['cta_clicked_primary']
+      }
+    },
+    confidence: 0.9,
+    notes: 'Analytics golden output for prakash-tiwari hero widget.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/**
+ * The known-good Feature Flagging upstream output. Pre-stages
+ * `exp_hero_cta_2026_05` so the A/B Testing architect's flag-key choice
+ * matches.
+ */
+function buildFeatureFlaggingUpstreamOutput(): ArchitectOutput {
+  return {
+    architectName: 'featureFlagging',
+    architectureFields: {
+      'featureFlagging.flagsSchema': {
+        exp_hero_cta_2026_05: {
+          kind: 'string-variant',
+          variants: ['control', 'treatment'],
+          defaultValue: 'control',
+          killSwitch: 'exp_hero_cta_2026_05_kill',
+          owner: 'experimentation-team'
+        }
+      }
+    },
+    confidence: 0.85,
+    notes: 'Feature flag scaffolded for hero-cta experiment.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/**
+ * The canonical fixture — a Widget ticket from prakash-tiwari.com
+ * marked experimental, with both Analytics and Feature Flagging upstream
+ * outputs populated.
+ */
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-ab-001',
+      type: 'Widget',
+      scope: 'story',
+      parent_id: null,
+      experimental: true,
+      quality_tags: ['ui', 'analytics', 'ab-test', 'experiment'],
+      acceptance_criteria: [
+        'Treatment CTA copy lifts booking_started conversion by ≥5% relative vs. control.',
+        'Variant assignment is sticky per user across sessions.',
+        'Experiment auto-terminates at 28 days regardless of significance.',
+        'SRM check is active and halts the experiment on failure.',
+        'Holdout group is preserved across the entire experiment lifecycle.'
+      ],
+      business_requirements: {
+        title: 'A/B test hero CTA copy variants',
+        description:
+          'Experiment: does treatment CTA copy ("Book a session") drive more bookings than control ("Reserve your slot")? Baseline conversion rate ~12%. Interview answer: 10% relative lift would be meaningful.',
+        experimentMetric: 'booking_started',
+        mdePct: 10,
+        baselineConversionRatePct: 12
+      }
+    },
+    upstream: {
+      outputs: {
+        analytics: buildAnalyticsUpstreamOutput(),
+        featureFlagging: buildFeatureFlaggingUpstreamOutput()
+      }
+    },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: "High-intent prospective sitters in the artist's metropolitan area.",
+      goals: [
+        'Drive contact-form submissions',
+        'Project warm + grounded brand voice',
+        "Make the booking CTA the page's primary action"
+      ],
+      brandVoice: 'warm + grounded',
+      constraints: ['No third-party fonts beyond next/font defaults']
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [
+        {
+          anchorId: 'hero',
+          kind: 'section',
+          bbox: { x: 0, y: 0, w: 1440, h: 720 },
+          meta: { variant: 'hero', breakpoints: ['sm', 'md', 'lg', 'xl'] }
+        },
+        {
+          anchorId: 'hero-cta-primary',
+          kind: 'button',
+          bbox: { x: 600, y: 320, w: 200, h: 56 },
+          meta: { variant: 'primary' }
+        }
+      ],
+      tokens: {
+        'color.brand.primary': '#0f3057',
+        'color.brand.accent': '#e8c547'
+      },
+      breakpoints: ['sm', 'md', 'lg', 'xl']
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 },
+      compliance: { dataResidency: 'EU' }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+/**
+ * The known-good output for the prakash-tiwari Widget fixture.
+ *
+ * Sample-size math (the golden statistical-rigor lock):
+ *   baseline p1 = 0.12 ; relative MDE = 10% ⇒ p2 = 0.132 ; delta = 0.012
+ *   alpha = 0.05 (two-tailed) ⇒ Z_{α/2} ≈ 1.96
+ *   power = 0.8 ⇒ Z_β ≈ 0.8416
+ *   leading constant (Z_{α/2} + Z_β)^2 ≈ 7.849
+ *   variance term p1(1-p1) + p2(1-p2) = 0.1056 + 0.114576 = 0.220176
+ *   perVariantN ≈ 7.849 · 0.220176 / (0.012)^2 ≈ 12,002
+ * We round to 12,000 per variant; totalN = 24,000 (2 variants).
+ *
+ * IMPORTANT: this fixture is the golden "what good looks like" for the
+ * sample-size-matches-MDE invariant. The `sampleSize-matches-mde` test
+ * reads it and asserts the reference computation comes within ±20%.
+ */
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'abTesting',
+    architectureFields: {
+      'abTesting.experimentDesign': {
+        hypothesis:
+          'Treatment CTA copy ("Book a session") will increase booking_started conversion by at least 10% relative versus control ("Reserve your slot") within a 28-day window.',
+        primaryMetricId: 'booking_started',
+        guardrailMetricIds: ['page_load_time', 'error_emitted'],
+        expectedEffectSizePct: 10,
+        minimumDetectableEffectPct: 10,
+        baselineConversionRatePct: 12,
+        direction: 'increase'
+      },
+      'abTesting.variantRoutingStrategy': {
+        kind: 'sticky-user',
+        hashSeed: 'exp_hero_cta_2026_05',
+        salt: 'pt-ab-2026-05-24',
+        stickinessKey: 'userId',
+        variants: [
+          { id: 'control', name: 'Control — "Reserve your slot"', allocationPct: 50 },
+          { id: 'treatment', name: 'Treatment — "Book a session"', allocationPct: 50 }
+        ]
+      },
+      'abTesting.sampleSizeRequirements': {
+        perVariantN: 12000,
+        totalN: 24000,
+        powerCalcMethod: 'two-proportion-z-test',
+        alpha: 0.05,
+        power: 0.8,
+        mdePct: 10,
+        baselinePct: 12,
+        estimatedDurationDays: 12
+      },
+      'abTesting.randomizationUnit': {
+        unit: 'user',
+        reason:
+          'User-level randomization prevents within-user carryover — booking is a once-per-week-ish action, sessions are too short to capture conversion.'
+      },
+      'abTesting.holdoutAnalysisPlan': {
+        holdoutPct: 5,
+        holdoutGroupId: 'holdout_exp_hero_cta_2026_05',
+        durationDays: 90,
+        analysisCadence: 'monthly',
+        successCriteria:
+          'Lift persists vs. holdout at p<0.05 across 90-day post-promotion window — confirms no novelty/Hawthorne decay.'
+      },
+      'abTesting.statisticalReadoutMethod': {
+        kind: 'frequentist',
+        alpha: 0.05,
+        power: 0.8,
+        multipleComparisonsCorrection: 'none'
+      },
+      'abTesting.experimentLifecycle': {
+        currentPhase: 'draft',
+        transitions: [
+          {
+            from: 'draft',
+            to: 'running',
+            gateChecks: [
+              'srm-enabled',
+              'sampleSize-computed',
+              'guardrails-defined',
+              'flag-provisioned'
+            ]
+          },
+          {
+            from: 'running',
+            to: 'analysis',
+            gateChecks: ['sampleSizeFloor-reached', 'srm-passing', 'duration-not-capped']
+          },
+          {
+            from: 'analysis',
+            to: 'decided',
+            gateChecks: ['primary-metric-significant', 'guardrails-respected']
+          },
+          {
+            from: 'decided',
+            to: 'archived',
+            gateChecks: ['promotion-applied', 'flag-archived']
+          }
+        ],
+        gateChecks: {
+          'srm-enabled': 'daily SRM check active with alpha=0.001',
+          'sampleSize-computed': 'perVariantN matches closed-form z-test ±20%',
+          'guardrails-defined': 'at least one guardrail metric declared',
+          'flag-provisioned': 'featureFlagDependencies.flagKey exists in flagsSchema',
+          'sampleSizeFloor-reached': 'perVariantN reached in observed data',
+          'srm-passing': 'daily SRM chi-square > alpha',
+          'duration-not-capped': 'wall-clock < durationCap.maxDays',
+          'primary-metric-significant': 'p < alpha on primary metric',
+          'guardrails-respected': 'no guardrail exceeded tolerance',
+          'promotion-applied': 'flag default flipped to winning variant',
+          'flag-archived': 'flag marked archived in flagsSchema'
+        }
+      },
+      'abTesting.featureFlagDependencies': {
+        flagKey: 'exp_hero_cta_2026_05',
+        expectedFlagShape: 'string-variant',
+        requiredVariants: ['control', 'treatment'],
+        killSwitchKey: 'exp_hero_cta_2026_05_kill',
+        defaultVariantOnDisable: 'control'
+      },
+      'abTesting.primaryMetric': {
+        eventId: 'booking_started',
+        metricType: 'conversion',
+        aggregation: 'unique-users',
+        successDirection: 'increase'
+      },
+      'abTesting.secondaryMetrics': [
+        {
+          eventId: 'cta_clicked_primary',
+          metricType: 'count',
+          aggregation: 'sum',
+          successDirection: 'increase',
+          guardrail: false
+        },
+        {
+          eventId: 'cta_clicked_secondary',
+          metricType: 'count',
+          aggregation: 'sum',
+          successDirection: 'increase',
+          guardrail: false
+        }
+      ],
+      'abTesting.guardrailMetrics': [
+        {
+          eventId: 'page_load_time',
+          metricType: 'continuous',
+          aggregation: 'mean',
+          direction: 'non-increase',
+          tolerancePct: 5
+        },
+        {
+          eventId: 'error_emitted',
+          metricType: 'count',
+          aggregation: 'sum',
+          direction: 'non-increase',
+          tolerancePct: 10
+        }
+      ],
+      'abTesting.allocation': {
+        control: 50,
+        treatment: 50
+      },
+      'abTesting.winnerPromotionPolicy': {
+        auto: true,
+        criteria: {
+          pValueBelow: 0.05,
+          srmPass: true,
+          minDurationDays: 7,
+          guardrailsRespected: true,
+          sampleSizeFloorReached: true
+        },
+        fallback: 'manual-review'
+      },
+      'abTesting.durationCap': {
+        maxDays: 28,
+        hardStop: true,
+        reasonForCap: 'Spec §2.13 — prevents indefinite running on tied outcomes.'
+      },
+      'abTesting.srmCheck': {
+        enabled: true,
+        alpha: 0.001,
+        schedule: 'daily',
+        actionOnFail: 'halt-and-alert'
+      }
+    },
+    confidence: 0.9,
+    notes:
+      'A/B test spec for hero CTA copy. Sticky-by-user routing. Baseline 12%, 10% relative MDE → 12k per variant via two-proportion z-test (α=0.05, power=0.8). 50/50 split. Primary metric: booking_started. Guardrails: page_load_time (≤5%), error_emitted (≤10%). 5% holdout, 90-day post-promotion analysis. 28-day duration cap with hard-stop. SRM daily at α=0.001. Auto-promote on all-gates pass; otherwise manual review.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+export function composedArchitectureForInvariants(): Readonly<Record<string, unknown>> {
+  const abTesting = goldenExpectedOutput().architectureFields;
+  const analytics = buildAnalyticsUpstreamOutput().architectureFields;
+  const featureFlagging = buildFeatureFlaggingUpstreamOutput().architectureFields;
+  return { ...abTesting, ...analytics, ...featureFlagging };
+}
+
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of AB_TESTING_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/ab-testing-architect/tests/invariants.test.ts
+++ b/packages/ab-testing-architect/tests/invariants.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Cross-architect invariants — verifies A/B Testing's contributions to
+ * the EA Reviewer's invariant registry (per spec §6.2).
+ *
+ * Includes the golden statistical-correctness tests: sample size matches
+ * the closed-form two-proportion z-test, SRM enabled, allocations
+ * sum-to-100, all-criteria auto-promotion.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  AB_TESTING_INVARIANTS,
+  computeReferenceSampleSize
+} from '../src/invariants.js';
+import {
+  composedArchitectureForInvariants,
+  goldenExpectedOutput
+} from './helpers/fakes.js';
+
+describe('AB_TESTING_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(AB_TESTING_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of AB_TESTING_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `abTesting`', () => {
+    for (const inv of AB_TESTING_INVARIANTS) {
+      expect(inv.contributor).toBe('abTesting');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of AB_TESTING_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of AB_TESTING_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of AB_TESTING_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('AB_TESTING_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of AB_TESTING_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('srmCheck-enabled fails when SRM is disabled', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.srmCheck-enabled');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.srmCheck': { enabled: false, alpha: 0.001, schedule: 'daily' }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('allocation-sums-to-100 fails on a 60/30 split', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.allocation-sums-to-100');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.allocation': { control: 60, treatment: 30 }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('allocation-sums-to-100 passes on a 50/50 split', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.allocation-sums-to-100');
+    expect(inv).toBeDefined();
+    expect(inv!.detect(goldenArch)).toBe(true);
+  });
+
+  it('allocation-sums-to-100 passes on 34/33/33 three-way', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.allocation-sums-to-100');
+    const variant = {
+      ...goldenArch,
+      'abTesting.allocation': { control: 34, treatment_a: 33, treatment_b: 33 }
+    };
+    expect(inv!.detect(variant)).toBe(true);
+  });
+
+  it('variantRouting-allocations-sum-to-100 fails when variant allocations don\'t sum', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.variantRouting-allocations-sum-to-100'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.variantRoutingStrategy': {
+        kind: 'sticky-user',
+        hashSeed: 'x',
+        salt: 'y',
+        stickinessKey: 'userId',
+        variants: [
+          { id: 'control', name: 'C', allocationPct: 40 },
+          { id: 'treatment', name: 'T', allocationPct: 40 }
+        ]
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('variantRouting-control-first fails when control is not the first variant', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.variantRouting-control-first');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.variantRoutingStrategy': {
+        kind: 'sticky-user',
+        hashSeed: 'x',
+        salt: 'y',
+        stickinessKey: 'userId',
+        variants: [
+          { id: 'treatment', name: 'T', allocationPct: 50 },
+          { id: 'control', name: 'C', allocationPct: 50 }
+        ]
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('holdout-nonzero fails when holdoutPct is 0', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.holdout-nonzero');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.holdoutAnalysisPlan': { holdoutPct: 0, holdoutGroupId: 'x', durationDays: 90 }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('durationCap-under-28d fails when maxDays > 28', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.durationCap-under-28d');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.durationCap': { maxDays: 60, hardStop: true, reasonForCap: 'x' }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('durationCap-hardstop fails when hardStop is false', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.durationCap-hardstop');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.durationCap': { maxDays: 28, hardStop: false, reasonForCap: 'x' }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('winnerPromotion-all-criteria fails when a criterion is missing', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.winnerPromotion-all-criteria'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.winnerPromotionPolicy': {
+        auto: true,
+        criteria: {
+          pValueBelow: 0.05,
+          srmPass: true
+          // missing minDurationDays, guardrailsRespected, sampleSizeFloorReached
+        },
+        fallback: 'manual-review'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('sampleSize-matches-mde passes on golden (12% baseline, 10% MDE → ~12k per variant)', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.sampleSize-matches-mde');
+    expect(inv).toBeDefined();
+    expect(inv!.detect(goldenArch)).toBe(true);
+  });
+
+  it('sampleSize-matches-mde fails when perVariantN is wildly off (e.g. 100)', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.sampleSize-matches-mde');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.sampleSizeRequirements': {
+        perVariantN: 100,
+        totalN: 200,
+        powerCalcMethod: 'two-proportion-z-test',
+        alpha: 0.05,
+        power: 0.8,
+        mdePct: 10,
+        baselinePct: 12,
+        estimatedDurationDays: 1
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('sampleSize-matches-mde fails when perVariantN is too large (10x reference)', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.sampleSize-matches-mde');
+    const ref = computeReferenceSampleSize(12, 10, 0.05, 0.8);
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.sampleSizeRequirements': {
+        perVariantN: ref * 10,
+        totalN: ref * 20,
+        powerCalcMethod: 'two-proportion-z-test',
+        alpha: 0.05,
+        power: 0.8,
+        mdePct: 10,
+        baselinePct: 12,
+        estimatedDurationDays: 28
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('sampleSize-totalN-matches-perVariant fails when totalN ≠ perVariantN × variants', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.sampleSize-totalN-matches-perVariant'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.sampleSizeRequirements': {
+        perVariantN: 12000,
+        totalN: 12000, // ← wrong: should be 24000 for 2 variants
+        powerCalcMethod: 'two-proportion-z-test',
+        alpha: 0.05,
+        power: 0.8,
+        mdePct: 10,
+        baselinePct: 12,
+        estimatedDurationDays: 12
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('experimentLifecycle-valid-state fails on unknown phase', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.experimentLifecycle-valid-state'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.experimentLifecycle': { currentPhase: 'flying' }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('experimentDesign-falsifiable-hypothesis fails on a vague hypothesis', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.experimentDesign-falsifiable-hypothesis'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.experimentDesign': {
+        ...((goldenArch['abTesting.experimentDesign'] as object) ?? {}),
+        hypothesis: 'Make things better.'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('primaryMetric-exists-in-analytics passes against composed view', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.primaryMetric-exists-in-analytics'
+    );
+    expect(inv).toBeDefined();
+    expect(inv!.detect(composedArchitectureForInvariants())).toBe(true);
+  });
+
+  it('primaryMetric-exists-in-analytics passes trivially when analytics upstream absent', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.primaryMetric-exists-in-analytics'
+    );
+    // The per-architect view (goldenArch alone) has no analytics.eventTaxonomy.
+    // The invariant should pass trivially (cross-arch lax mode).
+    expect(inv!.detect(goldenArch)).toBe(true);
+  });
+
+  it('primaryMetric-exists-in-analytics fails on a dangling primary metric reference (composed)', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.primaryMetric-exists-in-analytics'
+    );
+    const composed = { ...composedArchitectureForInvariants() };
+    composed['abTesting.primaryMetric'] = {
+      eventId: 'NOT_A_REAL_EVENT',
+      metricType: 'conversion',
+      aggregation: 'unique-users',
+      successDirection: 'increase'
+    };
+    expect(inv!.detect(composed)).toBe(false);
+  });
+
+  it('secondaryMetrics-exist-in-analytics fails on a dangling secondary metric (composed)', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.secondaryMetrics-exist-in-analytics'
+    );
+    const composed = { ...composedArchitectureForInvariants() };
+    composed['abTesting.secondaryMetrics'] = [
+      {
+        eventId: 'NOT_A_REAL_EVENT',
+        metricType: 'engagement',
+        aggregation: 'sum',
+        successDirection: 'increase',
+        guardrail: false
+      }
+    ];
+    expect(inv!.detect(composed)).toBe(false);
+  });
+
+  it('guardrailMetrics-exist-in-analytics fails on a dangling guardrail (composed)', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.guardrailMetrics-exist-in-analytics'
+    );
+    const composed = { ...composedArchitectureForInvariants() };
+    composed['abTesting.guardrailMetrics'] = [
+      {
+        eventId: 'NOT_A_REAL_EVENT',
+        metricType: 'continuous',
+        aggregation: 'mean',
+        direction: 'non-increase',
+        tolerancePct: 5
+      }
+    ];
+    expect(inv!.detect(composed)).toBe(false);
+  });
+
+  it('guardrails-non-empty fails when no guardrails declared', () => {
+    const inv = AB_TESTING_INVARIANTS.find(i => i.id === 'abTesting.guardrails-non-empty');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.guardrailMetrics': []
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('featureFlagDependencies-key-naming advisory fires on bad key', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.featureFlagDependencies-key-naming'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.featureFlagDependencies': {
+        flagKey: 'random-name-not-conventional',
+        expectedFlagShape: 'string-variant',
+        requiredVariants: ['control', 'treatment'],
+        killSwitchKey: 'x',
+        defaultVariantOnDisable: 'control'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('featureFlagDependencies-control-default fails when default-on-disable is treatment', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.featureFlagDependencies-control-default'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.featureFlagDependencies': {
+        flagKey: 'exp_x_2026_05',
+        expectedFlagShape: 'string-variant',
+        requiredVariants: ['control', 'treatment'],
+        killSwitchKey: 'x',
+        defaultVariantOnDisable: 'treatment'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('statisticalReadout-alpha-power-sane fails when alpha > 0.1', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.statisticalReadout-alpha-power-sane'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.statisticalReadoutMethod': { kind: 'frequentist', alpha: 0.25, power: 0.8 }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('statisticalReadout-alpha-power-sane fails when power < 0.7', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.statisticalReadout-alpha-power-sane'
+    );
+    const corrupted = {
+      ...goldenArch,
+      'abTesting.statisticalReadoutMethod': { kind: 'frequentist', alpha: 0.05, power: 0.5 }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+});
+
+describe('AB_TESTING_INVARIANTS — composed (with Analytics + Feature Flagging) view', () => {
+  it('featureFlag-bound-to-existing-flag passes when the flag exists in upstream schema', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.featureFlag-bound-to-existing-flag'
+    );
+    expect(inv).toBeDefined();
+    expect(inv!.detect(composedArchitectureForInvariants())).toBe(true);
+  });
+
+  it('featureFlag-bound-to-existing-flag fails when the flag is not in upstream schema (composed)', () => {
+    const inv = AB_TESTING_INVARIANTS.find(
+      i => i.id === 'abTesting.featureFlag-bound-to-existing-flag'
+    );
+    const composed = { ...composedArchitectureForInvariants() };
+    composed['abTesting.featureFlagDependencies'] = {
+      flagKey: 'exp_does_not_exist_2026_05',
+      expectedFlagShape: 'string-variant',
+      requiredVariants: ['control', 'treatment'],
+      killSwitchKey: 'x',
+      defaultVariantOnDisable: 'control'
+    };
+    expect(inv!.detect(composed)).toBe(false);
+  });
+
+  it('every fail-severity invariant passes against the fully composed view', () => {
+    const composed = composedArchitectureForInvariants();
+    for (const inv of AB_TESTING_INVARIANTS) {
+      if (inv.severity === 'fail') {
+        expect(inv.detect(composed), `${inv.id} should pass on composed view`).toBe(true);
+      }
+    }
+  });
+});
+
+describe('computeReferenceSampleSize — sanity', () => {
+  it('grows when MDE shrinks', () => {
+    const big = computeReferenceSampleSize(12, 5, 0.05, 0.8);
+    const small = computeReferenceSampleSize(12, 20, 0.05, 0.8);
+    expect(big).toBeGreaterThan(small);
+  });
+
+  it('grows when power increases', () => {
+    const lo = computeReferenceSampleSize(12, 10, 0.05, 0.8);
+    const hi = computeReferenceSampleSize(12, 10, 0.05, 0.9);
+    expect(hi).toBeGreaterThan(lo);
+  });
+
+  it('grows when alpha tightens', () => {
+    const lax = computeReferenceSampleSize(12, 10, 0.1, 0.8);
+    const tight = computeReferenceSampleSize(12, 10, 0.01, 0.8);
+    expect(tight).toBeGreaterThan(lax);
+  });
+
+  it('returns a finite positive integer for sane inputs', () => {
+    const n = computeReferenceSampleSize(12, 10, 0.05, 0.8);
+    expect(Number.isFinite(n)).toBe(true);
+    expect(n).toBeGreaterThan(0);
+    expect(Number.isInteger(n)).toBe(true);
+  });
+
+  it('returns Infinity when MDE is 0 (cannot detect zero effect)', () => {
+    const n = computeReferenceSampleSize(12, 0, 0.05, 0.8);
+    expect(n).toBe(Infinity);
+  });
+});

--- a/packages/ab-testing-architect/tests/run.test.ts
+++ b/packages/ab-testing-architect/tests/run.test.ts
@@ -1,0 +1,242 @@
+/**
+ * `run()` tests — verifies the runtime pipeline.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { AB_TESTING_ARCHITECT_NAME, ABTestingArchitect } from '../src/architect.js';
+import { AB_TESTING_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runABTestingArchitect } from '../src/run.js';
+import { buildABTestingSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runABTestingArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runABTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('abTesting');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runABTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    for (const k of AB_TESTING_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runABTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runABTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runABTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildABTestingSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runABTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runABTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runABTestingArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runABTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    const b = await runABTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runABTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    const r2 = await runABTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).slice().sort()).toEqual(
+      Object.keys(r1.architectureFields).slice().sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(AB_TESTING_OWNED_FIELD_KEYS.length);
+  });
+});
+
+describe('runABTestingArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runABTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"abTesting"}');
+    const out = await runABTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runABTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runABTestingArchitect — dependency declaration', () => {
+  it('abTesting is a wave-3 architect (no sibling-ticket deps in this fixture)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runABTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildABTestingSystemPrompt(),
+      architectName: AB_TESTING_ARCHITECT_NAME
+    });
+    expect(out.dependencies).toEqual([]);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-ab-001');
+  });
+
+  it('serialises the Analytics upstream eventTaxonomy', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('analytics.eventTaxonomy');
+    expect(p).toContain('booking_started');
+  });
+
+  it('serialises the Analytics upstream conversionGoals', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('analytics.conversionGoals');
+  });
+
+  it('serialises the Feature Flagging upstream flagsSchema', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('featureFlagging.flagsSchema');
+    expect(p).toContain('exp_hero_cta_2026_05');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('preserves tenantContext.compliance.dataResidency', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('dataResidency');
+    expect(p).toContain('EU');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: { reason: 'increase MDE to fit in duration cap', severity: 'P1' as const }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('increase MDE to fit in duration cap');
+  });
+});
+
+describe('ABTestingArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new ABTestingArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('abTesting');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/ab-testing-architect/tests/system-prompt.test.ts
+++ b/packages/ab-testing-architect/tests/system-prompt.test.ts
@@ -1,0 +1,134 @@
+/**
+ * System-prompt tests — verifies the briefing satisfies spec §11(b).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { AB_TESTING_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildABTestingSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildABTestingSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildABTestingSystemPrompt();
+    const p2 = buildABTestingSystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's A/B Testing Architect");
+  });
+
+  it('contains the Locked stack section with statistical defaults', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('two-proportion z-test');
+    expect(p).toContain('α=0.05');
+    expect(p).toContain('power=0.8');
+    expect(p).toContain('Sample-Ratio-Mismatch');
+    expect(p).toContain('SRM');
+  });
+
+  it('mentions sticky-by-user-id variant routing as the default', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('sticky-by-user-id');
+  });
+
+  it('mentions the 28-day duration cap', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('28 days');
+  });
+
+  it('mentions the 5% holdout default', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('5%');
+    expect(p).toContain('holdout');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildABTestingSystemPrompt();
+    for (const key of AB_TESTING_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('falsifiable');
+  });
+
+  it('contains a Refusal patterns section that rejects skipping SRM', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('SRM');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('abTesting.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains the sample-size formula or its derivation', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('perVariantN');
+    expect(p.toLowerCase()).toMatch(/two-proportion|closed[- ]form|power[- ]?calc/);
+  });
+
+  it('contains the all-criteria auto-promote rule', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p.toLowerCase()).toContain('auto-promote');
+    expect(p).toContain('SRM pass');
+    expect(p).toContain('guardrails');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('does not refer to fields outside the `abTesting.*` namespace', () => {
+    const p = buildABTestingSystemPrompt();
+    const foreignPrefixes = [
+      'backend.apiShape',
+      'database.schemaDDL',
+      'security.cspPolicy',
+      'a11y.wcagLevel',
+      'observability.logShape',
+      'frontend.componentTree'
+    ];
+    for (const prefix of foreignPrefixes) {
+      expect(p).not.toContain(prefix);
+    }
+  });
+
+  it('size is bounded (token-budget proxy: < 25k chars)', () => {
+    const p = buildABTestingSystemPrompt();
+    expect(p).toBeDefined();
+    expect(p.length).toBeLessThan(25_000);
+  });
+});

--- a/packages/ab-testing-architect/tests/validation.test.ts
+++ b/packages/ab-testing-architect/tests/validation.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Output validation tests — verifies the contract validator catches
+ * every documented error class and accepts well-formed outputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { AB_TESTING_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), AB_TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('abTesting');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ```json fences (lenient parser)', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, AB_TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, AB_TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', AB_TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', AB_TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', AB_TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput(
+      '{"architectName":"abTesting"}',
+      AB_TESTING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    const codes = result.errors.map(e => e.code);
+    expect(codes).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['abTesting.experimentDesign'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      AB_TESTING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'backend.apiShape': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      AB_TESTING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      AB_TESTING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      AB_TESTING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      AB_TESTING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      AB_TESTING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      AB_TESTING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(
+        JSON.stringify(variant),
+        AB_TESTING_OWNED_FIELD_KEYS
+      );
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/ab-testing-architect/tsconfig.build.json
+++ b/packages/ab-testing-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/ab-testing-architect/tsconfig.json
+++ b/packages/ab-testing-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/ab-testing-architect/vitest.config.ts
+++ b/packages/ab-testing-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,25 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
+  packages/ab-testing-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/accessibility-architect:
     dependencies:
       '@caia/architect-kit':


### PR DESCRIPTION
## What

Ships **architect #13 of 17** in CAIA's EA fan-out — the **A/B Testing Architect** (`@caia/ab-testing-architect`).

Senior experimentation engineer focused on A/B testing rigor: hypothesis framing, sample-size power calculations, sequential / Bayesian / frequentist statistical readout, variant routing, holdout analysis.

## Owns

`abTesting.*` slice of `tickets.architecture` JSONB — 15 fields:

- `experimentDesign` — hypothesis + primary metric + guardrail metrics + expected effect size + MDE + baseline + direction
- `variantRoutingStrategy` — sticky-user (default) / sticky-session / percentage / geographic + hash seed + salt + per-variant allocations
- `sampleSizeRequirements` — perVariantN + totalN + power-calc method + α + power + MDE + baseline + estimated days
- `randomizationUnit` — user / session / pageview
- `holdoutAnalysisPlan` — 5% default global holdout never exposed to winning variant
- `statisticalReadoutMethod` — frequentist (default two-proportion z-test) / Bayesian / sequential (O'Brien-Fleming / Pocock)
- `experimentLifecycle` — `draft → running → analysis → decided → archived` state machine with per-transition gate checks
- `featureFlagDependencies` — forward-references Feature Flagging Architect's `flagsSchema`
- `primaryMetric`, `secondaryMetrics`, `guardrailMetrics`
- `allocation` (default 50/50, control first)
- `winnerPromotionPolicy` — auto-promote only when ALL of {p<α, SRM passes, min duration met, guardrails respected, sample-size floor reached}
- `durationCap` — 28-day hard-stop per spec §2.13
- `srmCheck` — Sample-Ratio-Mismatch check (always on, α=0.001, daily)

## Wave + dependencies

- **Wave 3** (the lone wave-3 architect per spec §3.3)
- **Depends on:** Analytics (`eventTaxonomy`, `funnelDefinitions`, `conversionGoals`) AND Feature Flagging (`flagsSchema`)
- **Precedence rank 6** per the canonical ladder (statistical correctness ranks below security/devops/a11y/seo/performance because incorrect-but-significant experiment results are recoverable while a security breach is not)
- **fanoutPolicy: conditional** — only runs on tickets explicitly marked for experimentation

## Does NOT do

- ❌ Write component code (Frontend's territory)
- ❌ Write backend logic (Backend's territory)
- ❌ Decide event taxonomy (Analytics owns it; A/B Testing picks IDs from it)
- ❌ Decide flag schema (Feature Flagging owns it; A/B Testing forward-references flag keys)
- ❌ Populate fields outside `abTesting.*` — validator rejects them

## Tests

**185 vitest tests passing** across 7 files:

| File | Tests |
|---|---|
| `architect.test.ts` | 12 |
| `contract.test.ts` | 39 |
| `system-prompt.test.ts` | 18 |
| `validation.test.ts` | 19 |
| `run.test.ts` | 22 |
| `invariants.test.ts` | 41 |
| `golden/golden.test.ts` | 34 |

Including the **golden experiment-design rigor lens** that locks the canonical hero-CTA experiment fixture:

- Hypothesis is falsifiable + names a quantified effect size
- **Sample size matches the closed-form two-proportion z-test** (baseline 12%, MDE 10%, α=0.05, power=0.8 → `perVariantN ≈ 12,000`, within ±20% of reference)
- `totalN = perVariantN × number of variants`
- Estimated duration within the 28-day hard cap
- Allocation sums to 100, control variant first
- SRM enabled at α=0.001 daily
- Holdout ≥5%
- Duration cap = 28 days with hard-stop
- Auto-promotion requires ALL five gate criteria
- Lifecycle starts in `draft` and includes all five canonical phases
- Flag key follows `exp_<id>_<yyyy_mm>` convention
- Default-on-disable is `control` (safe fallback)
- Primary / secondary / guardrail metric IDs all exist in upstream Analytics taxonomy
- Expected effect size matches MDE
- Baseline + MDE consistent between `experimentDesign` and `sampleSizeRequirements`

## Statistical posture (locked)

- Two-proportion z-test default, α=0.05 two-tailed, power=0.8
- Closed-form sample size: `n ≈ ((Z_α/2 + Z_β)² · (p1(1-p1) + p2(1-p2))) / (p1 - p2)²`
- Sticky-by-user-id variant routing via stable hash seeded per experiment
- 5% global holdout, never exposed to winning variant
- 28-day duration cap, hard-stop
- Auto-promote: ALL of {p<α, SRM pass, min duration met, guardrails respected, sample-size floor reached}
- SRM check mandatory at α=0.001 daily

## Constraints honoured

- ✅ Subscription-only — spawns Claude via `@chiefaia/claude-spawner` (never sets `ANTHROPIC_API_KEY`)
- ✅ shadcn/ui + Tailwind stack-lock (N/A — this architect produces no JSX)
- ✅ TypeScript strict — zero typecheck errors
- ✅ True-Zero rule — no stubs, no advisory-only returns; every owned field is `required: true`

## Spec references

- `research/17_architect_framework_spec_2026.md` §2.13 (architect role), §3.3 (wave scheduling), §5.2 (precedence ladder), §11.A13 (architect brief)
- `agent-memory/project_caia_17_architects.md` #13 (roster)

## V1 tools

Empty. The `caia-power-calc` deterministic two-proportion z-test MCP tool is a planned V2 addition per spec §2.13. For V1 the closed-form result is computed inline by the model per the system-prompt guidance.
