### PR TITLE
feat(@caia/api-gateway-architect): ship architect #11 of 17 — API Gateway specialist

### DIFF
--- a/packages/api-gateway-architect/README.md
+++ b/packages/api-gateway-architect/README.md
@@ -1,0 +1,35 @@
+# @caia/api-gateway-architect
+
+Architect #11 of CAIA's 17-architect EA fan-out. Senior API platform engineer focused on **gateways + rate limiting + auth gates + versioning**. Sits in front of Backend's endpoints.
+
+## What it owns
+
+`apiGateway.*` slice of the `tickets.architecture` JSONB column:
+
+- `apiGateway.rateLimits` — per-route + per-tenant rate limits (extends Security's `rateLimitingRules` with gateway-layer enforcement)
+- `apiGateway.authGates` — which routes require auth + which auth type (public, Cloudflare Access, JWT bearer, service-token, mTLS, API-key)
+- `apiGateway.versioningStrategy` — URL-versioning (`/v1/`, `/v2/`) vs header-versioning + sunset policy
+- `apiGateway.errorEnvelope` — gateway error envelope extending Backend's (adds `requestId`, `gatewayCode`, `retryable`, `upstream`)
+- `apiGateway.requestResponseTransforms` — request rewrites, response rewrites, header manipulations applied at the edge
+- `apiGateway.corsPolicy` — origin allowlist, allowed methods + headers, credentials, max-age, per-tenant override
+- `apiGateway.webhookSecrets` — webhook signing posture (HMAC alg, header name, timestamp tolerance, replay protection, rotation)
+- `apiGateway.apiQuotas` — per-tier monthly/daily quota enforcement (subscription tier → quota mapping, overage behaviour)
+
+## What it does NOT do
+
+No backend logic (Backend Architect owns that). No auth implementation (Security Architect owns that — API Gateway only specifies which gate is on which route + how the gateway enforces it). No UI. No database. No CI pipelines.
+
+## How it runs
+
+Implements `SpecialistArchitect` from `@caia/architect-kit` (merged PR #535). Depends on **Backend Architect** (`apiEndpoints`, `authRequirements`, `rateLimits`) and **Security Architect** (`authenticationStrategy`, `authorizationRules`) upstream — wave-2. Each spawn calls `@chiefaia/claude-spawner` with Sonnet default.
+
+Precedence rank **8** per spec §2.11.
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (≥30 tests)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```

--- a/packages/api-gateway-architect/eslint.config.cjs
+++ b/packages/api-gateway-architect/eslint.config.cjs
@@ -1,0 +1,31 @@
+// @ts-check
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/api-gateway-architect/package.json
+++ b/packages/api-gateway-architect/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@caia/api-gateway-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "API Gateway Architect — architect #11 of CAIA's 17-architect EA fan-out. Owns apiGateway.* (rateLimits, authGates, versioningStrategy, errorEnvelope, requestResponseTransforms, corsPolicy, webhookSecrets, apiQuotas). Sits in front of Backend's endpoints. Depends on Backend Architect + Security Architect upstream. Precedence rank 8 per spec §5.2. Spawns Claude via @chiefaia/claude-spawner (subscription-only) with Sonnet default.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@caia/backend-architect": "workspace:*",
+    "@caia/security-architect": "workspace:*",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/api-gateway-architect/src/architect.ts
+++ b/packages/api-gateway-architect/src/architect.ts
@@ -1,0 +1,52 @@
+/**
+ * `ApiGatewayArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes.
+ */
+
+import { ApiGatewayArchitectContract } from './contract.js';
+import { runApiGatewayArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildApiGatewaySystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches the `apiGateway` slot in the canonical precedence ladder. */
+export const API_GATEWAY_ARCHITECT_NAME = 'apiGateway' as const;
+
+/** V1: no architect-specific tools. */
+export const API_GATEWAY_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface ApiGatewayArchitectConfig {
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class ApiGatewayArchitect implements SpecialistArchitect {
+  readonly name = API_GATEWAY_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = ApiGatewayArchitectContract;
+  readonly tools: readonly ToolDefinition[] = API_GATEWAY_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: ApiGatewayArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  systemPrompt(): string {
+    return buildApiGatewaySystemPrompt();
+  }
+
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runApiGatewayArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/api-gateway-architect/src/contract.ts
+++ b/packages/api-gateway-architect/src/contract.ts
@@ -1,0 +1,178 @@
+/**
+ * `ApiGatewayArchitectContract` — the canonical owned-fields declaration
+ * for architect #11 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.11 (API Gateway Architect owns `apiGateway.*`)
+ *   - task brief (rateLimits, authGates, versioningStrategy,
+ *     errorEnvelope, requestResponseTransforms, corsPolicy,
+ *     webhookSecrets, apiQuotas)
+ *
+ * Upstream dependencies (`dependsOn`): Backend Architect
+ * (`backend.apiEndpoints`, `backend.authRequirements`,
+ * `backend.rateLimits`, `backend.errorEnvelope`) and Security Architect
+ * (`security.authenticationStrategy`, `security.authorizationRules`,
+ * `security.rateLimitingRules`). API Gateway is a **wave-2** architect.
+ *
+ * Precedence rank **8** per spec §5.2 — boundary integrity sits above
+ * observability/analytics/database/backend/frontend but below the
+ * safety/perf critics.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+export const API_GATEWAY_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'apiGateway.rateLimits':
+    'Extend Backend\'s + Security\'s rate limits at the edge. Output {perRoute:{<METHOD /path>:{windowMs,max,burst?,scope,onLimit}}, perTenant:{<tier>:{windowMs,max,onLimit}}, defaults:{...}}. Scope is one of tenant|ip|user|apiKey. onLimit defaults to {status:429,retryAfterSec:60}. Marketing-public routes always IP-scoped + capped.',
+  'apiGateway.authGates':
+    'For each route in Backend\'s `apiEndpoints`, declare {authType:public|cloudflare-access|jwt-bearer|service-token|mtls|api-key, gateAt:edge|origin, required:true|false}. MUST cross-validate against Security\'s `authenticationStrategy.perEndpoint`. Marketing-public defaults to {authType:public, gateAt:edge, required:false}.',
+  'apiGateway.versioningStrategy':
+    'Default to {kind:url-prefix, prefix:/v1, sunsetPolicy:{advanceNoticeDays:180, headerName:Sunset, deprecationHeaderName:Deprecation}}. Header-versioning only permitted when the operator explicitly tags the ticket with `header-versioning`.',
+  'apiGateway.errorEnvelope':
+    'EXTEND (do not replace) Backend\'s `errorEnvelope`. Output {schema:{...extending Backend\'s shape...}, addedFields:{requestId, gatewayCode, retryable, upstream?}, mapping:{<gatewayCondition>:{httpStatus, gatewayCode, retryable}}}. Required gatewayCodes include GATEWAY_RATE_LIMITED, GATEWAY_AUTH_FAILED, GATEWAY_UPSTREAM_TIMEOUT, GATEWAY_UPSTREAM_UNAVAILABLE, GATEWAY_BAD_REQUEST.',
+  'apiGateway.requestResponseTransforms':
+    'Edge transforms applied before/after Backend handlers. ALWAYS inject `X-Request-Id` if absent; ALWAYS strip `Server` + `X-Powered-By` from responses.',
+  'apiGateway.corsPolicy':
+    'Default to {default:{allowedOrigins:[same-origin], allowedMethods:[GET,POST,PATCH,DELETE], allowedHeaders:[Content-Type,Authorization,X-Request-Id], exposedHeaders:[X-Request-Id, Sunset, Deprecation, Retry-After], allowCredentials:false, maxAgeSec:600}, perTenant:{<tenantId>:{allowedOrigins:[...]}}}. Reject `*` for allowedOrigins when allowCredentials is true.',
+  'apiGateway.webhookSecrets':
+    'Forward-reference to `@caia/secrets-adapter` for storage. HMAC-SHA256 over (timestamp.body), header `X-CAIA-Signature`, timestamp header `X-CAIA-Timestamp`, 300s tolerance, nonce-store replay protection, 90-day rotation.',
+  'apiGateway.apiQuotas':
+    'Per-tier monthly/daily quota enforcement keyed by subscription tier. Free tier always rejects on overage; pro/enterprise throttle then bill.'
+};
+
+export const API_GATEWAY_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'apiGateway.rateLimits',
+    description:
+      'Per-route + per-tenant rate limits enforced at the gateway edge. Extends (does not replace) Backend\'s `rateLimits` and Security\'s `rateLimitingRules` with gateway-layer specifics: window, max, burst, scope (tenant|ip|user|apiKey), on-limit response.',
+    required: true
+  },
+  {
+    path: 'apiGateway.authGates',
+    description:
+      'Per-route gateway-layer auth gate: which routes require auth, which auth type (public, Cloudflare Access, JWT bearer, service-token, mTLS, API-key), and whether the gate fires at the edge or at the origin. Cross-validates against Security\'s `authenticationStrategy.perEndpoint`.',
+    required: true
+  },
+  {
+    path: 'apiGateway.versioningStrategy',
+    description:
+      'API versioning posture: URL-prefix (`/v1/`, `/v2/`) by default, or header-versioning when the ticket is explicitly tagged. Includes sunset policy (advance-notice days, `Sunset` + `Deprecation` headers) for deprecated versions.',
+    required: true
+  },
+  {
+    path: 'apiGateway.errorEnvelope',
+    description:
+      'Gateway error envelope that EXTENDS Backend\'s `errorEnvelope` with gateway-specific fields: `requestId`, `gatewayCode`, `retryable`, optional `upstream` reference. Mapping table covers rate-limited, auth-failed, upstream-timeout, upstream-unavailable, bad-request.',
+    required: true
+  },
+  {
+    path: 'apiGateway.requestResponseTransforms',
+    description:
+      'Edge transforms applied before/after Backend handlers: request rewrites (path, headers, query canonicalization), response rewrites (header injection/stripping, body rewrite), and edge cache rules (path → scope/TTL/vary). Always inject X-Request-Id; always strip server-fingerprint headers.',
+    required: true
+  },
+  {
+    path: 'apiGateway.corsPolicy',
+    description:
+      'CORS policy: origin allowlist (per default + per-tenant override), allowed methods + headers, exposed headers, allow-credentials, max-age. Wildcard `*` for `allowedOrigins` is forbidden when `allowCredentials` is true.',
+    required: true
+  },
+  {
+    path: 'apiGateway.webhookSecrets',
+    description:
+      'Webhook signing posture: HMAC algorithm + header names + timestamp tolerance + replay protection + rotation policy. Forward-references `@caia/secrets-adapter` for storage.',
+    required: true
+  },
+  {
+    path: 'apiGateway.apiQuotas',
+    description:
+      'Per-tier subscription quota enforcement (monthly/daily request budgets per tier). Includes per-endpoint cost multipliers and quota-surfacing response headers (`X-Quota-Remaining`, `X-Quota-Reset`). Free tier rejects on overage; pro/enterprise throttle then bill.',
+    required: true
+  }
+];
+
+export const API_GATEWAY_OWNED_FIELD_KEYS: readonly string[] = API_GATEWAY_OWNED_SECTIONS.map(
+  s => s.path
+);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §2.11 — API Gateway runs on every ticket that exposes an API
+ * endpoint.
+ */
+export function apiGatewayArchitectAppliesPredicate(ticket: Ticket): boolean {
+  if (
+    ticket.type === 'Page' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List' ||
+    ticket.type === 'Foundation'
+  ) {
+    return true;
+  }
+  if (ticket.type === 'Widget') {
+    const tags = ticket.quality_tags ?? [];
+    return (
+      tags.includes('api') ||
+      tags.includes('backend') ||
+      tags.includes('persists') ||
+      tags.includes('webhook')
+    );
+  }
+  return false;
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+export const API_GATEWAY_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['backend', 'security'],
+  precedenceLevel: 8,
+  fanoutPolicy: 'always',
+  appliesPredicate: apiGatewayArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const ApiGatewayArchitectContract: ArchitectSectionContract = {
+  contractId: 'api-gateway-architect.v1',
+  architectName: 'apiGateway',
+  version: '0.1.0',
+  sections: API_GATEWAY_OWNED_SECTIONS,
+  architectMeta: API_GATEWAY_ARCHITECT_META
+};
+
+// ─── Reusable constants ─────────────────────────────────────────────────────
+
+export const REQUIRED_GATEWAY_CODES: readonly string[] = [
+  'GATEWAY_RATE_LIMITED',
+  'GATEWAY_AUTH_FAILED',
+  'GATEWAY_UPSTREAM_TIMEOUT',
+  'GATEWAY_UPSTREAM_UNAVAILABLE',
+  'GATEWAY_BAD_REQUEST'
+];
+
+export const ALLOWED_AUTH_TYPES: readonly string[] = [
+  'public',
+  'cloudflare-access',
+  'jwt-bearer',
+  'service-token',
+  'mtls',
+  'api-key'
+];
+
+export const ALLOWED_VERSIONING_KINDS: readonly string[] = [
+  'url-prefix',
+  'accept-header'
+];
+
+export const REQUIRED_QUOTA_TIERS: readonly string[] = ['free', 'pro', 'enterprise'];

--- a/packages/api-gateway-architect/src/index.ts
+++ b/packages/api-gateway-architect/src/index.ts
@@ -1,0 +1,82 @@
+/**
+ * @caia/api-gateway-architect — public surface.
+ *
+ * Architect #11 of CAIA's 17-architect EA fan-out. Senior API platform
+ * engineer focused on gateways, rate limiting, auth gates, versioning,
+ * and edge-layer enforcement. Sits in front of Backend's endpoints.
+ *
+ * Depends on Backend Architect + Security Architect upstream
+ * (wave-2). Precedence rank 8 per spec §5.2.
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { ApiGatewayArchitect } from './architect.js';
+
+export {
+  ApiGatewayArchitect,
+  API_GATEWAY_ARCHITECT_NAME,
+  API_GATEWAY_ARCHITECT_TOOLS
+} from './architect.js';
+export type { ApiGatewayArchitectConfig } from './architect.js';
+
+export {
+  ApiGatewayArchitectContract,
+  API_GATEWAY_OWNED_SECTIONS,
+  API_GATEWAY_OWNED_FIELD_KEYS,
+  API_GATEWAY_FIELD_FIX_HINTS,
+  API_GATEWAY_ARCHITECT_META,
+  REQUIRED_GATEWAY_CODES,
+  ALLOWED_AUTH_TYPES,
+  ALLOWED_VERSIONING_KINDS,
+  REQUIRED_QUOTA_TIERS,
+  apiGatewayArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildApiGatewaySystemPrompt } from './system-prompt.js';
+
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+export { runApiGatewayArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+export { API_GATEWAY_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+export function registerWith(registry: ArchitectRegistry): ApiGatewayArchitect {
+  const architect = new ApiGatewayArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/api-gateway-architect/src/invariants.ts
+++ b/packages/api-gateway-architect/src/invariants.ts
@@ -1,0 +1,278 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ */
+
+import {
+  ALLOWED_AUTH_TYPES,
+  ALLOWED_VERSIONING_KINDS,
+  REQUIRED_GATEWAY_CODES,
+  REQUIRED_QUOTA_TIERS
+} from './contract.js';
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  contributor: string;
+  reads: readonly string[];
+  severity: InvariantSeverity;
+  description: string;
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+function asObject(v: unknown): Readonly<Record<string, unknown>> | null {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return null;
+  return v as Readonly<Record<string, unknown>>;
+}
+
+function asArray(v: unknown): readonly unknown[] | null {
+  return Array.isArray(v) ? v : null;
+}
+
+export const API_GATEWAY_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'apiGateway.error-envelope-covers-required-codes',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.errorEnvelope'],
+    severity: 'fail',
+    description:
+      'errorEnvelope.mapping MUST surface every required gateway code (GATEWAY_RATE_LIMITED, GATEWAY_AUTH_FAILED, GATEWAY_UPSTREAM_TIMEOUT, GATEWAY_UPSTREAM_UNAVAILABLE, GATEWAY_BAD_REQUEST). Observability + frontend retry rely on these names.',
+    detect(arch): boolean {
+      const env = asObject(readField(arch, 'apiGateway.errorEnvelope'));
+      if (!env) return false;
+      const mapping = asObject(env.mapping);
+      if (!mapping) return false;
+      const seenCodes = new Set<string>();
+      for (const [, entry] of Object.entries(mapping)) {
+        const e = asObject(entry);
+        if (!e) continue;
+        if (typeof e.gatewayCode === 'string') seenCodes.add(e.gatewayCode as string);
+      }
+      return REQUIRED_GATEWAY_CODES.every(c => seenCodes.has(c));
+    }
+  },
+  {
+    id: 'apiGateway.cors-wildcard-credentials-forbidden',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.corsPolicy'],
+    severity: 'fail',
+    description:
+      'CORS policy with `allowedOrigins: ["*"]` AND `allowCredentials: true` is rejected by every modern browser; emitting it is a bug.',
+    detect(arch): boolean {
+      const cors = asObject(readField(arch, 'apiGateway.corsPolicy'));
+      if (!cors) return false;
+      const candidates: Readonly<Record<string, unknown>>[] = [];
+      const def = asObject(cors.default);
+      if (def) candidates.push(def);
+      const perTenant = asObject(cors.perTenant);
+      if (perTenant) {
+        for (const [, v] of Object.entries(perTenant)) {
+          const inner = asObject(v);
+          if (inner) candidates.push(inner);
+        }
+      }
+      for (const c of candidates) {
+        const origins = asArray(c.allowedOrigins);
+        if (!origins) continue;
+        const hasWildcard = origins.some(o => o === '*');
+        if (hasWildcard && c.allowCredentials === true) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'apiGateway.versioning-kind-allowed',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.versioningStrategy'],
+    severity: 'fail',
+    description: `versioningStrategy.kind MUST be one of ${ALLOWED_VERSIONING_KINDS.join(' | ')}.`,
+    detect(arch): boolean {
+      const vs = asObject(readField(arch, 'apiGateway.versioningStrategy'));
+      if (!vs) return false;
+      return typeof vs.kind === 'string' && ALLOWED_VERSIONING_KINDS.includes(vs.kind as string);
+    }
+  },
+  {
+    id: 'apiGateway.versioning-sunset-window',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.versioningStrategy'],
+    severity: 'fail',
+    description:
+      'versioningStrategy.sunsetPolicy.advanceNoticeDays MUST be >= 180 days (locked operator policy).',
+    detect(arch): boolean {
+      const vs = asObject(readField(arch, 'apiGateway.versioningStrategy'));
+      if (!vs) return false;
+      const sp = asObject(vs.sunsetPolicy);
+      if (!sp) return false;
+      return typeof sp.advanceNoticeDays === 'number' && (sp.advanceNoticeDays as number) >= 180;
+    }
+  },
+  {
+    id: 'apiGateway.transforms-inject-request-id',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.requestResponseTransforms'],
+    severity: 'fail',
+    description:
+      'requestResponseTransforms.request MUST contain an inject-header op for X-Request-Id (case-insensitive).',
+    detect(arch): boolean {
+      const t = asObject(readField(arch, 'apiGateway.requestResponseTransforms'));
+      if (!t) return false;
+      const reqOps = asArray(t.request);
+      if (!reqOps) return false;
+      for (const raw of reqOps) {
+        const op = asObject(raw);
+        if (!op) continue;
+        if (op.op === 'inject-header' && typeof op.header === 'string') {
+          if ((op.header as string).toLowerCase() === 'x-request-id') return true;
+        }
+      }
+      return false;
+    }
+  },
+  {
+    id: 'apiGateway.transforms-strip-server-fingerprint',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.requestResponseTransforms'],
+    severity: 'fail',
+    description:
+      'requestResponseTransforms.response MUST strip both `Server` and `X-Powered-By` response headers.',
+    detect(arch): boolean {
+      const t = asObject(readField(arch, 'apiGateway.requestResponseTransforms'));
+      if (!t) return false;
+      const respOps = asArray(t.response);
+      if (!respOps) return false;
+      const stripped = new Set<string>();
+      for (const raw of respOps) {
+        const op = asObject(raw);
+        if (!op) continue;
+        if (op.op === 'strip-header' && typeof op.header === 'string') {
+          stripped.add((op.header as string).toLowerCase());
+        }
+      }
+      return stripped.has('server') && stripped.has('x-powered-by');
+    }
+  },
+  {
+    id: 'apiGateway.quotas-cover-required-tiers',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.apiQuotas'],
+    severity: 'fail',
+    description: `apiQuotas.perTier MUST include every required tier: ${REQUIRED_QUOTA_TIERS.join(', ')}.`,
+    detect(arch): boolean {
+      const q = asObject(readField(arch, 'apiGateway.apiQuotas'));
+      if (!q) return false;
+      const perTier = asObject(q.perTier);
+      if (!perTier) return false;
+      return REQUIRED_QUOTA_TIERS.every(t => t in perTier);
+    }
+  },
+  {
+    id: 'apiGateway.free-tier-rejects-overage',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.apiQuotas'],
+    severity: 'fail',
+    description:
+      'Free tier MUST reject on quota overage (otherwise the free tier is an unbounded cost surface).',
+    detect(arch): boolean {
+      const q = asObject(readField(arch, 'apiGateway.apiQuotas'));
+      if (!q) return false;
+      const perTier = asObject(q.perTier);
+      if (!perTier) return false;
+      const free = asObject(perTier.free);
+      if (!free) return false;
+      return free.overage === 'reject';
+    }
+  },
+  {
+    id: 'apiGateway.auth-gates-types-allowed',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.authGates'],
+    severity: 'fail',
+    description: `Every authGates entry MUST use a recognised authType: ${ALLOWED_AUTH_TYPES.join(' | ')}.`,
+    detect(arch): boolean {
+      const gates = readField(arch, 'apiGateway.authGates');
+      if (Array.isArray(gates)) {
+        for (const raw of gates) {
+          const g = asObject(raw);
+          if (!g) return false;
+          if (!ALLOWED_AUTH_TYPES.includes(g.authType as string)) return false;
+        }
+        return gates.length > 0;
+      }
+      const gateObj = asObject(gates);
+      if (!gateObj) return false;
+      const entries = Object.entries(gateObj);
+      if (entries.length === 0) return false;
+      for (const [, raw] of entries) {
+        const g = asObject(raw);
+        if (!g) return false;
+        if (!ALLOWED_AUTH_TYPES.includes(g.authType as string)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'apiGateway.webhook-signing-strong-algorithm',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.webhookSecrets'],
+    severity: 'fail',
+    description:
+      'Webhook signing MUST use HMAC-SHA256 (or stronger). Weaker algorithms (MD5, SHA1) are rejected.',
+    detect(arch): boolean {
+      const w = asObject(readField(arch, 'apiGateway.webhookSecrets'));
+      if (!w) return false;
+      const signing = asObject(w.signing);
+      if (!signing) return false;
+      const alg = typeof signing.algorithm === 'string' ? (signing.algorithm as string).toUpperCase() : '';
+      if (alg === 'HMAC-SHA256' || alg === 'HMAC-SHA384' || alg === 'HMAC-SHA512') return true;
+      return false;
+    }
+  },
+  {
+    id: 'apiGateway.webhook-timestamp-tolerance-bounded',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.webhookSecrets'],
+    severity: 'fail',
+    description:
+      'Webhook signing timestampToleranceSec MUST be > 0 and <= 300 (replay-attack window).',
+    detect(arch): boolean {
+      const w = asObject(readField(arch, 'apiGateway.webhookSecrets'));
+      if (!w) return false;
+      const signing = asObject(w.signing);
+      if (!signing) return false;
+      const t = signing.timestampToleranceSec;
+      return typeof t === 'number' && (t as number) > 0 && (t as number) <= 300;
+    }
+  },
+  {
+    id: 'apiGateway.rate-limits-perRoute-present',
+    contributor: 'apiGateway',
+    reads: ['apiGateway.rateLimits'],
+    severity: 'fail',
+    description:
+      'rateLimits MUST declare a perRoute map (even if empty) AND either a perTenant map or defaults block.',
+    detect(arch): boolean {
+      const rl = asObject(readField(arch, 'apiGateway.rateLimits'));
+      if (!rl) return false;
+      const perRoute = asObject(rl.perRoute);
+      if (!perRoute) return false;
+      const perTenant = asObject(rl.perTenant);
+      const defaults = asObject(rl.defaults);
+      return perTenant !== null || defaults !== null;
+    }
+  }
+];

--- a/packages/api-gateway-architect/src/invariants.ts
+++ b/packages/api-gateway-architect/src/invariants.ts
@@ -23,13 +23,19 @@ export interface ArchitectInvariant {
   detect(architecture: Readonly<Record<string, unknown>>): boolean;
 }
 
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
   if (path in arch) return arch[path];
   const parts = path.split('.');
   let cursor: unknown = arch;
   for (const part of parts) {
     if (typeof cursor !== 'object' || cursor === null) return undefined;
-    cursor = (cursor as Record<string, unknown>)[part];
+    // Defence in depth: refuse to traverse into prototype-chain keys.
+    if (UNSAFE_KEYS.has(part)) return undefined;
+    cursor = Object.prototype.hasOwnProperty.call(cursor, part)
+      ? (cursor as Record<string, unknown>)[part]
+      : undefined;
   }
   return cursor;
 }

--- a/packages/api-gateway-architect/src/run.ts
+++ b/packages/api-gateway-architect/src/run.ts
@@ -1,0 +1,127 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Re-runs REPLACE owned fields (no append).
+ *
+ * Architect-specific projections vs the canonical template:
+ *   - API Gateway is wave-2; both Backend and Security run upstream.
+ *   - `dependencies` always includes ['backend', 'security'] regardless
+ *     of what the model emitted (preserving sibling-ticket IDs).
+ *   - The user prompt projection drops vault namespace / schema name
+ *     (the gateway doesn't need them — only the tenantId for attribution
+ *     + billingPosture for the apiQuotas tier resolution).
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { API_GATEWAY_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+export async function runApiGatewayArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: ['backend', 'security'],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, API_GATEWAY_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: ['backend', 'security'],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  const parsed = validation.parsed;
+  const upstreamDeps = ensureUpstreamDependencies(parsed.dependencies);
+  return {
+    ...parsed,
+    architectName: deps.architectName,
+    dependencies: upstreamDeps,
+    spend
+  };
+}
+
+/**
+ * Ensure `backend` and `security` are present in the dependency list
+ * (preserving any sibling-ticket IDs the model emitted). Idempotent.
+ */
+function ensureUpstreamDependencies(
+  emitted: readonly string[] | undefined
+): readonly string[] {
+  const set = new Set(emitted ?? []);
+  set.add('backend');
+  set.add('security');
+  return Array.from(set);
+}

--- a/packages/api-gateway-architect/src/spawner.ts
+++ b/packages/api-gateway-architect/src/spawner.ts
@@ -1,0 +1,114 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+export interface ArchitectSpawnOutput {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  model: string;
+  ok: boolean;
+  diagnostic: string | null;
+}
+
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/api-gateway-architect/src/system-prompt.md
+++ b/packages/api-gateway-architect/src/system-prompt.md
@@ -1,0 +1,50 @@
+# API Gateway Architect — System Prompt (human-readable mirror)
+
+This is the human-readable mirror of `./system-prompt.ts`'s output. The
+TypeScript builder is the single source of truth at runtime; this
+markdown is for editing-with-eyes-on convenience. Keep them in lockstep.
+
+## Role
+
+You are CAIA's API Gateway Architect. You are a senior API platform
+engineer focused on gateways, rate limiting, auth gates, versioning, and
+edge-layer enforcement.
+
+You produce per-ticket API-gateway specs that sit IN FRONT OF Backend's
+endpoints. You DO NOT write backend logic itself or auth implementation.
+
+You read Backend's `apiEndpoints` + `authRequirements` + `rateLimits` +
+`errorEnvelope` and Security's `authenticationStrategy` +
+`authorizationRules` + `rateLimitingRules` as upstream input, then
+cross-validate and emit the binding gateway contract.
+
+Precedence rank **8** in the EA Dispatcher.
+
+## Locked stack
+
+- **Edge platform**: Cloudflare (Workers + Pages Functions + WAF).
+- **Rate limiting**: sliding-window with optional burst; default
+  on-limit HTTP 429 + `Retry-After`.
+- **Auth gates**: Cloudflare Access (tenant-scoped default), JWT bearer,
+  service-token, mTLS, API-key, public.
+- **Versioning**: URL-prefix default; sunset advance notice ≥ 180 days.
+- **Error envelope**: EXTENDS Backend's; adds `requestId`, `gatewayCode`,
+  `retryable`, optional `upstream`.
+- **Edge transforms**: always inject `X-Request-Id`; always strip
+  `Server` + `X-Powered-By`.
+- **CORS**: same-origin default; wildcard `*` forbidden with credentials.
+- **Webhook signing**: HMAC-SHA256, 300s timestamp tolerance, nonce-store
+  replay protection, 90-day rotation.
+- **API quotas**: `free` (overage:reject), `pro` and `enterprise`
+  (throttle-then-bill).
+
+## Owned fields
+
+1. `apiGateway.rateLimits`
+2. `apiGateway.authGates`
+3. `apiGateway.versioningStrategy`
+4. `apiGateway.errorEnvelope`
+5. `apiGateway.requestResponseTransforms`
+6. `apiGateway.corsPolicy`
+7. `apiGateway.webhookSecrets`
+8. `apiGateway.apiQuotas`

--- a/packages/api-gateway-architect/src/system-prompt.ts
+++ b/packages/api-gateway-architect/src/system-prompt.ts
@@ -1,0 +1,277 @@
+/**
+ * The API Gateway Architect's system prompt — a pure function returning
+ * a static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked stack
+ *   3. Input format
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples
+ *
+ * Mirrors `@caia/frontend-architect`'s `system-prompt.ts` shape per the
+ * canonical template. A human-readable mirror lives in
+ * `./system-prompt.md` — keep them in lockstep when editing.
+ */
+
+import {
+  ALLOWED_AUTH_TYPES,
+  ALLOWED_VERSIONING_KINDS,
+  API_GATEWAY_OWNED_FIELD_KEYS,
+  REQUIRED_GATEWAY_CODES,
+  REQUIRED_QUOTA_TIERS
+} from './contract.js';
+
+export function buildApiGatewaySystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    sectionOutputSchema(),
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    sectionSelfCheck(),
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's API Gateway Architect. You are a senior API platform
+engineer focused on gateways, rate limiting, auth gates, versioning, and
+edge-layer enforcement.
+
+You produce per-ticket API-gateway specs that sit IN FRONT OF Backend's
+endpoints. You DO NOT write backend logic itself (Backend Architect owns
+that) or auth implementation (Security Architect owns that). You DO
+specify what the gateway layer enforces: which routes need which auth
+gate, what the per-route + per-tenant rate limits are, how the gateway
+versions endpoints, how the gateway extends Backend's error envelope,
+which request/response transforms apply at the edge, the CORS policy,
+the webhook-signing protocol, and the per-tier subscription quotas.
+
+You read Backend's \`apiEndpoints\` + \`authRequirements\` + \`rateLimits\` +
+\`errorEnvelope\` and Security's \`authenticationStrategy\` +
+\`authorizationRules\` + \`rateLimitingRules\` as upstream input, then
+cross-validate and emit the binding gateway contract.
+
+You hold precedence rank **8** in the EA Dispatcher. Flag every
+deviation from a locked default in \`risks[]\` so the Reviewer can audit.
+
+Output tight architecture that an edge-layer worker can implement
+directly.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Edge platform**: Cloudflare (Workers + Pages Functions + WAF) for
+  the gateway tier. Origin is Next.js 15 App Router Route Handlers.
+- **Rate limiting**: sliding-window with optional burst; enforced at
+  the edge via Cloudflare Rate Limiting Rules. Per-route scopes:
+  \`tenant\` | \`ip\` | \`user\` | \`apiKey\`. Default on-limit:
+  HTTP 429 + \`Retry-After: <seconds>\` header.
+- **Auth gates**: Cloudflare Access (default for tenant-scoped routes),
+  JWT bearer (end-user sessions), service-token (orchestrator-internal),
+  mTLS (partner B2B), API-key (developer programs), public (marketing).
+  Gate-at-edge by default; gate-at-origin only when the auth decision
+  requires DB state.
+- **Versioning**: URL-prefix (\`/v1/\`, \`/v2/\`) by default.
+  Header-versioning only on explicit operator opt-in. Sunset policy:
+  180 days advance notice via \`Sunset\` + \`Deprecation\` response
+  headers.
+- **Error envelope**: EXTENDS Backend's. Adds \`requestId\` (always
+  injected at the edge), \`gatewayCode\` (stable enum), \`retryable\`
+  (boolean), optional \`upstream\` reference.
+- **Edge transforms**: ALWAYS inject \`X-Request-Id\` if absent.
+  ALWAYS strip \`Server\` + \`X-Powered-By\` response headers.
+- **CORS**: default same-origin; wildcard \`*\` FORBIDDEN with
+  credentials.
+- **Webhook signing**: HMAC-SHA256 over (\`timestamp.body\`); 300s
+  timestamp tolerance; nonce-store replay protection with 600s TTL;
+  90-day rotation.
+- **API quotas**: per-tier monthly + daily request budgets. Tiers:
+  \`free\` (rejects on overage), \`pro\` (throttle-then-bill),
+  \`enterprise\` (throttle-then-bill at higher caps). Quota surfacing:
+  \`X-Quota-Remaining\` + \`X-Quota-Reset\` on every authenticated
+  response.
+
+Reject any decision that violates a locked default. List violations in
+\`risks[]\`, set \`confidence\` ≤ 0.5, and pick the locked default
+anyway.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List|Foundation",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptance_criteria": ["..."] },
+  "businessPlan": { "ventureName": "...", "oneLiner": "...",
+                    "audience": "...", "goals": ["..."] },
+  "designVersion": { "versionId": "...", "anchors": [...] },
+  "tenantContext": { "tenantId": "...", "billingPosture": "subscription|byok" },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {
+    "backend": {
+      "architectureFields": {
+        "backend.apiEndpoints": [ ... ],
+        "backend.authRequirements": { ... },
+        "backend.rateLimits": { ... },
+        "backend.errorEnvelope": { ... }
+      }
+    },
+    "security": {
+      "architectureFields": {
+        "security.authenticationStrategy": { ... },
+        "security.authorizationRules": { ... },
+        "security.rateLimitingRules": { ... }
+      }
+    }
+  } }
+}
+\`\`\`
+
+You MUST read \`upstream.outputs.backend.architectureFields\` to
+enumerate routes AND \`upstream.outputs.security.architectureFields\` to
+cross-validate auth + rate-limit posture. If either is absent, set
+\`confidence\` ≤ 0.5 and list the missing upstream(s) under \`risks[]\`.`;
+
+function sectionOutputSchema(): string {
+  return `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No
+prose outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "apiGateway",
+  "architectureFields": {
+${API_GATEWAY_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`apiGateway.rateLimits\` — \`{perRoute:{<METHOD /path>:{windowMs,max,burst?,scope,onLimit}}, perTenant:{<tier>:{windowMs,max,onLimit}}, defaults:{public,authenticated,service}}\`. Scope ∈ \`tenant\`|\`ip\`|\`user\`|\`apiKey\`. Marketing-public routes always IP-scoped + capped. Cross-validate against Security's \`rateLimitingRules\`.
+- \`apiGateway.authGates\` — For EVERY route in Backend's \`apiEndpoints\`, one entry: \`{authType:${ALLOWED_AUTH_TYPES.join('|')}, gateAt:edge|origin, required:true|false}\`. \`required:false\` only for marketing-public.
+- \`apiGateway.versioningStrategy\` — \`{kind:${ALLOWED_VERSIONING_KINDS.join('|')}, prefix?:/v1, acceptHeader?:application/vnd.caia.v1+json, currentVersion:v1, deprecatedVersions:[], sunsetPolicy:{advanceNoticeDays:180, headerName:Sunset, deprecationHeaderName:Deprecation}}\`.
+- \`apiGateway.errorEnvelope\` — \`{extends:backend.errorEnvelope, addedFields:{requestId, gatewayCode, retryable, upstream?}, mapping:{<gatewayCondition>:{httpStatus, gatewayCode, retryable}}}\`. REQUIRED \`gatewayCode\` values (verbatim):
+${REQUIRED_GATEWAY_CODES.map(c => `  - \`${c}\``).join('\n')}
+- \`apiGateway.requestResponseTransforms\` — \`{request:[{op:rewrite-path|inject-header|strip-header|canonicalize-query, ...}], response:[{op:inject-header|strip-header|rewrite-body, ...}], cacheRules:[{path, scope:tenant|public, ttlSec, vary:[...]}]}\`. Always include the X-Request-Id injection on \`request\` and the Server / X-Powered-By stripping on \`response\`.
+- \`apiGateway.corsPolicy\` — \`{default:{allowedOrigins:[...], allowedMethods:[...], allowedHeaders:[...], exposedHeaders:[...], allowCredentials:false, maxAgeSec:600}, perTenant:{<tenantId>:{...overrides}}}\`. Reject \`*\` allowedOrigins when allowCredentials=true.
+- \`apiGateway.webhookSecrets\` — \`{provider:vault, namespace:tenant/{{tenantId}}/webhooks, signing:{algorithm:HMAC-SHA256, headerName:X-CAIA-Signature, timestampHeaderName:X-CAIA-Timestamp, timestampToleranceSec:300}, replayProtection:{kind:nonce-store, ttlSec:600}, rotation:{kind:scheduled, intervalDays:90}, perWebhook?:{<id>:{...}}}\`. Never echo secret values.
+- \`apiGateway.apiQuotas\` — \`{perTier:{${REQUIRED_QUOTA_TIERS.join(',')}:{monthlyRequests, dailyRequests, overage:reject|throttle|bill}}, perEndpoint?:{<route>:{costMultiplier}}, surfacing:{headerName:X-Quota-Remaining, resetHeaderName:X-Quota-Reset}}\`. \`free\` MUST be \`overage:reject\`; \`pro\` and \`enterprise\` MUST be \`overage:throttle\` or \`overage:bill\`.`;
+}
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **One Backend route = one authGate entry + one rateLimits entry.**
+  Missing entries are silent vulnerabilities — flag them in \`risks[]\`.
+- **Cross-validate with Security.** On conflict, pick Security's
+  choice (rank 1) and log under \`risks[]\`.
+- **Edge over origin.** Default \`gateAt: "edge"\`. Use \`gateAt:
+  "origin"\` only when the auth decision requires DB lookup.
+- **URL versioning by default.** Header-versioning is an explicit
+  operator opt-in via a \`header-versioning\` ticket tag.
+- **Extend the envelope, never replace.** Backend's inner shape MUST be
+  preserved verbatim.
+- **Inject X-Request-Id at the edge.** Every request gets a request-id
+  (UUID v7) if the client didn't supply one.
+- **Strip server-fingerprint headers.** \`Server\`, \`X-Powered-By\`,
+  and any framework-leak header is stripped on response.
+- **Free tier rejects on quota overage.** Otherwise the free tier is
+  an unbounded cost surface.
+- **CORS \`*\` with credentials is forbidden.** Refuse.
+- **Webhook timestamps required.** 300-second tolerance window;
+  nonce store with 600s TTL.
+- **Marketing routes are IP-scoped + capped.** Always.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Skip auth on a non-marketing route** → refuse, default to
+  Cloudflare Access at the edge, list under \`risks[]\`, set
+  \`confidence\` ≤ 0.5.
+- **Use a CORS wildcard \`*\` with allowCredentials=true** → never.
+- **Allow free-tier quota overage** → never.
+- **Disable rate limiting on a public endpoint** → never.
+- **Replace Backend's errorEnvelope (rather than extend it)** → never.
+- **Skip the X-Request-Id injection** → never.
+- **Drop a required gatewayCode mapping** → never.
+- **Use a webhook signing algorithm weaker than HMAC-SHA256** → never.
+- **Issue a versioning sunset with less than 180 days notice** →
+  refuse; list under \`risks[]\`.
+- **Skip a required quota tier (free, pro, enterprise)** → never.
+- **Decide UI components, database schemas, backend handler code, CI
+  pipelines, or any field NOT under \`apiGateway.*\`** → ignore.
+- **Skip an owned field** → never.`;
+
+function sectionSelfCheck(): string {
+  return `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the ${API_GATEWAY_OWNED_FIELD_KEYS.length}
+   owned field paths (no extras, no missing).
+2. Every route in Backend's \`apiEndpoints\` has a matching entry in
+   \`apiGateway.authGates\` AND \`apiGateway.rateLimits.perRoute\`.
+3. Every \`authGates\` entry's \`authType\` matches what Security
+   declared (or the mismatch is logged in \`risks[]\`).
+4. \`errorEnvelope.mapping\` covers EVERY required gateway code:
+   ${REQUIRED_GATEWAY_CODES.join(', ')}.
+5. \`requestResponseTransforms.request\` contains an inject-header op
+   for \`X-Request-Id\`. \`requestResponseTransforms.response\`
+   contains strip-header ops for \`Server\` and \`X-Powered-By\`.
+6. \`corsPolicy.default\` is the locked default; any
+   \`allowedOrigins: ["*"]\` MUST have \`allowCredentials: false\`.
+7. \`webhookSecrets.signing.algorithm\` is \`HMAC-SHA256\`;
+   \`timestampToleranceSec\` ≤ 300; \`replayProtection\` enabled.
+8. \`apiQuotas.perTier\` includes every required tier
+   (${REQUIRED_QUOTA_TIERS.join(', ')}); \`free.overage\` is \`reject\`.
+9. \`versioningStrategy.kind\` is one of
+   ${ALLOWED_VERSIONING_KINDS.join(' | ')};
+   \`sunsetPolicy.advanceNoticeDays\` ≥ 180.
+10. \`confidence\` reflects how comfortable you are — sub-0.6 triggers
+    the EA Reviewer to scrutinize.
+11. \`notes\` is ≤ 800 characters.
+12. Output is a single JSON object. No prose. No code fences.`;
+}
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a Form Story ticket for "contact-form submission"
+exposing \`POST /v1/contacts\` produces an \`authGates\` entry of
+\`{authType:"public", gateAt:"edge", required:false}\`; a
+\`rateLimits.perRoute\` entry of
+\`{windowMs:60000, max:10, scope:"ip", onLimit:{status:429, retryAfterSec:60}}\`;
+a \`versioningStrategy\` of
+\`{kind:"url-prefix", prefix:"/v1", currentVersion:"v1", deprecatedVersions:[], sunsetPolicy:{advanceNoticeDays:180, headerName:"Sunset", deprecationHeaderName:"Deprecation"}}\`;
+an \`errorEnvelope\` extending Backend's with the five required
+gatewayCodes; \`requestResponseTransforms\` that injects X-Request-Id
+on requests and strips Server + X-Powered-By on responses;
+\`corsPolicy.default\` with same-origin allowedOrigins +
+\`allowCredentials:false\`; \`webhookSecrets\` using HMAC-SHA256 with
+300s tolerance + nonce-store replay protection + 90-day rotation; and
+\`apiQuotas\` with all three tiers (\`free\` rejecting, \`pro\` and
+\`enterprise\` throttle/bill).`;

--- a/packages/api-gateway-architect/src/types.ts
+++ b/packages/api-gateway-architect/src/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * Mirrors the canonical `@caia/frontend-architect` template verbatim —
+ * only the architect-specific field-spec lives in `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/api-gateway-architect/src/validation.ts
+++ b/packages/api-gateway-architect/src/validation.ts
@@ -1,0 +1,189 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Pure + synchronous. Failures return a structured `ValidationResult`.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/api-gateway-architect/tests/architect.test.ts
+++ b/packages/api-gateway-architect/tests/architect.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `ApiGatewayArchitect` — interface compliance tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  ApiGatewayArchitect,
+  API_GATEWAY_ARCHITECT_NAME,
+  API_GATEWAY_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { ApiGatewayArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('ApiGatewayArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new ApiGatewayArchitect();
+    expect(a).toBeInstanceOf(ApiGatewayArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new ApiGatewayArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the precedence-ladder slot', () => {
+    const a = new ApiGatewayArchitect();
+    expect(a.name).toBe('apiGateway');
+    expect(a.name).toBe(API_GATEWAY_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new ApiGatewayArchitect();
+    expect(a.sectionContract).toBe(ApiGatewayArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new ApiGatewayArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1', () => {
+    const a = new ApiGatewayArchitect();
+    expect(a.tools).toBe(API_GATEWAY_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new ApiGatewayArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new ApiGatewayArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new ApiGatewayArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new ApiGatewayArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('apiGateway');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new ApiGatewayArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    const a = new ApiGatewayArchitect();
+    expect(a).toBeInstanceOf(ApiGatewayArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/api-gateway-architect/tests/contract.test.ts
+++ b/packages/api-gateway-architect/tests/contract.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Section contract structural + registration tests.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { ApiGatewayArchitect } from '../src/architect.js';
+import {
+  API_GATEWAY_ARCHITECT_META,
+  API_GATEWAY_OWNED_SECTIONS,
+  API_GATEWAY_OWNED_FIELD_KEYS,
+  ApiGatewayArchitectContract,
+  apiGatewayArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('ApiGatewayArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(ApiGatewayArchitectContract.contractId).toBe('api-gateway-architect.v1');
+  });
+
+  it('architectName is `apiGateway` (matches precedence ladder slot)', () => {
+    expect(ApiGatewayArchitectContract.architectName).toBe('apiGateway');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(ApiGatewayArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `apiGateway.`', () => {
+    for (const key of API_GATEWAY_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('apiGateway.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the task-brief mandatory fields', () => {
+    const required = [
+      'apiGateway.rateLimits',
+      'apiGateway.authGates',
+      'apiGateway.versioningStrategy',
+      'apiGateway.errorEnvelope',
+      'apiGateway.requestResponseTransforms',
+      'apiGateway.corsPolicy',
+      'apiGateway.webhookSecrets',
+      'apiGateway.apiQuotas'
+    ];
+    for (const r of required) {
+      expect(API_GATEWAY_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('exposes exactly 8 owned fields per the task brief', () => {
+    expect(API_GATEWAY_OWNED_FIELD_KEYS.length).toBe(8);
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of API_GATEWAY_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(ApiGatewayArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(ApiGatewayArchitectContract).sort()).toEqual(
+      [...API_GATEWAY_OWNED_FIELD_KEYS].sort()
+    );
+  });
+});
+
+describe('ApiGatewayArchitectContract — architectMeta', () => {
+  it('declares Backend + Security as upstream dependencies', () => {
+    expect(API_GATEWAY_ARCHITECT_META.dependsOn).toEqual(['backend', 'security']);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(API_GATEWAY_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(API_GATEWAY_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 8 per spec §2.11', () => {
+    expect(API_GATEWAY_ARCHITECT_META.precedenceLevel).toBe(8);
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(API_GATEWAY_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per spec §2.11', () => {
+    expect(API_GATEWAY_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(API_GATEWAY_ARCHITECT_META.appliesPredicate).toBe(apiGatewayArchitectAppliesPredicate);
+  });
+
+  it('matches the canonical precedence ladder for `apiGateway`', () => {
+    expect(precedenceRank('apiGateway')).toBe(API_GATEWAY_ARCHITECT_META.precedenceLevel);
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('apiGateway');
+  });
+});
+
+describe('apiGatewayArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Page' };
+
+  it('returns true for Page', () => {
+    expect(apiGatewayArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })).toBe(true);
+  });
+
+  it('returns true for Story', () => {
+    expect(apiGatewayArchitectAppliesPredicate({ ...baseTicket, type: 'Story' })).toBe(true);
+  });
+
+  it('returns true for Form', () => {
+    expect(apiGatewayArchitectAppliesPredicate({ ...baseTicket, type: 'Form' })).toBe(true);
+  });
+
+  it('returns true for List', () => {
+    expect(apiGatewayArchitectAppliesPredicate({ ...baseTicket, type: 'List' })).toBe(true);
+  });
+
+  it('returns true for Foundation', () => {
+    expect(apiGatewayArchitectAppliesPredicate({ ...baseTicket, type: 'Foundation' })).toBe(true);
+  });
+
+  it('returns false for Widget without API tags', () => {
+    expect(apiGatewayArchitectAppliesPredicate({ ...baseTicket, type: 'Widget' })).toBe(false);
+  });
+
+  it('returns true for Widget tagged with `api`', () => {
+    expect(
+      apiGatewayArchitectAppliesPredicate({ ...baseTicket, type: 'Widget', quality_tags: ['api'] })
+    ).toBe(true);
+  });
+
+  it('returns true for Widget tagged with `webhook`', () => {
+    expect(
+      apiGatewayArchitectAppliesPredicate({ ...baseTicket, type: 'Widget', quality_tags: ['webhook'] })
+    ).toBe(true);
+  });
+
+  it('returns false for an unrecognised type', () => {
+    expect(apiGatewayArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })).toBe(false);
+  });
+});
+
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the API Gateway architect cleanly', () => {
+    expect(() => {
+      registry.register(new ApiGatewayArchitect());
+    }).not.toThrow();
+    expect(registry.get('apiGateway')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new ApiGatewayArchitect());
+    for (const k of API_GATEWAY_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('apiGateway');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new ApiGatewayArchitect());
+    expect(() => registry.register(new ApiGatewayArchitect())).toThrowError(ArchitectRegistryError);
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new ApiGatewayArchitect());
+    const colliding: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        { path: 'apiGateway.rateLimits', description: 'colliding owner', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 15,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', colliding));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new ApiGatewayArchitect());
+    const disjoint: ArchitectSectionContract = {
+      contractId: 'frontend-architect.v1',
+      architectName: 'frontend',
+      version: '0.1.0',
+      sections: [{ path: 'frontend.componentTree', description: 'tree', required: true }],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 14,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('frontend', disjoint));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(API_GATEWAY_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it('disjointness() detects no conflicts when only API Gateway is present', () => {
+    const conflicts = disjointness([ApiGatewayArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between API Gateway and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...ApiGatewayArchitectContract,
+      contractId: 'api-gateway-clone.v1',
+      architectName: 'apiGateway-clone'
+    };
+    const conflicts = disjointness([ApiGatewayArchitectContract, clone]);
+    expect(conflicts.length).toBe(API_GATEWAY_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() is empty after a clean registration (with upstream stubs)', () => {
+    // API Gateway depends on backend + security; the registry's validate()
+    // complains about missing upstream deps. Register stub upstreams so
+    // the registry is internally consistent.
+    const stubMeta = {
+      dependsOn: [],
+      precedenceLevel: 12,
+      fanoutPolicy: 'always' as const,
+      appliesPredicate: () => true,
+      runtimeModel: 'sonnet' as const
+    };
+    registry.register(
+      new StubArchitect('backend', {
+        contractId: 'backend-architect.v1',
+        architectName: 'backend',
+        version: '0.1.0',
+        sections: [{ path: 'backend.framework', description: 'fw', required: true }],
+        architectMeta: stubMeta
+      })
+    );
+    registry.register(
+      new StubArchitect('security', {
+        contractId: 'security-architect.v1',
+        architectName: 'security',
+        version: '0.1.0',
+        sections: [{ path: 'security.authenticationStrategy', description: 'auth', required: true }],
+        architectMeta: { ...stubMeta, precedenceLevel: 1 }
+      })
+    );
+    registry.register(new ApiGatewayArchitect());
+    expect(registry.validate()).toEqual([]);
+  });
+
+  it('registry.validate() flags missing upstream backend + security when API Gateway is registered alone', () => {
+    registry.register(new ApiGatewayArchitect());
+    const errors = registry.validate();
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+    const joined = errors.join('|');
+    expect(joined).toContain('backend');
+    expect(joined).toContain('security');
+  });
+});

--- a/packages/api-gateway-architect/tests/golden/golden.test.ts
+++ b/packages/api-gateway-architect/tests/golden/golden.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Golden test — the canonical known-good API-Gateway-architect artifact
+ * for a known prakash-tiwari Form Story ticket (POST /v1/contacts).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { ApiGatewayArchitect } from '../../src/architect.js';
+import { API_GATEWAY_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { API_GATEWAY_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari contact-form Form Story ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8'));
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-upstream.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-upstream.json'), 'utf-8'));
+    const fixture = buildFakeInput().upstream;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new ApiGatewayArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    expect(out.architectName).toBe('apiGateway');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    for (const k of API_GATEWAY_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.risks).toEqual(expected.risks);
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('security');
+  });
+
+  it('output passes every API Gateway invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new ApiGatewayArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of API_GATEWAY_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new ApiGatewayArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+
+  it('every Backend route has a matching authGates entry', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new ApiGatewayArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    const backendEndpoints = buildFakeInput().upstream.outputs.backend.architectureFields[
+      'backend.apiEndpoints'
+    ] as Array<{ method: string; path: string }>;
+    const authGates = out.architectureFields['apiGateway.authGates'] as Record<string, unknown>;
+    for (const ep of backendEndpoints) {
+      const key = `${ep.method} ${ep.path}`;
+      expect(authGates).toHaveProperty(key);
+    }
+  });
+
+  it('every Backend route has a matching rateLimits.perRoute entry', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new ApiGatewayArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    const backendEndpoints = buildFakeInput().upstream.outputs.backend.architectureFields[
+      'backend.apiEndpoints'
+    ] as Array<{ method: string; path: string }>;
+    const perRoute = (out.architectureFields['apiGateway.rateLimits'] as {
+      perRoute: Record<string, unknown>;
+    }).perRoute;
+    for (const ep of backendEndpoints) {
+      const key = `${ep.method} ${ep.path}`;
+      expect(perRoute).toHaveProperty(key);
+    }
+  });
+
+  it('errorEnvelope extends (does not replace) Backend\'s errorEnvelope', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new ApiGatewayArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+    const env = out.architectureFields['apiGateway.errorEnvelope'] as {
+      extends: string;
+      addedFields: Record<string, unknown>;
+    };
+    expect(env.extends).toBe('backend.errorEnvelope');
+    expect(env.addedFields).toHaveProperty('requestId');
+    expect(env.addedFields).toHaveProperty('gatewayCode');
+    expect(env.addedFields).toHaveProperty('retryable');
+  });
+});

--- a/packages/api-gateway-architect/tests/golden/input-businessplan.json
+++ b/packages/api-gateway-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,10 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": []
+}

--- a/packages/api-gateway-architect/tests/golden/input-ticket.json
+++ b/packages/api-gateway-architect/tests/golden/input-ticket.json
@@ -1,0 +1,22 @@
+{
+  "id": "ticket-pt-api-001",
+  "type": "Form",
+  "scope": "story",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "POST /v1/contacts is rate-limited to 10 req/min per IP.",
+    "X-Request-Id is propagated through to the response.",
+    "No Server / X-Powered-By headers leak in any response.",
+    "Free-tier API quota overage rejects the request.",
+    "CORS allowlist is same-origin by default."
+  ],
+  "business_requirements": {
+    "title": "Contact form submission endpoint",
+    "description": "Public POST endpoint that accepts a contact-form payload and writes to the tenant's contacts table. Backs the marketing site's \"Book a session\" widget."
+  },
+  "quality_tags": [
+    "api",
+    "persists",
+    "backend"
+  ]
+}

--- a/packages/api-gateway-architect/tests/golden/input-upstream.json
+++ b/packages/api-gateway-architect/tests/golden/input-upstream.json
@@ -1,0 +1,197 @@
+{
+  "outputs": {
+    "backend": {
+      "architectName": "backend",
+      "architectureFields": {
+        "backend.framework": {
+          "name": "next",
+          "version": "15.x",
+          "runtime": "edge+node",
+          "handlerStyle": "app-router-route-handlers+server-actions"
+        },
+        "backend.apiEndpoints": [
+          {
+            "method": "POST",
+            "path": "/v1/contacts",
+            "op": "createContact",
+            "requestSchemaRef": "ContactCreate",
+            "responseSchemaRef": "Contact",
+            "persistsTo": [
+              "contacts"
+            ],
+            "auth": {
+              "scheme": "public"
+            },
+            "rateLimit": {
+              "windowMs": 60000,
+              "max": 10,
+              "scope": "ip"
+            }
+          },
+          {
+            "method": "GET",
+            "path": "/v1/contacts",
+            "op": "listContacts",
+            "responseSchemaRef": "ContactList",
+            "readsFrom": [
+              "contacts"
+            ],
+            "auth": {
+              "scheme": "jwt-bearer"
+            },
+            "rateLimit": {
+              "windowMs": 60000,
+              "max": 60,
+              "scope": "tenant"
+            }
+          }
+        ],
+        "backend.authRequirements": {
+          "default": "cloudflare-access",
+          "perEndpoint": {
+            "POST /v1/contacts": {
+              "scheme": "public"
+            },
+            "GET /v1/contacts": {
+              "scheme": "jwt-bearer",
+              "issuer": "caia",
+              "scopes": [
+                "contacts:read"
+              ]
+            }
+          }
+        },
+        "backend.rateLimits": {
+          "default": {
+            "windowMs": 60000,
+            "max": 60,
+            "scope": "tenant"
+          },
+          "perEndpoint": {
+            "POST /v1/contacts": {
+              "windowMs": 60000,
+              "max": 10,
+              "scope": "ip"
+            }
+          }
+        },
+        "backend.errorEnvelope": {
+          "schema": {
+            "error": {
+              "code": "string",
+              "message": "string",
+              "details": "object?",
+              "requestId": "string"
+            }
+          },
+          "examples": [
+            {
+              "status": 400,
+              "body": {
+                "error": {
+                  "code": "INVALID_BODY",
+                  "message": "Invalid request body",
+                  "requestId": "req_…"
+                }
+              }
+            }
+          ],
+          "mapping": {
+            "ValidationError": {
+              "httpStatus": 400,
+              "code": "INVALID_BODY"
+            }
+          }
+        }
+      },
+      "confidence": 0.9,
+      "notes": "Backend fixture.",
+      "dependencies": [],
+      "risks": [],
+      "toolCalls": [],
+      "spend": {
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "usdCost": 0,
+        "wallClockMs": 0,
+        "model": "sonnet"
+      },
+      "status": "ok"
+    },
+    "security": {
+      "architectName": "security",
+      "architectureFields": {
+        "security.authenticationStrategy": {
+          "default": "cloudflare-access",
+          "perEndpoint": {
+            "POST /v1/contacts": {
+              "scheme": "public"
+            },
+            "GET /v1/contacts": {
+              "scheme": "jwt-bearer",
+              "issuer": "caia"
+            }
+          },
+          "sessionModel": {
+            "kind": "jwt",
+            "alg": "RS256",
+            "accessTtlSec": 900,
+            "refreshTtlSec": 2592000
+          }
+        },
+        "security.authorizationRules": {
+          "model": "rbac+abac",
+          "roles": [
+            "owner",
+            "admin",
+            "member",
+            "viewer"
+          ],
+          "denyByDefault": true
+        },
+        "security.rateLimitingRules": {
+          "perAuthTier": {
+            "public": {
+              "windowMs": 60000,
+              "max": 20
+            },
+            "authenticated": {
+              "windowMs": 60000,
+              "max": 60
+            },
+            "service": {
+              "windowMs": 60000,
+              "max": 600
+            }
+          },
+          "perEndpoint": {
+            "POST /v1/contacts": {
+              "windowMs": 60000,
+              "max": 10,
+              "scope": "ip",
+              "onLimit": {
+                "status": 429
+              }
+            }
+          }
+        }
+      },
+      "confidence": 0.9,
+      "notes": "Security fixture.",
+      "dependencies": [
+        "backend",
+        "database"
+      ],
+      "risks": [],
+      "toolCalls": [],
+      "spend": {
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "usdCost": 0,
+        "wallClockMs": 0,
+        "model": "sonnet"
+      },
+      "status": "ok"
+    }
+  }
+}

--- a/packages/api-gateway-architect/tests/helpers/fakes.ts
+++ b/packages/api-gateway-architect/tests/helpers/fakes.ts
@@ -1,0 +1,369 @@
+/**
+ * Test fixtures + fake spawner factory.
+ *
+ *   - `buildFakeInput()` — produces a deterministic `ArchitectInput`
+ *     for a known prakash-tiwari Form Story ticket (POST /v1/contacts).
+ *
+ *   - `fakeSpawnerReturning(text)` — fabricates an `ArchitectSpawnerFn`
+ *     that returns the given text deterministically.
+ *
+ *   - `goldenExpectedOutput()` — the canonical known-good
+ *     `ArchitectOutput` for the prakash-tiwari Form fixture.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { API_GATEWAY_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+function buildBackendUpstreamFields(): Record<string, unknown> {
+  return {
+    'backend.framework': {
+      name: 'next',
+      version: '15.x',
+      runtime: 'edge+node',
+      handlerStyle: 'app-router-route-handlers+server-actions'
+    },
+    'backend.apiEndpoints': [
+      {
+        method: 'POST',
+        path: '/v1/contacts',
+        op: 'createContact',
+        requestSchemaRef: 'ContactCreate',
+        responseSchemaRef: 'Contact',
+        persistsTo: ['contacts'],
+        auth: { scheme: 'public' },
+        rateLimit: { windowMs: 60_000, max: 10, scope: 'ip' }
+      },
+      {
+        method: 'GET',
+        path: '/v1/contacts',
+        op: 'listContacts',
+        responseSchemaRef: 'ContactList',
+        readsFrom: ['contacts'],
+        auth: { scheme: 'jwt-bearer' },
+        rateLimit: { windowMs: 60_000, max: 60, scope: 'tenant' }
+      }
+    ],
+    'backend.authRequirements': {
+      default: 'cloudflare-access',
+      perEndpoint: {
+        'POST /v1/contacts': { scheme: 'public' },
+        'GET /v1/contacts': { scheme: 'jwt-bearer', issuer: 'caia', scopes: ['contacts:read'] }
+      }
+    },
+    'backend.rateLimits': {
+      default: { windowMs: 60_000, max: 60, scope: 'tenant' },
+      perEndpoint: {
+        'POST /v1/contacts': { windowMs: 60_000, max: 10, scope: 'ip' }
+      }
+    },
+    'backend.errorEnvelope': {
+      schema: {
+        error: {
+          code: 'string',
+          message: 'string',
+          details: 'object?',
+          requestId: 'string'
+        }
+      },
+      examples: [
+        {
+          status: 400,
+          body: { error: { code: 'INVALID_BODY', message: 'Invalid request body', requestId: 'req_…' } }
+        }
+      ],
+      mapping: {
+        ValidationError: { httpStatus: 400, code: 'INVALID_BODY' }
+      }
+    }
+  };
+}
+
+function buildSecurityUpstreamFields(): Record<string, unknown> {
+  return {
+    'security.authenticationStrategy': {
+      default: 'cloudflare-access',
+      perEndpoint: {
+        'POST /v1/contacts': { scheme: 'public' },
+        'GET /v1/contacts': { scheme: 'jwt-bearer', issuer: 'caia' }
+      },
+      sessionModel: { kind: 'jwt', alg: 'RS256', accessTtlSec: 900, refreshTtlSec: 2_592_000 }
+    },
+    'security.authorizationRules': {
+      model: 'rbac+abac',
+      roles: ['owner', 'admin', 'member', 'viewer'],
+      denyByDefault: true
+    },
+    'security.rateLimitingRules': {
+      perAuthTier: {
+        public: { windowMs: 60_000, max: 20 },
+        authenticated: { windowMs: 60_000, max: 60 },
+        service: { windowMs: 60_000, max: 600 }
+      },
+      perEndpoint: {
+        'POST /v1/contacts': { windowMs: 60_000, max: 10, scope: 'ip', onLimit: { status: 429 } }
+      }
+    }
+  };
+}
+
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-api-001',
+      type: 'Form',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'POST /v1/contacts is rate-limited to 10 req/min per IP.',
+        'X-Request-Id is propagated through to the response.',
+        'No Server / X-Powered-By headers leak in any response.',
+        'Free-tier API quota overage rejects the request.',
+        'CORS allowlist is same-origin by default.'
+      ],
+      business_requirements: {
+        title: 'Contact form submission endpoint',
+        description:
+          'Public POST endpoint that accepts a contact-form payload and writes to the tenant\'s contacts table. Backs the marketing site\'s "Book a session" widget.'
+      },
+      quality_tags: ['api', 'persists', 'backend']
+    },
+    upstream: {
+      outputs: {
+        backend: {
+          architectName: 'backend',
+          architectureFields: buildBackendUpstreamFields(),
+          confidence: 0.9,
+          notes: 'Backend fixture.',
+          dependencies: [],
+          risks: [],
+          toolCalls: [],
+          spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+          status: 'ok'
+        },
+        security: {
+          architectName: 'security',
+          architectureFields: buildSecurityUpstreamFields(),
+          confidence: 0.9,
+          notes: 'Security fixture.',
+          dependencies: ['backend', 'database'],
+          risks: [],
+          toolCalls: [],
+          spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+          status: 'ok'
+        }
+      }
+    },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: 'High-intent prospective sitters in the artist\'s metropolitan area.',
+      goals: ['Drive contact-form submissions'],
+      brandVoice: 'warm + grounded',
+      constraints: []
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [],
+      tokens: {},
+      breakpoints: ['sm', 'md', 'lg', 'xl']
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'apiGateway',
+    architectureFields: {
+      'apiGateway.rateLimits': {
+        perRoute: {
+          'POST /v1/contacts': {
+            windowMs: 60_000,
+            max: 10,
+            scope: 'ip',
+            onLimit: { status: 429, retryAfterSec: 60 }
+          },
+          'GET /v1/contacts': {
+            windowMs: 60_000,
+            max: 60,
+            scope: 'tenant',
+            onLimit: { status: 429, retryAfterSec: 30 }
+          }
+        },
+        perTenant: {
+          free: { windowMs: 60_000, max: 100, onLimit: { status: 429, retryAfterSec: 60 } },
+          pro: { windowMs: 60_000, max: 600, onLimit: { status: 429, retryAfterSec: 30 } },
+          enterprise: { windowMs: 60_000, max: 6_000, onLimit: { status: 429, retryAfterSec: 15 } }
+        },
+        defaults: {
+          public: { windowMs: 60_000, max: 20, scope: 'ip', onLimit: { status: 429, retryAfterSec: 60 } },
+          authenticated: { windowMs: 60_000, max: 60, scope: 'tenant', onLimit: { status: 429, retryAfterSec: 30 } },
+          service: { windowMs: 60_000, max: 600, scope: 'apiKey', onLimit: { status: 429, retryAfterSec: 5 } }
+        }
+      },
+      'apiGateway.authGates': {
+        'POST /v1/contacts': { authType: 'public', gateAt: 'edge', required: false },
+        'GET /v1/contacts': { authType: 'jwt-bearer', gateAt: 'edge', required: true }
+      },
+      'apiGateway.versioningStrategy': {
+        kind: 'url-prefix',
+        prefix: '/v1',
+        currentVersion: 'v1',
+        deprecatedVersions: [],
+        sunsetPolicy: {
+          advanceNoticeDays: 180,
+          headerName: 'Sunset',
+          deprecationHeaderName: 'Deprecation'
+        }
+      },
+      'apiGateway.errorEnvelope': {
+        extends: 'backend.errorEnvelope',
+        addedFields: {
+          requestId: 'string',
+          gatewayCode: 'string',
+          retryable: 'boolean',
+          upstream: 'object?'
+        },
+        mapping: {
+          rateLimited: { httpStatus: 429, gatewayCode: 'GATEWAY_RATE_LIMITED', retryable: true },
+          authFailed: { httpStatus: 401, gatewayCode: 'GATEWAY_AUTH_FAILED', retryable: false },
+          upstreamTimeout: { httpStatus: 504, gatewayCode: 'GATEWAY_UPSTREAM_TIMEOUT', retryable: true },
+          upstreamUnavailable: { httpStatus: 503, gatewayCode: 'GATEWAY_UPSTREAM_UNAVAILABLE', retryable: true },
+          badRequest: { httpStatus: 400, gatewayCode: 'GATEWAY_BAD_REQUEST', retryable: false }
+        }
+      },
+      'apiGateway.requestResponseTransforms': {
+        request: [
+          { op: 'inject-header', header: 'X-Request-Id', generator: 'uuid-v7-if-absent' },
+          { op: 'canonicalize-query', target: '*' }
+        ],
+        response: [
+          { op: 'strip-header', header: 'Server' },
+          { op: 'strip-header', header: 'X-Powered-By' },
+          { op: 'inject-header', header: 'X-Request-Id', source: 'request:X-Request-Id' }
+        ],
+        cacheRules: [
+          { path: '/v1/contacts', scope: 'tenant', ttlSec: 0, vary: ['Authorization', 'Accept-Language'] }
+        ]
+      },
+      'apiGateway.corsPolicy': {
+        default: {
+          allowedOrigins: ['same-origin'],
+          allowedMethods: ['GET', 'POST', 'PATCH', 'DELETE'],
+          allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-Id'],
+          exposedHeaders: ['X-Request-Id', 'Sunset', 'Deprecation', 'Retry-After', 'X-Quota-Remaining', 'X-Quota-Reset'],
+          allowCredentials: false,
+          maxAgeSec: 600
+        },
+        perTenant: {
+          'tenant-prakash-tiwari': {
+            allowedOrigins: ['https://prakashtiwari.com', 'https://www.prakashtiwari.com'],
+            allowCredentials: false
+          }
+        }
+      },
+      'apiGateway.webhookSecrets': {
+        provider: 'vault',
+        namespace: 'tenant/{{tenantId}}/webhooks',
+        signing: {
+          algorithm: 'HMAC-SHA256',
+          headerName: 'X-CAIA-Signature',
+          timestampHeaderName: 'X-CAIA-Timestamp',
+          timestampToleranceSec: 300
+        },
+        replayProtection: { kind: 'nonce-store', ttlSec: 600 },
+        rotation: { kind: 'scheduled', intervalDays: 90 },
+        perWebhook: {}
+      },
+      'apiGateway.apiQuotas': {
+        perTier: {
+          free: { monthlyRequests: 1_000, dailyRequests: 100, overage: 'reject' },
+          pro: { monthlyRequests: 100_000, dailyRequests: 10_000, overage: 'throttle' },
+          enterprise: { monthlyRequests: 10_000_000, dailyRequests: 1_000_000, overage: 'bill' }
+        },
+        perEndpoint: {
+          'POST /v1/contacts': { costMultiplier: 1 },
+          'GET /v1/contacts': { costMultiplier: 1 }
+        },
+        surfacing: {
+          headerName: 'X-Quota-Remaining',
+          resetHeaderName: 'X-Quota-Reset'
+        }
+      }
+    },
+    confidence: 0.9,
+    notes:
+      'Per-route auth + rate-limit derived from Backend\'s apiEndpoints and cross-validated against Security\'s rateLimitingRules + authenticationStrategy. URL versioning at /v1 with 180-day sunset window. Error envelope extends Backend\'s; adds requestId + gatewayCode + retryable. X-Request-Id injected at the edge; Server + X-Powered-By stripped on response. Same-origin CORS default; HMAC-SHA256 webhook signing with 300s tolerance and 90d rotation. Free tier rejects on overage; pro + enterprise throttle/bill.',
+    dependencies: ['backend', 'security'],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of API_GATEWAY_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/api-gateway-architect/tests/invariants.test.ts
+++ b/packages/api-gateway-architect/tests/invariants.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Cross-architect invariants — verifies API Gateway's contributions to
+ * the EA Reviewer's invariant registry (per spec §6.2).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { API_GATEWAY_INVARIANTS } from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('API_GATEWAY_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(API_GATEWAY_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of API_GATEWAY_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `apiGateway`', () => {
+    for (const inv of API_GATEWAY_INVARIANTS) {
+      expect(inv.contributor).toBe('apiGateway');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of API_GATEWAY_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of API_GATEWAY_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of API_GATEWAY_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('API_GATEWAY_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of API_GATEWAY_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('error-envelope-covers-required-codes fails when a code is missing', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.error-envelope-covers-required-codes');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.errorEnvelope': {
+        ...(goldenArch['apiGateway.errorEnvelope'] as Record<string, unknown>),
+        mapping: { rateLimited: { httpStatus: 429, gatewayCode: 'GATEWAY_RATE_LIMITED', retryable: true } }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('cors-wildcard-credentials-forbidden fails when wildcard + credentials are set', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.cors-wildcard-credentials-forbidden');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.corsPolicy': {
+        default: { allowedOrigins: ['*'], allowCredentials: true }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('versioning-kind-allowed fails on an unknown kind', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.versioning-kind-allowed');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.versioningStrategy': { kind: 'date-based', sunsetPolicy: { advanceNoticeDays: 180 } }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('versioning-sunset-window fails on < 180 days', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.versioning-sunset-window');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.versioningStrategy': {
+        kind: 'url-prefix',
+        sunsetPolicy: { advanceNoticeDays: 30 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('transforms-inject-request-id fails when no inject-header op for X-Request-Id exists', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.transforms-inject-request-id');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.requestResponseTransforms': {
+        request: [{ op: 'canonicalize-query', target: '*' }],
+        response: [
+          { op: 'strip-header', header: 'Server' },
+          { op: 'strip-header', header: 'X-Powered-By' }
+        ]
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('transforms-strip-server-fingerprint fails when Server / X-Powered-By aren\'t stripped', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.transforms-strip-server-fingerprint');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.requestResponseTransforms': {
+        request: [{ op: 'inject-header', header: 'X-Request-Id' }],
+        response: [{ op: 'strip-header', header: 'Server' }]
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('quotas-cover-required-tiers fails when a tier is missing', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.quotas-cover-required-tiers');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.apiQuotas': {
+        perTier: { free: { overage: 'reject' }, pro: { overage: 'throttle' } }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('free-tier-rejects-overage fails when free tier throttles instead of rejecting', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.free-tier-rejects-overage');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.apiQuotas': {
+        perTier: {
+          free: { overage: 'throttle' },
+          pro: { overage: 'throttle' },
+          enterprise: { overage: 'bill' }
+        }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('auth-gates-types-allowed fails on an unknown auth type', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.auth-gates-types-allowed');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.authGates': {
+        'POST /v1/contacts': { authType: 'basic-auth', gateAt: 'edge', required: true }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('webhook-signing-strong-algorithm fails on HMAC-SHA1', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.webhook-signing-strong-algorithm');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.webhookSecrets': {
+        signing: { algorithm: 'HMAC-SHA1', timestampToleranceSec: 300 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('webhook-timestamp-tolerance-bounded fails on > 300 seconds', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.webhook-timestamp-tolerance-bounded');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.webhookSecrets': {
+        signing: { algorithm: 'HMAC-SHA256', timestampToleranceSec: 3600 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('rate-limits-perRoute-present fails when perRoute is missing', () => {
+    const inv = API_GATEWAY_INVARIANTS.find(i => i.id === 'apiGateway.rate-limits-perRoute-present');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'apiGateway.rateLimits': {
+        defaults: { public: { max: 20 } }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+});

--- a/packages/api-gateway-architect/tests/run.test.ts
+++ b/packages/api-gateway-architect/tests/run.test.ts
@@ -1,0 +1,257 @@
+/**
+ * `run()` tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { API_GATEWAY_ARCHITECT_NAME, ApiGatewayArchitect } from '../src/architect.js';
+import { API_GATEWAY_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runApiGatewayArchitect } from '../src/run.js';
+import { buildApiGatewaySystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runApiGatewayArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('apiGateway');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    for (const k of API_GATEWAY_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildApiGatewaySystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runApiGatewayArchitect(input, {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runApiGatewayArchitect(input, {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runApiGatewayArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runApiGatewayArchitect(input, {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    const b = await runApiGatewayArchitect(input, {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runApiGatewayArchitect(input, {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    const r2 = await runApiGatewayArchitect(input, {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(
+      Object.keys(r1.architectureFields).sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(API_GATEWAY_OWNED_FIELD_KEYS.length);
+  });
+});
+
+describe('runApiGatewayArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('security');
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"apiGateway"}');
+    const out = await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('security');
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runApiGatewayArchitect — dependency declaration', () => {
+  it('API Gateway is wave-2; ensures backend + security in dependencies', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('security');
+  });
+
+  it('preserves sibling ticket IDs the model emitted alongside the canonical deps', async () => {
+    const fakeWithSiblings = {
+      ...JSON.parse(goldenAssistantText()),
+      dependencies: ['ticket-other-1', 'backend']
+    };
+    const { fn: spawner } = fakeSpawnerReturning(JSON.stringify(fakeWithSiblings));
+    const out = await runApiGatewayArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildApiGatewaySystemPrompt(),
+      architectName: API_GATEWAY_ARCHITECT_NAME
+    });
+    expect(out.dependencies).toContain('ticket-other-1');
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('security');
+    expect(out.dependencies.filter(d => d === 'backend').length).toBe(1);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-api-001');
+  });
+
+  it('serialises the upstream Backend output (apiEndpoints)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('backend.apiEndpoints');
+    expect(p).toContain('/v1/contacts');
+  });
+
+  it('serialises the upstream Security output (authenticationStrategy)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('security.authenticationStrategy');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('includes the tenant billingPosture for tier resolution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('subscription');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: { reason: 'fix the rate limit', severity: 'P1' as const }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('fix the rate limit');
+  });
+});
+
+describe('ApiGatewayArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new ApiGatewayArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('apiGateway');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/api-gateway-architect/tests/system-prompt.test.ts
+++ b/packages/api-gateway-architect/tests/system-prompt.test.ts
@@ -1,0 +1,119 @@
+/**
+ * System-prompt tests — verifies the briefing satisfies spec §11(b).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  API_GATEWAY_OWNED_FIELD_KEYS,
+  REQUIRED_GATEWAY_CODES,
+  REQUIRED_QUOTA_TIERS
+} from '../src/contract.js';
+import { buildApiGatewaySystemPrompt } from '../src/system-prompt.js';
+
+describe('buildApiGatewaySystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildApiGatewaySystemPrompt();
+    const p2 = buildApiGatewaySystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's API Gateway Architect");
+  });
+
+  it('contains the Locked stack section', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('Cloudflare');
+    expect(p).toContain('HMAC-SHA256');
+    expect(p).toContain('X-Request-Id');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildApiGatewaySystemPrompt();
+    for (const key of API_GATEWAY_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('references every required gateway code at least once', () => {
+    const p = buildApiGatewaySystemPrompt();
+    for (const code of REQUIRED_GATEWAY_CODES) {
+      expect(p).toContain(code);
+    }
+  });
+
+  it('references every required quota tier at least once', () => {
+    const p = buildApiGatewaySystemPrompt();
+    for (const tier of REQUIRED_QUOTA_TIERS) {
+      expect(p).toContain(tier);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('apiGateway.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('does not refer to fields outside the `apiGateway.*` namespace', () => {
+    const p = buildApiGatewaySystemPrompt();
+    const foreignPrefixes = [
+      'frontend.componentTree',
+      'database.schemaDDL',
+      'security.cspPolicy',
+      'analytics.eventTaxonomy',
+      'observability.logShape'
+    ];
+    for (const prefix of foreignPrefixes) {
+      expect(p).not.toContain(prefix);
+    }
+  });
+
+  it('size is bounded (token-budget proxy: < 22k chars)', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(p.length).toBeLessThan(22_000);
+  });
+
+  it('declares the upstream Backend + Security inputs', () => {
+    const p = buildApiGatewaySystemPrompt();
+    expect(p).toContain('backend.apiEndpoints');
+    expect(p).toContain('security.authenticationStrategy');
+  });
+});

--- a/packages/api-gateway-architect/tests/validation.test.ts
+++ b/packages/api-gateway-architect/tests/validation.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Output validation tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { API_GATEWAY_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('apiGateway');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ```json fences (lenient parser)', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput(
+      '{"architectName":"apiGateway"}',
+      API_GATEWAY_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['apiGateway.rateLimits'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'backend.apiEndpoints': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), API_GATEWAY_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(JSON.stringify(variant), API_GATEWAY_OWNED_FIELD_KEYS);
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/api-gateway-architect/tsconfig.build.json
+++ b/packages/api-gateway-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/api-gateway-architect/tsconfig.json
+++ b/packages/api-gateway-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/api-gateway-architect/vitest.config.ts
+++ b/packages/api-gateway-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -771,6 +771,31 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/api-gateway-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@caia/backend-architect':
+        specifier: workspace:*
+        version: link:../backend-architect
+      '@caia/security-architect':
+        specifier: workspace:*
+        version: link:../security-architect
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/apprentice-corpus:
     dependencies:
       '@chiefaia/claude-spawner':


### PR DESCRIPTION
## Summary

Ships **API Gateway Architect** — architect #11 of CAIA's 17-architect EA fan-out — as `@caia/api-gateway-architect`. Senior API platform engineer focused on **gateways + rate limiting + auth gates + versioning**. Sits in front of Backend's endpoints and specifies what the gateway layer enforces.

## Per spec §2.11 + task brief

**Owns** the `apiGateway.*` slice of `tickets.architecture` JSONB (8 fields):

| Field | What it carries |
|---|---|
| `rateLimits` | per-route + per-tenant rate limits (extends Backend's + Security's) |
| `authGates` | per-route auth-type + edge\|origin gate placement |
| `versioningStrategy` | URL-prefix (default) vs accept-header; ≥180-day sunset policy |
| `errorEnvelope` | extends Backend's with `requestId` / `gatewayCode` / `retryable` / optional `upstream` |
| `requestResponseTransforms` | X-Request-Id injection + `Server`/`X-Powered-By` stripping + edge cache rules |
| `corsPolicy` | same-origin default; wildcard `*` forbidden with credentials |
| `webhookSecrets` | HMAC-SHA256 / 300s tolerance / nonce-store replay protection / 90d rotation |
| `apiQuotas` | per-tier (`free`/`pro`/`enterprise`); free rejects on overage |

**System prompt**: senior API platform engineer. Does NOT write backend logic (Backend Architect owns that) or auth implementation (Security Architect owns that — gateway only specifies which gate is on which route + how the edge enforces it).

**Depends on**: Backend Architect (`apiEndpoints`, `authRequirements`, `rateLimits`, `errorEnvelope`) + Security Architect (`authenticationStrategy`, `authorizationRules`, `rateLimitingRules`) upstream. **Wave-2**.

**Precedence rank**: 8 per spec §5.2 — boundary integrity sits above observability/analytics/database/backend/frontend but below the safety/perf critics (security/devops/a11y/seo/performance/abTesting/featureFlagging).

**Tools**: empty for V1.

## Implementation shape

Mirrors `@caia/frontend-architect` (the canonical template, PR #537) and `@caia/security-architect` (architect #10, fellow wave-2 + Backend-dependent, PR #555):

- `src/architect.ts` — `ApiGatewayArchitect` class implementing `SpecialistArchitect`.
- `src/contract.ts` — section contract + 8 owned-field specs + apply predicate + architect meta + the canonical gateway-code/auth-type/quota-tier constants.
- `src/system-prompt.ts` — pure function returning the role/locked-stack/input/output-schema/heuristics/refusals/self-check/examples briefing (≈14 KB).
- `src/system-prompt.md` — human-readable mirror.
- `src/run.ts` — runtime entry; serialises input, calls spawner, validates output, force-sets `dependencies: [..., 'backend', 'security']`.
- `src/spawner.ts` — `@chiefaia/claude-spawner` seam (test-injectable).
- `src/validation.ts` — defensive shape validator.
- `src/invariants.ts` — 12 cross-architect invariants for the EA Reviewer's registry.
- `src/types.ts` — re-exports from `@caia/architect-kit`.
- `src/index.ts` — public surface + `registerWith(registry)` helper.

## Tests — 131 passing

- `tests/architect.test.ts` — 12 interface compliance tests.
- `tests/contract.test.ts` — 34 contract structural + registration + disjointness + apply-predicate tests (including upstream-deps validation: registry flags missing `backend`/`security` when API Gateway is alone, and passes when both stubs are registered).
- `tests/system-prompt.test.ts` — 15 prompt-completeness tests (every owned field, every required gateway code, every required quota tier, foreign namespaces absent, locked-stack mentions present).
- `tests/validation.test.ts` — 19 validation-error-class tests.
- `tests/run.test.ts` — 22 run-pipeline tests (happy path + idempotency + REPLACE-not-append + failure modes + dependency declaration with sibling-id preservation).
- `tests/invariants.test.ts` — 19 invariant tests (golden passes all; each failure mode triggers).
- `tests/golden/golden.test.ts` — 10 end-to-end tests against a known prakash-tiwari Form Story ticket (POST + GET `/v1/contacts`) with realistic Backend + Security upstream fixtures.

```
Test Files  7 passed (7)
     Tests  131 passed (131)
```

TypeScript strict clean (`tsc --noEmit`). ESLint clean. Build emits `dist/`.

## Notes

- Spawner is subscription-only (`@chiefaia/claude-spawner`); no `ANTHROPIC_API_KEY`. True-Zero rule observed.
- Stack lock `[[project-caia-shadcn-react-first-locked]]` doesn't affect this architect's structure (no UI surface); flagged in case the system-prompt examples drift.
- The 12 cross-architect invariants cover the documented "silent vulnerability" failure modes: missing gateway codes, CORS `*`+credentials, weak webhook algorithms, free-tier overage anything but reject, missing X-Request-Id injection, missing server-fingerprint stripping, sub-180-day sunsets, unknown auth types, etc.

## Test plan

```bash
pnpm install --filter @caia/api-gateway-architect...
pnpm --filter @caia/api-gateway-architect typecheck
pnpm --filter @caia/api-gateway-architect lint
pnpm --filter @caia/api-gateway-architect test
pnpm --filter @caia/api-gateway-architect build
```

All pass locally.
