### PR TITLE
feat(@caia/devops-architect): ship architect #17 of 17 — DevOps specialist (LAST architect, completes the roster)

### DIFF
--- a/packages/devops-architect/README.md
+++ b/packages/devops-architect/README.md
@@ -1,0 +1,95 @@
+# @caia/devops-architect
+
+Architect **#17 of 17** in CAIA's EA fan-out. **This package completes the roster** — once it merges, every architect contract is in place and the EA Dispatcher can fan-out across all 17 in parallel for any ticket.
+
+Senior DevOps engineer focused on CI/CD + deployment strategies + rollback safety. Produces per-ticket **DEPLOY STRATEGY** specs.
+
+## Distinct from neighbouring packages
+
+This architect SPECIFIES how a deploy should happen. It does NOT execute deploys.
+
+- The **`caia/packages/deploy-steward`** bin/launchd EXECUTES deploys (it's not a TS package per the V2 audit — it's a launchd-triggered shell tool).
+- The **QA Engineer agent** validates production after deploy.
+- The **DevOps Architect (this package)** sets the STRATEGY: pipeline shape, deploy strategy, rollback contract, IaC patterns, env promotion gates.
+
+## Position in the architect fan-out
+
+- **Wave**: 3 (depends on Backend Architect + Database Architect + Security Architect).
+- **Precedence rank**: **2** per spec §5.2 — only Security outranks DevOps, because the operator is on the hook for a bad deploy.
+- **Runtime model**: Sonnet.
+
+## What it owns
+
+`devops.*` slice of the `tickets.architecture` JSONB column:
+
+- `devops.cicdPipeline` — GitHub Actions / GitLab CI / etc. (per customer's choice from onboarding)
+- `devops.deployStrategy` — blue-green / canary / ring deployment / rolling
+- `devops.rollbackContract` — how to roll back a bad deploy
+- `devops.infrastructureAsCode` — Terraform / Pulumi / Kubernetes manifests (per customer's choice)
+- `devops.environmentPromotion` — dev → staging → prod gates
+- `devops.deploymentObservability` — what gets logged per deploy
+- `devops.secretsManagementInPipeline` — forward-references the Security Architect
+
+## What it does NOT do
+
+No component code, no API endpoints, no SQL DDL, no UI. DevOps specifies the deployment contract that the deploy-steward executor implements.
+
+## Per-customer choices from onboarding
+
+The architect reads onboarding choices from `tenantContext` and the input `businessPlan`:
+
+- **CI/CD provider** — GitHub Actions (default), GitLab CI, CircleCI, Buildkite
+- **Cloud provider** — Cloudflare (default), AWS, GCP, Azure, fly.io
+- **IaC tool** — Terraform (default), Pulumi, Kubernetes manifests, CDK
+- **Repo provider** — GitHub (default), GitLab, Bitbucket
+
+When onboarding provides no choice the architect picks the locked default and notes the assumption in `risks[]`.
+
+## Deploy strategy realism (golden test)
+
+The golden test verifies the deploy strategy is realistic:
+
+- **blue-green** requires `2× infra` (two identical production environments).
+- **canary** requires `traffic-split` capability (a load-balancer or service-mesh that can route a fraction of traffic).
+- **ring deployment** requires `multi-region` topology (rings are concentric blast-radius bands).
+- **rolling** requires `multi-instance` minimum (you can't roll a singleton).
+
+The architect MUST flag mismatches between the chosen strategy and the available infra. The golden assistant text picks a strategy that matches the canonical contact-form ticket's infrastructure shape.
+
+## Quick start
+
+```ts
+import { DevopsArchitect, DevopsArchitectContract } from '@caia/devops-architect';
+
+const architect = new DevopsArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: { backend, database, security } },
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (>=30 tests, including deploy-strategy-realism golden)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+The test suite includes interface compliance, contract structural checks, registration disjointness vs frontend + backend + database + security, output validation, run() idempotency, dependency declaration (`['backend','database','security']`), cross-architect invariants (rollback contract reality, deploy-strategy infra match, secrets via Security, environment promotion sanity), and an end-to-end golden test against a known prakash-tiwari contact-form Story ticket.
+
+## 17 of 17 — milestone
+
+This is the final architect. With DevOps shipped, the canonical 17-architect roster is complete and the EA Dispatcher can fan-out across the full set:
+
+```
+Wave 1: Frontend, Backend, SEO, Feature Flagging, Time Machine, UX Version Control, AI/ML
+Wave 2: Database, Accessibility, Performance, Analytics, Observability, Security, API Gateway, Testing
+Wave 3: A/B Testing, DevOps
+```

--- a/packages/devops-architect/eslint.config.cjs
+++ b/packages/devops-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on security-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/devops-architect/package.json
+++ b/packages/devops-architect/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@caia/devops-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "DevOps/Deployment Architect — architect #17 of 17 in CAIA's EA fan-out (LAST architect; completes the roster). Owns the `devops.*` slice of `tickets.architecture` (cicdPipeline, deployStrategy, rollbackContract, infrastructureAsCode, environmentPromotion, deploymentObservability, secretsManagementInPipeline). Senior DevOps engineer focused on CI/CD + deployment strategies + rollback safety. Produces per-ticket DEPLOY STRATEGY specs. Distinct from (a) the deploy-steward bin/launchd which EXECUTES deploys and (b) the QA Engineer agent which validates production. Depends on Backend + Database + Security architects upstream. Precedence rank 2 — operator-on-hook for a bad deploy. Spawns Claude via @chiefaia/claude-spawner (subscription-only) with Sonnet default.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@caia/backend-architect": "workspace:*",
+    "@caia/database-architect": "workspace:*",
+    "@caia/frontend-architect": "workspace:*",
+    "@caia/security-architect": "workspace:*",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/devops-architect/src/architect.ts
+++ b/packages/devops-architect/src/architect.ts
@@ -1,0 +1,78 @@
+/**
+ * `DevopsArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. The class:
+ *
+ *   - Holds the section contract as a readonly field.
+ *   - Returns the system prompt as a pure function (no runtime state).
+ *   - Declares empty `tools` for V1 (per task brief).
+ *   - Exposes `run(input)` which delegates to `./run.ts`.
+ *
+ * Constructor takes an optional `spawner` so tests can inject a
+ * deterministic fake.
+ *
+ * Note: this class does NOT extend `BaseArchitect` from
+ * `@caia/architect-kit` — we satisfy `SpecialistArchitect`
+ * structurally to mirror the template exactly. When the kit's
+ * `BaseArchitect` becomes the canonical extension point (next minor),
+ * switch to `extends BaseArchitect`.
+ *
+ * This is the **17th and final architect**. With it shipped, the
+ * canonical roster is complete.
+ */
+
+import { DevopsArchitectContract } from './contract.js';
+import { runDevopsArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildDevopsSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches `@caia/devops-architect` minus the suffix. */
+export const DEVOPS_ARCHITECT_NAME = 'devops' as const;
+
+/** V1: no architect-specific tools. */
+export const DEVOPS_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface DevopsArchitectConfig {
+  /** Inject a fake spawner in tests. Default: real claude-spawner-backed spawner. */
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class DevopsArchitect implements SpecialistArchitect {
+  readonly name = DEVOPS_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = DevopsArchitectContract;
+  readonly tools: readonly ToolDefinition[] = DEVOPS_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: DevopsArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  /**
+   * Pure function; identical output every call. The Dispatcher uses this
+   * as the subagent's system prompt.
+   */
+  systemPrompt(): string {
+    return buildDevopsSystemPrompt();
+  }
+
+  /**
+   * Runtime entry point. Idempotent given identical input — re-runs
+   * REPLACE the architect's owned fields (no append) per the task brief.
+   */
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runDevopsArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/devops-architect/src/contract.ts
+++ b/packages/devops-architect/src/contract.ts
@@ -1,0 +1,263 @@
+/**
+ * `DevopsArchitectContract` — the canonical owned-fields declaration for
+ * architect #17 of CAIA's 17-architect EA fan-out. **This contract
+ * completes the roster.**
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.17 (DevOps/Deployment Architect owns `devops.*`)
+ *   - task brief (cicdPipeline, deployStrategy, rollbackContract,
+ *     infrastructureAsCode, environmentPromotion, deploymentObservability,
+ *     secretsManagementInPipeline)
+ *
+ * The reconciled superset below merges spec §2.17's stack-lock fields
+ * (ciPipeline / deployStrategy / rollbackContract / infrastructureAsCode /
+ * environmentPromotion / buildArtifactSpec / secretsInjectionStrategy /
+ * healthcheckPolicy) with the task brief's outcome-oriented names
+ * (cicdPipeline / deploymentObservability / secretsManagementInPipeline).
+ * The task brief is the source of truth; field names below mirror the
+ * brief verbatim.
+ *
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces. Every key lives under the `devops.*` namespace
+ * and does not collide with any sibling architect.
+ *
+ * Upstream dependencies (`dependsOn`): Backend Architect (`backend.framework`,
+ * `backend.serviceBoundaries`, `backend.apiEndpoints`), Database Architect
+ * (`database.engine`, `database.migrations`, `database.tenantIsolationStrategy`),
+ * and Security Architect (`security.secretsHandling`,
+ * `security.auditLogRequirements`, `security.tenantIsolationGuarantees`).
+ * DevOps is a **wave-3** architect.
+ *
+ * Precedence rank **2 (second-highest, only Security outranks)** per
+ * spec §5.2 — the operator is on the hook for a bad deploy contract.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Onboarding choice domains ──────────────────────────────────────────────
+
+/**
+ * Locked enumeration of CI/CD providers the architect understands. The
+ * customer picks during onboarding; the architect emits a `cicdPipeline`
+ * block tailored to that provider's syntax.
+ */
+export const CICD_PROVIDERS: readonly string[] = [
+  'github-actions',
+  'gitlab-ci',
+  'circleci',
+  'buildkite',
+  'azure-pipelines'
+];
+
+/**
+ * Locked enumeration of cloud providers.
+ */
+export const CLOUD_PROVIDERS: readonly string[] = [
+  'cloudflare',
+  'aws',
+  'gcp',
+  'azure',
+  'fly-io',
+  'render'
+];
+
+/**
+ * Locked enumeration of IaC tools.
+ */
+export const IAC_TOOLS: readonly string[] = [
+  'terraform',
+  'pulumi',
+  'kubernetes-manifests',
+  'cdk',
+  'cloudformation'
+];
+
+/**
+ * Locked enumeration of repo providers.
+ */
+export const REPO_PROVIDERS: readonly string[] = ['github', 'gitlab', 'bitbucket'];
+
+/**
+ * Locked enumeration of deploy strategies the architect supports.
+ * Realism predicates (see `invariants.ts`) cross-check the chosen
+ * strategy against the available infrastructure.
+ */
+export const DEPLOY_STRATEGIES: readonly string[] = [
+  'blue-green',
+  'canary',
+  'ring-deployment',
+  'rolling',
+  'recreate'
+];
+
+/**
+ * Deploy-strategy → required infrastructure capability map. Used by the
+ * `devops.deployStrategy-requires-realistic-infra` invariant and the
+ * golden test. Each entry lists the capabilities that MUST be present
+ * in `devops.infrastructureAsCode.capabilities` (or `evidenceRefs` to
+ * an upstream architect's field) for the strategy to be implementable.
+ *
+ *   - **blue-green** — needs two identical production environments
+ *     (2× infra) so you can cut traffic atomically.
+ *   - **canary** — needs a load-balancer / service-mesh / edge router
+ *     that can split traffic by percentage (traffic-split).
+ *   - **ring-deployment** — needs a multi-region topology so rings can
+ *     be concentric blast-radius bands.
+ *   - **rolling** — needs more than one instance (multi-instance) so
+ *     you can roll one at a time.
+ *   - **recreate** — needs nothing special; this is the simplest, also
+ *     the most operator-on-hook strategy.
+ */
+export const STRATEGY_INFRA_REQUIREMENTS: Readonly<Record<string, readonly string[]>> = {
+  'blue-green': ['two-identical-environments'],
+  'canary': ['traffic-split'],
+  'ring-deployment': ['multi-region'],
+  'rolling': ['multi-instance'],
+  'recreate': []
+};
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+/**
+ * Per-field operator fix-hints. The kit's `ArchitectSectionSpec` is
+ * intentionally minimal (`path`, `description`, `required`); the
+ * fix-hint dictionary lives next to the contract so the system-prompt
+ * builder and the future EA Reviewer can surface it without changing
+ * kit shape.
+ */
+export const DEVOPS_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'devops.cicdPipeline':
+    'Default to GitHub Actions with stages: lint → typecheck → test → build → deploy. Each stage has quality gates: lint blocks on @typescript-eslint errors; typecheck blocks on tsc errors; test blocks on coverage < threshold (per Testing Architect); build emits deterministic artifacts (pinned lockfiles); deploy blocks on Performance + Security architect outputs (Lighthouse + axe + CSP). Customer-onboarding can override the provider — accept gitlab-ci, circleci, buildkite, azure-pipelines.',
+  'devops.deployStrategy':
+    'Default to canary for production with 10% traffic for 30 min, then 100% on healthcheck pass. Accept blue-green, ring-deployment, rolling, recreate. STRATEGY MUST MATCH INFRA: blue-green requires 2× infra; canary requires traffic-split; ring-deployment requires multi-region; rolling requires multi-instance. Mismatches go in risks[].',
+  'devops.rollbackContract':
+    'Default: auto-revert when /_health returns non-200 for 5 min after deploy. Methods: prefer Time Machine snapshot key for stateful rollbacks; fall back to `git revert` + redeploy for code-only. RTO ≤ 5 min; RPO depends on Database lifecycle. Output {trigger, autoRevertWindowMin, method, timeMachineSnapshotKey?, dataMigrationRollback}.',
+  'devops.infrastructureAsCode':
+    'Default to Terraform for Cloudflare/Vault/R2 modules. Accept Pulumi, Kubernetes manifests, CDK, CloudFormation. Output {tool, modules:[name, source, version, purpose], capabilities:[...]}. capabilities MUST include the infra primitives the chosen deploy strategy requires (two-identical-environments / traffic-split / multi-region / multi-instance).',
+  'devops.environmentPromotion':
+    'Default: dev → staging → prod. dev auto-promotes on merge to a feature branch; staging auto-promotes on merge to main; prod requires manual operator gate at staging→prod. Output {environments:[name, purpose, autoPromote, gateKind, gateOwner?], promotionFlow:[from, to, condition], blockers:[...]}.',
+  'devops.deploymentObservability':
+    'Per-deploy telemetry: emit a deploy.started + deploy.succeeded/failed event with attributes {tenantId, ticketId, gitSha, environment, strategy, durationMs, healthcheckLatencyMs, rollbackReason?}. Log to the central secure sink (Security Architect owns `auditLogRequirements.sink`). Required deploy event types: deploy.started, deploy.succeeded, deploy.failed, deploy.rollback.triggered, deploy.healthcheck.failed. Per-event retention 365 days.',
+  'devops.secretsManagementInPipeline':
+    'Forward-reference Security Architect\'s `secretsHandling`. The pipeline NEVER stores secrets in repo files, CI variables (except short-lived tokens), or build artifacts. Use Vault per-tenant namespace via short-lived AppRole tokens (≤1h). Secrets injected as env-at-runtime, never baked into the build artifact. Output {provider:"vault-via-security-architect", injectionPoint, tokenLifetimeMin, neverInArtifact:["password","token","secret","authorization","api-key"], rotationOnRoleChange}.'
+};
+
+/**
+ * The owned section specs in stable order.
+ */
+export const DEVOPS_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'devops.cicdPipeline',
+    description:
+      'Per-ticket CI/CD pipeline spec: provider, stages (lint/typecheck/test/build/deploy), per-stage quality gates referencing Performance + Security + Testing architect outputs, triggers (push|pr|tag), per-stage retry policy. Customer onboarding picks the provider.',
+    required: true
+  },
+  {
+    path: 'devops.deployStrategy',
+    description:
+      'Per-ticket deploy strategy: blue-green | canary | ring-deployment | rolling | recreate. Includes traffic-shift schedule, healthcheck gate, dwell time, abort conditions. MUST match infrastructure capabilities — strategy/infra realism is a reviewer invariant.',
+    required: true
+  },
+  {
+    path: 'devops.rollbackContract',
+    description:
+      'Per-ticket rollback contract: auto-revert trigger (healthcheck failure window), preferred method (Time Machine snapshot key OR `git revert` + redeploy), RTO target, data migration rollback strategy (which migrations are reversible vs require forward-fix).',
+    required: true
+  },
+  {
+    path: 'devops.infrastructureAsCode',
+    description:
+      'Per-ticket IaC posture: tool (Terraform / Pulumi / Kubernetes / CDK / CloudFormation per onboarding), referenced modules, infrastructure capabilities the deployment depends on (two-identical-environments / traffic-split / multi-region / multi-instance).',
+    required: true
+  },
+  {
+    path: 'devops.environmentPromotion',
+    description:
+      'dev → staging → prod promotion flow: per-environment auto-promote/manual-gate posture, gate owner (operator name for manual gates), blocker rules (e.g. fail-on-test, fail-on-lighthouse, fail-on-security-deny).',
+    required: true
+  },
+  {
+    path: 'devops.deploymentObservability',
+    description:
+      'Per-deploy telemetry: event taxonomy (deploy.started/succeeded/failed/rollback.triggered/healthcheck.failed), attributes (tenantId, ticketId, gitSha, environment, strategy, durationMs, healthcheckLatencyMs, rollbackReason?), retention, alert thresholds. Sink references Security Architect\'s `auditLogRequirements.sink`.',
+    required: true
+  },
+  {
+    path: 'devops.secretsManagementInPipeline',
+    description:
+      'Forward-reference Security Architect\'s `secretsHandling`. CI/CD pipeline never persists secrets in repo files, build artifacts, or long-lived CI variables. Short-lived Vault AppRole tokens; env-at-runtime injection. neverInArtifact list mirrors Security\'s `secretsHandling.neverLog`.',
+    required: true
+  }
+];
+
+/**
+ * Flat list of owned field paths.
+ */
+export const DEVOPS_OWNED_FIELD_KEYS: readonly string[] = DEVOPS_OWNED_SECTIONS.map(
+  s => s.path
+);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §2.17 — DevOps runs on every ticket type that has a deployable
+ * artifact: Page, Story, Form, List, Foundation. Widget tickets
+ * typically inherit from the parent Page's deploy posture; only run
+ * when explicitly flagged with `deploy`, `infra`, or `persists`.
+ */
+export function devopsArchitectAppliesPredicate(ticket: Ticket): boolean {
+  if (
+    ticket.type === 'Page' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List' ||
+    ticket.type === 'Foundation'
+  ) {
+    return true;
+  }
+  if (ticket.type === 'Widget') {
+    const tags = ticket.quality_tags ?? [];
+    return (
+      tags.includes('deploy') ||
+      tags.includes('infra') ||
+      tags.includes('devops') ||
+      tags.includes('persists')
+    );
+  }
+  return false;
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+/**
+ * DevOps is a wave-3 architect — `dependsOn: ['backend', 'database', 'security']`.
+ * The task brief promoted Security upstream of DevOps (the spec §2.17
+ * coverage matrix had only Backend + Database); we follow the brief
+ * because the deploy strategy must encode Security's secretsHandling +
+ * auditLogRequirements + tenantIsolationGuarantees.
+ *
+ * Precedence rank **2** per spec §5.2 — only Security outranks DevOps.
+ */
+export const DEVOPS_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['backend', 'database', 'security'],
+  precedenceLevel: 2,
+  fanoutPolicy: 'always',
+  appliesPredicate: devopsArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const DevopsArchitectContract: ArchitectSectionContract = {
+  contractId: 'devops-architect.v1',
+  architectName: 'devops',
+  version: '0.1.0',
+  sections: DEVOPS_OWNED_SECTIONS,
+  architectMeta: DEVOPS_ARCHITECT_META
+};

--- a/packages/devops-architect/src/index.ts
+++ b/packages/devops-architect/src/index.ts
@@ -1,0 +1,109 @@
+/**
+ * @caia/devops-architect — public surface.
+ *
+ * Architect #17 of 17 in CAIA's EA fan-out — **the LAST architect**.
+ * When this lands every contract is in place and the EA Dispatcher
+ * can fan-out across all 17 in parallel for any ticket.
+ *
+ * Senior DevOps engineer focused on CI/CD pipelines + deployment
+ * strategies (blue-green / canary / ring / rolling / recreate) +
+ * rollback safety + Terraform-based IaC + dev→staging→prod promotion
+ * with manual prod gate. Produces per-ticket DEPLOY STRATEGY specs.
+ *
+ * DISTINCT from neighbouring packages:
+ *   - The `caia/packages/deploy-steward` bin/launchd EXECUTES deploys
+ *     (it's a launchd-triggered shell tool, not a TS package per V2
+ *     audit).
+ *   - The QA Engineer agent validates production AFTER deploy.
+ *   - This architect SPECIFIES the deploy contract; the other two
+ *     IMPLEMENT and ENFORCE it.
+ *
+ * Depends on Backend Architect + Database Architect + Security
+ * Architect upstream. Holds precedence rank 2 — only Security
+ * outranks DevOps (spec §5.2).
+ *
+ * Mirrors the canonical `@caia/frontend-architect` template (architect
+ * #1, PR #537) and `@caia/security-architect` template (architect #10).
+ *
+ * Registration: import this package's `registerWith()` helper to
+ * install the architect on a registry. The package does NOT
+ * self-register on import.
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { DevopsArchitect } from './architect.js';
+
+// Main exports — the Dispatcher imports these.
+export {
+  DevopsArchitect,
+  DEVOPS_ARCHITECT_NAME,
+  DEVOPS_ARCHITECT_TOOLS
+} from './architect.js';
+export type { DevopsArchitectConfig } from './architect.js';
+
+export {
+  DevopsArchitectContract,
+  DEVOPS_OWNED_SECTIONS,
+  DEVOPS_OWNED_FIELD_KEYS,
+  DEVOPS_FIELD_FIX_HINTS,
+  DEVOPS_ARCHITECT_META,
+  CICD_PROVIDERS,
+  CLOUD_PROVIDERS,
+  IAC_TOOLS,
+  REPO_PROVIDERS,
+  DEPLOY_STRATEGIES,
+  STRATEGY_INFRA_REQUIREMENTS,
+  devopsArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildDevopsSystemPrompt } from './system-prompt.js';
+
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+export { runDevopsArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+export { DEVOPS_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+/**
+ * Register a fresh DevopsArchitect on the given registry.
+ */
+export function registerWith(registry: ArchitectRegistry): DevopsArchitect {
+  const architect = new DevopsArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/devops-architect/src/invariants.ts
+++ b/packages/devops-architect/src/invariants.ts
@@ -32,13 +32,19 @@ export interface ArchitectInvariant {
   detect(architecture: Readonly<Record<string, unknown>>): boolean;
 }
 
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
   if (path in arch) return arch[path];
   const parts = path.split('.');
   let cursor: unknown = arch;
   for (const part of parts) {
     if (typeof cursor !== 'object' || cursor === null) return undefined;
-    cursor = (cursor as Record<string, unknown>)[part];
+    // Defence in depth: refuse to traverse into prototype-chain keys.
+    if (UNSAFE_KEYS.has(part)) return undefined;
+    cursor = Object.prototype.hasOwnProperty.call(cursor, part)
+      ? (cursor as Record<string, unknown>)[part]
+      : undefined;
   }
   return cursor;
 }

--- a/packages/devops-architect/src/invariants.ts
+++ b/packages/devops-architect/src/invariants.ts
@@ -1,0 +1,310 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (where keys are FLAT
+ *     dotted strings like `'devops.deployStrategy'`), or
+ *   - the composed `tickets.architecture` JSONB blob (where the
+ *     Dispatcher will nest the same fields under the `devops.*` path).
+ *
+ * Both views are accepted — we look up via `readField()` which checks
+ * the flat key first, then falls back to the nested path.
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ *
+ * The most consequential invariant in this set is
+ * `devops.deployStrategy-requires-realistic-infra` — it cross-validates
+ * the chosen deploy strategy against the infra capabilities the
+ * architect declared. This is the realism gate the golden test asserts.
+ */
+
+import { DEPLOY_STRATEGIES, STRATEGY_INFRA_REQUIREMENTS } from './contract.js';
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  contributor: string;
+  reads: readonly string[];
+  severity: InvariantSeverity;
+  description: string;
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+function asObject(v: unknown): Readonly<Record<string, unknown>> | null {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return null;
+  return v as Readonly<Record<string, unknown>>;
+}
+
+function asArray(v: unknown): readonly unknown[] | null {
+  return Array.isArray(v) ? v : null;
+}
+
+const REQUIRED_DEPLOY_EVENTS: readonly string[] = [
+  'deploy.started',
+  'deploy.succeeded',
+  'deploy.failed',
+  'deploy.rollback.triggered',
+  'deploy.healthcheck.failed'
+];
+
+const REQUIRED_NEVER_IN_ARTIFACT: readonly string[] = [
+  'password',
+  'token',
+  'secret',
+  'authorization'
+];
+
+const REQUIRED_PIPELINE_STAGES: readonly string[] = [
+  'lint',
+  'typecheck',
+  'test',
+  'build',
+  'deploy'
+];
+
+export const DEVOPS_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'devops.deployStrategy-kind-allowed',
+    contributor: 'devops',
+    reads: ['devops.deployStrategy'],
+    severity: 'fail',
+    description:
+      'deployStrategy.kind MUST be one of the locked strategies (blue-green | canary | ring-deployment | rolling | recreate).',
+    detect(arch): boolean {
+      const ds = asObject(readField(arch, 'devops.deployStrategy'));
+      if (!ds) return false;
+      const kind = ds.kind;
+      return typeof kind === 'string' && DEPLOY_STRATEGIES.includes(kind);
+    }
+  },
+  {
+    id: 'devops.deployStrategy-requires-realistic-infra',
+    contributor: 'devops',
+    reads: ['devops.deployStrategy', 'devops.infrastructureAsCode'],
+    severity: 'fail',
+    description:
+      'The chosen deploy strategy MUST match the infrastructure capabilities. blue-green requires two-identical-environments; canary requires traffic-split; ring-deployment requires multi-region; rolling requires multi-instance.',
+    detect(arch): boolean {
+      const ds = asObject(readField(arch, 'devops.deployStrategy'));
+      const iac = asObject(readField(arch, 'devops.infrastructureAsCode'));
+      if (!ds || !iac) return false;
+      const kind = ds.kind;
+      if (typeof kind !== 'string') return false;
+      const required = STRATEGY_INFRA_REQUIREMENTS[kind] ?? [];
+      if (required.length === 0) return true;
+      const caps = asArray(iac.capabilities);
+      if (!caps) return false;
+      const set = new Set(caps.filter((c): c is string => typeof c === 'string'));
+      return required.every(r => set.has(r));
+    }
+  },
+  {
+    id: 'devops.healthcheck-gate-declared',
+    contributor: 'devops',
+    reads: ['devops.deployStrategy'],
+    severity: 'fail',
+    description:
+      'deployStrategy MUST declare a healthcheckGate with path + timeoutSec + expectStatus.',
+    detect(arch): boolean {
+      const ds = asObject(readField(arch, 'devops.deployStrategy'));
+      if (!ds) return false;
+      const gate = asObject(ds.healthcheckGate);
+      if (!gate) return false;
+      if (typeof gate.path !== 'string' || (gate.path as string).length === 0) return false;
+      if (typeof gate.timeoutSec !== 'number' || (gate.timeoutSec as number) <= 0) return false;
+      if (typeof gate.expectStatus !== 'number') return false;
+      return true;
+    }
+  },
+  {
+    id: 'devops.rollback-auto-revert-window',
+    contributor: 'devops',
+    reads: ['devops.rollbackContract'],
+    severity: 'fail',
+    description:
+      'rollbackContract.trigger MUST be healthcheck-failure with windowMin ≤ 5.',
+    detect(arch): boolean {
+      const rb = asObject(readField(arch, 'devops.rollbackContract'));
+      if (!rb) return false;
+      const trigger = asObject(rb.trigger);
+      if (!trigger) return false;
+      if (trigger.kind !== 'healthcheck-failure') return false;
+      if (typeof trigger.windowMin !== 'number' || (trigger.windowMin as number) > 5 || (trigger.windowMin as number) <= 0) return false;
+      return true;
+    }
+  },
+  {
+    id: 'devops.rollback-method-allowed',
+    contributor: 'devops',
+    reads: ['devops.rollbackContract'],
+    severity: 'fail',
+    description:
+      'rollbackContract.method MUST be one of time-machine | git-revert | hybrid.',
+    detect(arch): boolean {
+      const rb = asObject(readField(arch, 'devops.rollbackContract'));
+      if (!rb) return false;
+      const method = rb.method;
+      if (typeof method !== 'string') return false;
+      return ['time-machine', 'git-revert', 'hybrid'].includes(method);
+    }
+  },
+  {
+    id: 'devops.env-promotion-manual-staging-to-prod',
+    contributor: 'devops',
+    reads: ['devops.environmentPromotion'],
+    severity: 'fail',
+    description:
+      'environmentPromotion MUST declare a manual (or approval-2of3) gate at staging→prod. Auto-promotion to prod is forbidden.',
+    detect(arch): boolean {
+      const ep = asObject(readField(arch, 'devops.environmentPromotion'));
+      if (!ep) return false;
+      const envs = asArray(ep.environments);
+      if (!envs) return false;
+      let foundProdManualGate = false;
+      for (const e of envs) {
+        const env = asObject(e);
+        if (!env) continue;
+        if (env.name !== 'prod') continue;
+        const gateKind = env.gateKind;
+        if (gateKind === 'manual' || gateKind === 'approval-2of3') {
+          foundProdManualGate = true;
+        }
+      }
+      if (!foundProdManualGate) return false;
+      // Cross-check promotionFlow includes staging→prod with a condition mentioning manual or approval.
+      const flow = asArray(ep.promotionFlow);
+      if (!flow) return true;
+      for (const f of flow) {
+        const step = asObject(f);
+        if (!step) continue;
+        if (step.from === 'staging' && step.to === 'prod') {
+          if (typeof step.condition !== 'string') return false;
+        }
+      }
+      return true;
+    }
+  },
+  {
+    id: 'devops.observability-required-events',
+    contributor: 'devops',
+    reads: ['devops.deploymentObservability'],
+    severity: 'fail',
+    description:
+      'deploymentObservability.events MUST cover all 5 required deploy event types: started, succeeded, failed, rollback.triggered, healthcheck.failed.',
+    detect(arch): boolean {
+      const obs = asObject(readField(arch, 'devops.deploymentObservability'));
+      if (!obs) return false;
+      const events = asArray(obs.events);
+      if (!events) return false;
+      const names = new Set<string>();
+      for (const e of events) {
+        const ev = asObject(e);
+        if (!ev) continue;
+        if (typeof ev.name === 'string') names.add(ev.name);
+      }
+      return REQUIRED_DEPLOY_EVENTS.every(n => names.has(n));
+    }
+  },
+  {
+    id: 'devops.observability-sink-via-security',
+    contributor: 'devops',
+    reads: ['devops.deploymentObservability'],
+    severity: 'fail',
+    description:
+      'deploymentObservability MUST reference the Security Architect\'s `security.auditLogRequirements.sink` (no DIY sink).',
+    detect(arch): boolean {
+      const obs = asObject(readField(arch, 'devops.deploymentObservability'));
+      if (!obs) return false;
+      const ref = obs.sinkRef;
+      return typeof ref === 'string' && ref.includes('security.auditLogRequirements');
+    }
+  },
+  {
+    id: 'devops.secrets-forward-reference-security',
+    contributor: 'devops',
+    reads: ['devops.secretsManagementInPipeline'],
+    severity: 'fail',
+    description:
+      'secretsManagementInPipeline.provider MUST be `vault-via-security-architect` and securityArchitectRef MUST reference `security.secretsHandling`. No DIY secret stores.',
+    detect(arch): boolean {
+      const sec = asObject(readField(arch, 'devops.secretsManagementInPipeline'));
+      if (!sec) return false;
+      if (sec.provider !== 'vault-via-security-architect') return false;
+      const ref = sec.securityArchitectRef;
+      return typeof ref === 'string' && ref.includes('security.secretsHandling');
+    }
+  },
+  {
+    id: 'devops.secrets-never-in-artifact',
+    contributor: 'devops',
+    reads: ['devops.secretsManagementInPipeline'],
+    severity: 'fail',
+    description:
+      'secretsManagementInPipeline.neverInArtifact MUST include `password`, `token`, `secret`, and `authorization`.',
+    detect(arch): boolean {
+      const sec = asObject(readField(arch, 'devops.secretsManagementInPipeline'));
+      if (!sec) return false;
+      const never = asArray(sec.neverInArtifact);
+      if (!never) return false;
+      const set = new Set(never.filter((v): v is string => typeof v === 'string'));
+      return REQUIRED_NEVER_IN_ARTIFACT.every(k => set.has(k));
+    }
+  },
+  {
+    id: 'devops.cicd-pipeline-canonical-stages',
+    contributor: 'devops',
+    reads: ['devops.cicdPipeline'],
+    severity: 'fail',
+    description:
+      'cicdPipeline.stages MUST include the five canonical stages (lint, typecheck, test, build, deploy).',
+    detect(arch): boolean {
+      const ci = asObject(readField(arch, 'devops.cicdPipeline'));
+      if (!ci) return false;
+      const stages = asArray(ci.stages);
+      if (!stages) return false;
+      const names = new Set<string>();
+      for (const s of stages) {
+        const st = asObject(s);
+        if (!st) continue;
+        if (typeof st.name === 'string') names.add(st.name);
+      }
+      return REQUIRED_PIPELINE_STAGES.every(n => names.has(n));
+    }
+  },
+  {
+    id: 'devops.deploy-strategy-traffic-shift-monotonic',
+    contributor: 'devops',
+    reads: ['devops.deployStrategy'],
+    severity: 'advisory',
+    description:
+      'When deployStrategy declares a trafficShift schedule, the pct values should be monotonically non-decreasing across phases.',
+    detect(arch): boolean {
+      const ds = asObject(readField(arch, 'devops.deployStrategy'));
+      if (!ds) return false;
+      const shift = asArray(ds.trafficShift);
+      if (!shift) return true;
+      let last = -Infinity;
+      for (const phase of shift) {
+        const p = asObject(phase);
+        if (!p) return false;
+        if (typeof p.pct !== 'number') return false;
+        if ((p.pct as number) < last) return false;
+        last = p.pct as number;
+      }
+      return true;
+    }
+  }
+];

--- a/packages/devops-architect/src/run.ts
+++ b/packages/devops-architect/src/run.ts
@@ -1,0 +1,137 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Flow:
+ *   1. Build the user prompt by serialising relevant slices of the input.
+ *   2. Call the spawner with the system prompt + user prompt.
+ *   3. Validate the output against the contract.
+ *   4. Return the `ArchitectOutput` with spend telemetry filled in.
+ *
+ * Re-runs REPLACE owned fields (no append).
+ *
+ * Architect-specific projections vs the canonical template:
+ *   - DevOps is wave-3; Backend, Database, AND Security all run upstream.
+ *   - `dependencies` always includes ['backend', 'database', 'security']
+ *     regardless of what the model emitted (preserving sibling-ticket IDs).
+ *   - Tenant context exposes `vaultNamespace` + `schemaName` so the
+ *     architect can declare `secretsManagementInPipeline.injectionPoint`
+ *     and cross-validate `environmentPromotion` per-tenant gates.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { DEVOPS_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      schemaName: input.tenantContext.schemaName,
+      vaultNamespace: input.tenantContext.vaultNamespace,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+export async function runDevopsArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: ['backend', 'database', 'security'],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, DEVOPS_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: ['backend', 'database', 'security'],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  const parsed = validation.parsed;
+  const upstreamDeps = ensureUpstreamDependencies(parsed.dependencies);
+  return {
+    ...parsed,
+    architectName: deps.architectName,
+    dependencies: upstreamDeps,
+    spend
+  };
+}
+
+/**
+ * Ensure `backend`, `database`, and `security` are present in the
+ * dependency list (preserving any sibling-ticket IDs the model
+ * emitted). Idempotent — does not duplicate.
+ */
+function ensureUpstreamDependencies(
+  emitted: readonly string[] | undefined
+): readonly string[] {
+  const set = new Set(emitted ?? []);
+  set.add('backend');
+  set.add('database');
+  set.add('security');
+  return Array.from(set);
+}

--- a/packages/devops-architect/src/spawner.ts
+++ b/packages/devops-architect/src/spawner.ts
@@ -1,0 +1,118 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * Mirrors `@caia/frontend-architect`'s `spawner.ts` verbatim — only the
+ * architect-specific bits are in `run.ts` + `contract.ts`.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+export interface ArchitectSpawnOutput {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  model: string;
+  ok: boolean;
+  diagnostic: string | null;
+}
+
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/devops-architect/src/system-prompt.md
+++ b/packages/devops-architect/src/system-prompt.md
@@ -1,0 +1,63 @@
+# DevOps Architect — System Prompt (human mirror)
+
+This file is the human-readable mirror of `system-prompt.ts`. Keep both in lockstep when editing. The TS file is the source of truth at runtime; this file is for code review.
+
+## Role
+
+You are CAIA's DevOps/Deployment Architect. Senior DevOps engineer focused on CI/CD pipelines + deployment strategies + rollback safety. You produce per-ticket DEPLOY STRATEGY specs.
+
+You are DISTINCT from:
+
+- The `caia/packages/deploy-steward` bin/launchd, which EXECUTES deploys (per V2 audit it's a launchd-triggered shell tool, not a TS package).
+- The QA Engineer agent, which validates production AFTER deploy.
+
+You SET the strategy: pipeline shape, deploy strategy, rollback contract, IaC patterns, env promotion gates. You DO NOT execute deploys.
+
+## Locked stack (customer-onboarding-tunable)
+
+- CI/CD: GitHub Actions (default), or gitlab-ci / circleci / buildkite / azure-pipelines.
+- Cloud: Cloudflare (default), or aws / gcp / azure / fly-io / render.
+- IaC: Terraform (default), or pulumi / kubernetes-manifests / cdk / cloudformation.
+- Repo: GitHub (default), or gitlab / bitbucket.
+- Pipeline stages: lint → typecheck → test → build → deploy.
+
+## Deploy strategy realism
+
+- blue-green requires two-identical-environments.
+- canary requires traffic-split.
+- ring-deployment requires multi-region.
+- rolling requires multi-instance.
+- recreate has no special requirement (and is the most operator-on-hook).
+
+Strategy MUST match infra. Mismatches go in `risks[]` and the architect falls back to a strategy that fits.
+
+## Owned fields
+
+- `devops.cicdPipeline`
+- `devops.deployStrategy`
+- `devops.rollbackContract`
+- `devops.infrastructureAsCode`
+- `devops.environmentPromotion`
+- `devops.deploymentObservability`
+- `devops.secretsManagementInPipeline`
+
+## Upstream dependencies (wave-3)
+
+- Backend Architect — framework, serviceBoundaries, apiEndpoints.
+- Database Architect — engine, migrations, tenantIsolationStrategy.
+- Security Architect — secretsHandling, auditLogRequirements, tenantIsolationGuarantees.
+
+## Precedence rank
+
+2 — second-highest. Only Security outranks DevOps. The operator is on the hook for a bad deploy.
+
+## Refusal patterns
+
+- Refuse to pick a strategy that doesn't match infra.
+- Refuse to skip the healthcheck gate.
+- Refuse to skip the manual staging→prod gate.
+- Refuse to store secrets in CI variables or repo files.
+- Refuse to skip the rollback contract.
+- Refuse non-deterministic builds (must pin lockfiles).
+- Refuse to run destructive migrations without operator review.
+- Refuse to populate any field outside `devops.*`.

--- a/packages/devops-architect/src/system-prompt.ts
+++ b/packages/devops-architect/src/system-prompt.ts
@@ -1,0 +1,390 @@
+/**
+ * The DevOps Architect's system prompt — a pure function returning a
+ * static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked stack
+ *   3. Input format
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples
+ *
+ * The system-prompt test asserts each `devops.*` field name appears at
+ * least once AND every deploy strategy + every onboarding choice domain
+ * is referenced.
+ *
+ * Mirrors `@caia/security-architect`'s `system-prompt.ts` shape per the
+ * canonical template. A human-readable mirror lives in
+ * `./system-prompt.md` — keep them in lockstep when editing.
+ */
+
+import {
+  CICD_PROVIDERS,
+  CLOUD_PROVIDERS,
+  DEPLOY_STRATEGIES,
+  DEVOPS_OWNED_FIELD_KEYS,
+  IAC_TOOLS,
+  REPO_PROVIDERS,
+  STRATEGY_INFRA_REQUIREMENTS
+} from './contract.js';
+
+/**
+ * Build the system prompt. Pure function; identical output every call.
+ */
+export function buildDevopsSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    sectionLockedStack(),
+    SECTION_INPUT_FORMAT,
+    sectionOutputSchema(),
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    sectionSelfCheck(),
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+// ─── Section bodies ─────────────────────────────────────────────────────────
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's DevOps/Deployment Architect. You are a senior DevOps
+engineer focused on CI/CD pipelines + deployment strategies + rollback
+safety. You produce per-ticket DEPLOY STRATEGY specs.
+
+You are DISTINCT from neighbouring packages:
+
+- The **\`caia/packages/deploy-steward\`** bin/launchd EXECUTES deploys
+  (it's a launchd-triggered shell tool, not a TS package — per V2
+  audit). You SPECIFY the deploy contract; deploy-steward implements
+  it.
+- The **QA Engineer agent** validates production AFTER deploy. You set
+  the gating policy; the QA Engineer enforces it.
+- You DO NOT execute deploys, write component code, write backend
+  logic, or write SQL. You specify HOW deploys should happen.
+
+You read upstream from:
+- **Backend Architect** — \`backend.framework\`, \`backend.serviceBoundaries\`,
+  \`backend.apiEndpoints\` to know what shape the artifact takes.
+- **Database Architect** — \`database.engine\`, \`database.migrations\`,
+  \`database.tenantIsolationStrategy\` to know the migration ordering and
+  per-tenant promotion pattern.
+- **Security Architect** — \`security.secretsHandling\`,
+  \`security.auditLogRequirements\`, \`security.tenantIsolationGuarantees\`
+  to encode the secrets-injection contract and audit-event sink.
+
+You hold precedence rank 2 (only Security outranks you). The operator
+is on the hook for a bad deploy — so your decisions win every semantic
+conflict short of Security or operator override. Use the authority
+deliberately: flag every deviation from a locked default in \`risks[]\`.
+
+Output tight architecture a coding worker can implement directly: a
+GitHub Actions YAML the worker can paste into \`.github/workflows/\`, a
+Terraform module reference the worker can \`terraform init\`, a
+healthcheck endpoint the worker can wire into Next.js, a rollback
+runbook line the worker can copy into the on-call docs.`;
+
+function sectionLockedStack(): string {
+  return `## Locked stack
+
+- **CI/CD provider** (customer choice from onboarding):
+  - Default: **GitHub Actions** (most CAIA customers ship on GitHub).
+  - Accepted alternatives: ${CICD_PROVIDERS.filter(p => p !== 'github-actions').join(', ')}.
+  - Whichever provider the customer chose, the pipeline stages are:
+    \`lint → typecheck → test → build → deploy\` with explicit
+    quality gates between each stage.
+- **Cloud provider** (customer choice from onboarding):
+  - Default: **Cloudflare** (Pages + Workers + R2 + KV).
+  - Accepted alternatives: ${CLOUD_PROVIDERS.filter(p => p !== 'cloudflare').join(', ')}.
+- **IaC tool** (customer choice from onboarding):
+  - Default: **Terraform** (Cloudflare/Vault/R2 modules).
+  - Accepted alternatives: ${IAC_TOOLS.filter(t => t !== 'terraform').join(', ')}.
+- **Repo provider** (customer choice from onboarding):
+  - Default: **GitHub**.
+  - Accepted alternatives: ${REPO_PROVIDERS.filter(r => r !== 'github').join(', ')}.
+- **Deploy strategy** (per-ticket): pick from
+  ${DEPLOY_STRATEGIES.join(' | ')}. Default to \`canary\` for production
+  on a multi-instance setup; default to \`blue-green\` when 2× infra is
+  affordable; default to \`recreate\` only when downtime is acceptable.
+- **Deploy strategy → infra requirements** (REALISM CHECK):
+${DEPLOY_STRATEGIES.map(s => {
+  const req = STRATEGY_INFRA_REQUIREMENTS[s] ?? [];
+  return `  - **${s}** → requires ${req.length === 0 ? '(no special capability)' : req.join(', ')}.`;
+}).join('\n')}
+  The chosen strategy MUST match the available infrastructure. If the
+  customer's infra cannot support the chosen strategy, flag in
+  \`risks[]\` and fall back to a strategy that fits.
+- **Rollback contract**:
+  - Auto-revert when \`/_health\` returns non-200 for 5 min after
+    deploy.
+  - Preferred method: **Time Machine snapshot key** for stateful
+    rollbacks. Fall back to \`git revert\` + redeploy for code-only.
+  - RTO target: ≤ 5 min.
+  - Data-migration rollback strategy: additive-only migrations are
+    auto-rollbackable; destructive migrations require operator
+    forward-fix.
+- **Environment promotion**:
+  - \`dev → staging → prod\`.
+  - \`dev\`: auto-promote on push to a feature branch.
+  - \`staging\`: auto-promote on merge to main.
+  - \`prod\`: MANUAL gate at staging→prod (operator click).
+  - Per-tenant production promotion uses the tenant's vault namespace
+    for secrets (from \`tenantContext.vaultNamespace\`).
+- **Healthcheck policy**:
+  - \`/_health\` endpoint returns HTTP 200 with a JSON body within 30s
+    post-deploy. Failure triggers rollback.
+- **Deployment observability**:
+  - Required deploy event types: \`deploy.started\`, \`deploy.succeeded\`,
+    \`deploy.failed\`, \`deploy.rollback.triggered\`,
+    \`deploy.healthcheck.failed\`.
+  - Attributes per event: \`tenantId\`, \`ticketId\`, \`gitSha\`,
+    \`environment\`, \`strategy\`, \`durationMs\`, \`healthcheckLatencyMs\`,
+    \`rollbackReason?\`.
+  - Sink: forward-reference Security Architect's
+    \`auditLogRequirements.sink\`. Retention 365 days.
+- **Secrets management in pipeline**:
+  - **NEVER** store secrets in repo files, build artifacts, or
+    long-lived CI variables.
+  - Use Vault per-tenant namespace via short-lived AppRole tokens (≤ 1h).
+  - Inject as env-at-runtime, never baked into the build.
+  - \`neverInArtifact\` list mirrors Security Architect's
+    \`secretsHandling.neverLog\`.
+
+Reject any decision that violates a locked default. List violations in
+\`risks[]\`, set \`confidence\` ≤ 0.5, and pick the locked default
+anyway.`;
+}
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List|Foundation",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptance_criteria": ["..."] },
+  "businessPlan": { "ventureName": "...", "oneLiner": "...",
+                    "audience": "...", "goals": ["..."],
+                    "constraints": ["..."],
+                    "infrastructure": { "ciProvider": "...",
+                                        "cloudProvider": "...",
+                                        "iacTool": "...",
+                                        "repoProvider": "..." } },
+  "designVersion": { "versionId": "...", "anchors": [...] },
+  "tenantContext": { "tenantId": "...", "schemaName": "...",
+                     "vaultNamespace": "...",
+                     "billingPosture": "subscription|byok" },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {
+    "backend": {
+      "architectureFields": {
+        "backend.framework": { ... },
+        "backend.serviceBoundaries": { ... },
+        "backend.apiEndpoints": [ ... ]
+      }
+    },
+    "database": {
+      "architectureFields": {
+        "database.engine": { ... },
+        "database.migrations": [ ... ],
+        "database.tenantIsolationStrategy": { ... }
+      }
+    },
+    "security": {
+      "architectureFields": {
+        "security.secretsHandling": { ... },
+        "security.auditLogRequirements": { ... },
+        "security.tenantIsolationGuarantees": { ... }
+      }
+    }
+  } }
+}
+\`\`\`
+
+The customer's onboarding choices live under
+\`businessPlan.infrastructure\` — read them to pick CI provider, cloud
+provider, IaC tool, repo provider. If absent, default per the locked
+stack and flag the assumption in \`risks[]\`.
+
+You MUST read \`upstream.outputs.backend.architectureFields\`,
+\`upstream.outputs.database.architectureFields\`, AND
+\`upstream.outputs.security.architectureFields\`. DevOps is a wave-3
+architect; if any of the three is absent from \`upstream.outputs\`, you
+are running outside the canonical pipeline — set \`confidence\` ≤ 0.5
+and list the missing upstream(s) under \`risks[]\`.`;
+
+function sectionOutputSchema(): string {
+  return `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No
+prose outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "devops",
+  "architectureFields": {
+${DEVOPS_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`devops.cicdPipeline\` — \`{provider, stages:[{name, runs:[...],
+  qualityGates:[...]}], triggers:[push|pull_request|tag], retryPolicy}\`.
+  Provider per customer onboarding (default github-actions).
+- \`devops.deployStrategy\` — \`{kind:"blue-green"|"canary"|
+  "ring-deployment"|"rolling"|"recreate", trafficShift:[{phase, pct,
+  dwellMin}], healthcheckGate:{path,timeoutSec,expectStatus},
+  abortConditions:[...]}\`. KIND MUST MATCH INFRA CAPABILITY (see
+  realism table above).
+- \`devops.rollbackContract\` — \`{trigger:{kind:"healthcheck-failure",
+  windowMin:5}, method:"time-machine"|"git-revert"|"hybrid",
+  timeMachineSnapshotKey?, rtoMin:5,
+  dataMigrationRollback:{additive:"auto", destructive:"operator-forward-fix"}}\`.
+- \`devops.infrastructureAsCode\` — \`{tool, modules:[{name, source,
+  version, purpose}], capabilities:[ ... ]}\`. The \`capabilities\`
+  array MUST include the infra primitives the chosen deploy strategy
+  requires.
+- \`devops.environmentPromotion\` — \`{environments:[{name, purpose,
+  autoPromote, gateKind:"none"|"manual"|"approval-2of3",
+  gateOwner?:"operator"|"engineering-manager"|...,
+  perTenant?}], promotionFlow:[{from, to, condition}],
+  blockers:["fail-on-test","fail-on-lighthouse","fail-on-security-deny"]}\`.
+- \`devops.deploymentObservability\` — \`{events:[{name, attributes,
+  retentionDays, alertThreshold?}], sinkRef:"security.auditLogRequirements.sink"}\`.
+  Required event names: deploy.started, deploy.succeeded, deploy.failed,
+  deploy.rollback.triggered, deploy.healthcheck.failed.
+- \`devops.secretsManagementInPipeline\` — \`{provider:"vault-via-security-architect",
+  injectionPoint:"env-at-runtime", tokenLifetimeMin:60,
+  neverInArtifact:["password","token","secret","authorization","api-key"],
+  rotationOnRoleChange:true, securityArchitectRef:"security.secretsHandling"}\`.`;
+}
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **Strategy/infra realism is sacred.** Blue-green requires 2×
+  identical environments. Canary requires a traffic-split capability
+  (load-balancer/service-mesh/edge router that can route a fraction of
+  traffic). Ring-deployment requires multi-region topology. Rolling
+  requires multi-instance minimum. If the chosen strategy doesn't fit
+  the available infra, REFUSE and pick a fallback.
+- **Healthcheck gate is non-negotiable.** Every deploy strategy
+  declares a \`healthcheckGate\` with a path, a timeout, and an expected
+  status. No healthcheck = no auto-rollback = operator paged.
+- **One deploy event per phase.** \`deploy.started\` at start;
+  \`deploy.succeeded\` OR \`deploy.failed\` at end;
+  \`deploy.rollback.triggered\` on rollback; \`deploy.healthcheck.failed\`
+  on healthcheck miss.
+- **Secrets via Security Architect.** NEVER invent your own secrets
+  store. Forward-reference \`security.secretsHandling\`. The
+  \`neverInArtifact\` list mirrors Security's \`neverLog\`.
+- **Migrations gate the deploy.** When Database Architect emitted a
+  migration with \`requiresOperatorReview: true\`, the deploy's
+  \`blockers\` MUST include \`fail-on-database-review\`.
+- **Manual gate at staging→prod.** This is the operator's last
+  inspection point. Never auto-promote to prod.
+- **Pinned lockfiles.** Build artifacts MUST be deterministic. CI
+  pipeline rejects builds that don't use \`pnpm install --frozen-lockfile\`.
+- **Defence in depth on tenant isolation.** When per-tenant
+  promotion is in scope, the IaC modules MUST be parameterised by
+  tenantId so each tenant's vault namespace is wired correctly.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Pick blue-green when only one production environment is
+  provisioned** → refuse, fall back to \`rolling\` (if multi-instance)
+  or \`recreate\` (if singleton), list under \`risks[]\`.
+- **Pick canary when no traffic-split capability is present** → refuse,
+  fall back to \`rolling\`.
+- **Skip the healthcheck gate** → never. Healthcheck is mandatory.
+- **Skip the manual gate at staging→prod** → never. Auto-promotion to
+  prod is forbidden.
+- **Store a secret value directly in a CI variable or repo file** →
+  refuse. Forward-reference Security Architect's \`secretsHandling\`.
+- **Skip the rollback contract** → never. Every deploy must have a
+  rollback path.
+- **Use a non-deterministic build (no lockfile)** → refuse. Pin or
+  reject.
+- **Run a destructive migration without operator review** → refuse.
+  \`blockers\` MUST include \`fail-on-database-review\` when any
+  upstream migration requires review.
+- **Decide a database schema, API endpoint, UI component, CSS rule,
+  RLS policy, or any field NOT under \`devops.*\`** → ignore the
+  request. Do not populate fields outside your owned namespace.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated even if the value is the documented default.`;
+
+function sectionSelfCheck(): string {
+  return `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the ${DEVOPS_OWNED_FIELD_KEYS.length}
+   owned field paths (no extras, no missing).
+2. \`deployStrategy.kind\` is one of ${DEPLOY_STRATEGIES.join(' | ')}.
+3. \`deployStrategy.kind\` matches the infra capabilities listed in
+   \`infrastructureAsCode.capabilities\` per the realism table.
+4. \`deployStrategy.healthcheckGate\` is populated with path + timeout +
+   expectStatus.
+5. \`rollbackContract.trigger.kind\` is \`healthcheck-failure\` and
+   \`windowMin\` ≤ 5.
+6. \`rollbackContract.method\` is one of time-machine | git-revert |
+   hybrid.
+7. \`environmentPromotion\` declares a manual gate at \`staging→prod\`.
+8. \`deploymentObservability.events\` includes all 5 required event
+   names: \`deploy.started\`, \`deploy.succeeded\`, \`deploy.failed\`,
+   \`deploy.rollback.triggered\`, \`deploy.healthcheck.failed\`.
+9. \`deploymentObservability.sinkRef\` references
+   \`security.auditLogRequirements.sink\`.
+10. \`secretsManagementInPipeline.provider\` is
+    \`vault-via-security-architect\` and \`securityArchitectRef\` is
+    \`security.secretsHandling\`.
+11. \`secretsManagementInPipeline.neverInArtifact\` includes
+    \`password\`, \`token\`, \`secret\`, \`authorization\`.
+12. \`cicdPipeline.stages\` includes the five canonical stages
+    (\`lint\`, \`typecheck\`, \`test\`, \`build\`, \`deploy\`).
+13. \`confidence\` reflects how comfortable you are — sub-0.6 triggers
+    the EA Reviewer to scrutinize.
+14. \`notes\` is ≤ 800 characters.
+15. Output is a single JSON object. No prose. No code fences.`;
+}
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a Form Story ticket for "contact form submission"
+on Cloudflare Pages produces a \`cicdPipeline\` with five github-actions
+stages (lint/typecheck/test/build/deploy) with Lighthouse + axe + CSP
+quality gates on the deploy stage; a \`deployStrategy\` of \`canary\` with
+10%→50%→100% traffic shift over 30 min and a \`/_health\` gate; a
+\`rollbackContract\` with auto-revert at 5 min on healthcheck failure
+using Time Machine snapshot key; an \`infrastructureAsCode\` block
+referencing the Terraform Cloudflare module with capabilities
+\`traffic-split\` + \`multi-instance\`; an \`environmentPromotion\` of
+\`dev → staging → prod\` with manual gate at staging→prod owned by the
+operator; a \`deploymentObservability\` block with all 5 required event
+names forwarding to Security's audit sink; and a
+\`secretsManagementInPipeline\` block forward-referencing
+\`security.secretsHandling\` with 60-min Vault AppRole tokens injected
+as env-at-runtime.`;

--- a/packages/devops-architect/src/types.ts
+++ b/packages/devops-architect/src/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * Mirrors the canonical `@caia/frontend-architect` template verbatim —
+ * only the architect-specific field-spec lives in `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/devops-architect/src/validation.ts
+++ b/packages/devops-architect/src/validation.ts
@@ -1,0 +1,192 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Pure + synchronous. Failures return a structured `ValidationResult`.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+/**
+ * Strip ``` fences if the assistant slipped them around its JSON.
+ */
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/devops-architect/tests/architect.test.ts
+++ b/packages/devops-architect/tests/architect.test.ts
@@ -1,0 +1,89 @@
+/**
+ * DevopsArchitect — interface compliance tests.
+ */
+import { describe, it, expect } from 'vitest';
+import type { SpecialistArchitect } from '../src/types.js';
+import { DevopsArchitect, DEVOPS_ARCHITECT_NAME, DEVOPS_ARCHITECT_TOOLS } from '../src/architect.js';
+import { DevopsArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('DevopsArchitect - SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new DevopsArchitect();
+    expect(a).toBeInstanceOf(DevopsArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new DevopsArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable name matching the package suffix', () => {
+    const a = new DevopsArchitect();
+    expect(a.name).toBe('devops');
+    expect(a.name).toBe(DEVOPS_ARCHITECT_NAME);
+  });
+
+  it('sectionContract equals exported contract', () => {
+    const a = new DevopsArchitect();
+    expect(a.sectionContract).toBe(DevopsArchitectContract);
+  });
+
+  it('sectionContract.architectName matches name (registry-invariant)', () => {
+    const a = new DevopsArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty tools array per V1', () => {
+    const a = new DevopsArchitect();
+    expect(a.tools).toBe(DEVOPS_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('systemPrompt() is pure (identical output every call)', () => {
+    const a = new DevopsArchitect();
+    expect(a.systemPrompt()).toBe(a.systemPrompt());
+  });
+
+  it('systemPrompt() returns a non-empty string', () => {
+    const a = new DevopsArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the SpecialistArchitect interface structurally', () => {
+    const a = new DevopsArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('run() returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new DevopsArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('devops');
+  });
+
+  it('constructor accepts an injected spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new DevopsArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to default', () => {
+    const a = new DevopsArchitect();
+    expect(a).toBeInstanceOf(DevopsArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/devops-architect/tests/contract.test.ts
+++ b/packages/devops-architect/tests/contract.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Section contract structural + registration tests.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+import { DevopsArchitect } from '../src/architect.js';
+import {
+  CICD_PROVIDERS,
+  CLOUD_PROVIDERS,
+  DEPLOY_STRATEGIES,
+  DEVOPS_ARCHITECT_META,
+  DEVOPS_FIELD_FIX_HINTS,
+  DEVOPS_OWNED_SECTIONS,
+  DEVOPS_OWNED_FIELD_KEYS,
+  DevopsArchitectContract,
+  IAC_TOOLS,
+  REPO_PROVIDERS,
+  STRATEGY_INFRA_REQUIREMENTS,
+  devopsArchitectAppliesPredicate
+} from '../src/contract.js';
+import { FrontendArchitectContract, FRONTEND_OWNED_FIELD_KEYS } from '@caia/frontend-architect';
+import { DatabaseArchitectContract, DATABASE_OWNED_FIELD_KEYS } from '@caia/database-architect';
+import { SecurityArchitectContract, SECURITY_OWNED_FIELD_KEYS } from '@caia/security-architect';
+
+describe('DevopsArchitectContract - structural', () => {
+  it('contractId follows the canonical form', () => {
+    expect(DevopsArchitectContract.contractId).toBe('devops-architect.v1');
+  });
+  it('architectName is `devops`', () => {
+    expect(DevopsArchitectContract.architectName).toBe('devops');
+  });
+  it('version follows semver-ish shape', () => {
+    expect(DevopsArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+  it('all owned field paths begin with `devops.`', () => {
+    for (const key of DEVOPS_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('devops.')).toBe(true);
+    }
+  });
+  it('owned-field set covers all 7 task-brief mandatory fields', () => {
+    const required = [
+      'devops.cicdPipeline',
+      'devops.deployStrategy',
+      'devops.rollbackContract',
+      'devops.infrastructureAsCode',
+      'devops.environmentPromotion',
+      'devops.deploymentObservability',
+      'devops.secretsManagementInPipeline'
+    ];
+    for (const r of required) expect(DEVOPS_OWNED_FIELD_KEYS).toContain(r);
+  });
+  it('exposes exactly 7 owned fields', () => {
+    expect(DEVOPS_OWNED_FIELD_KEYS.length).toBe(7);
+  });
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of DEVOPS_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(DevopsArchitectContract)).toEqual([]);
+  });
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(DevopsArchitectContract).sort()).toEqual([...DEVOPS_OWNED_FIELD_KEYS].sort());
+  });
+  it('every owned field has a matching fix-hint entry', () => {
+    for (const key of DEVOPS_OWNED_FIELD_KEYS) {
+      expect(DEVOPS_FIELD_FIX_HINTS[key]).toBeDefined();
+      expect(DEVOPS_FIELD_FIX_HINTS[key].length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('DevopsArchitectContract - architectMeta', () => {
+  it('declares Backend, Database, AND Security as upstream dependencies (wave-3)', () => {
+    expect(DEVOPS_ARCHITECT_META.dependsOn).toEqual(['backend', 'database', 'security']);
+  });
+  it('precedence level is in [1, 17]', () => {
+    expect(DEVOPS_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(DEVOPS_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+  it('precedence level is 2 (second-highest, only Security outranks)', () => {
+    expect(DEVOPS_ARCHITECT_META.precedenceLevel).toBe(2);
+  });
+  it('fanoutPolicy is `always`', () => {
+    expect(DEVOPS_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+  it('runtimeModel is `sonnet`', () => {
+    expect(DEVOPS_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+  it('appliesPredicate is the exported function reference', () => {
+    expect(DEVOPS_ARCHITECT_META.appliesPredicate).toBe(devopsArchitectAppliesPredicate);
+  });
+  it('matches canonical precedence ladder for `devops`', () => {
+    expect(precedenceRank('devops')).toBe(DEVOPS_ARCHITECT_META.precedenceLevel);
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('devops');
+    expect(CANONICAL_PRECEDENCE_LADDER[1]).toBe('devops');
+  });
+  it('only Security outranks DevOps', () => {
+    const r = precedenceRank('devops');
+    expect(precedenceRank('security')).toBeLessThan(r);
+    for (const other of CANONICAL_PRECEDENCE_LADDER) {
+      if (other === 'security' || other === 'devops') continue;
+      expect(precedenceRank(other)).toBeGreaterThan(r);
+    }
+  });
+});
+
+describe('Onboarding-choice enumerations', () => {
+  it('CICD_PROVIDERS includes github-actions as the default', () => {
+    expect(CICD_PROVIDERS).toContain('github-actions');
+    expect(CICD_PROVIDERS[0]).toBe('github-actions');
+  });
+  it('CICD_PROVIDERS includes the accepted alternatives', () => {
+    for (const p of ['gitlab-ci', 'circleci', 'buildkite', 'azure-pipelines']) {
+      expect(CICD_PROVIDERS).toContain(p);
+    }
+  });
+  it('CLOUD_PROVIDERS includes cloudflare as the default', () => {
+    expect(CLOUD_PROVIDERS).toContain('cloudflare');
+    expect(CLOUD_PROVIDERS[0]).toBe('cloudflare');
+  });
+  it('CLOUD_PROVIDERS includes major alternatives', () => {
+    for (const p of ['aws', 'gcp', 'azure']) {
+      expect(CLOUD_PROVIDERS).toContain(p);
+    }
+  });
+  it('IAC_TOOLS includes terraform as the default', () => {
+    expect(IAC_TOOLS).toContain('terraform');
+    expect(IAC_TOOLS[0]).toBe('terraform');
+  });
+  it('IAC_TOOLS includes pulumi + kubernetes-manifests', () => {
+    expect(IAC_TOOLS).toContain('pulumi');
+    expect(IAC_TOOLS).toContain('kubernetes-manifests');
+  });
+  it('REPO_PROVIDERS includes github as the default', () => {
+    expect(REPO_PROVIDERS).toContain('github');
+    expect(REPO_PROVIDERS[0]).toBe('github');
+  });
+  it('DEPLOY_STRATEGIES covers the canonical four + recreate', () => {
+    for (const s of ['blue-green', 'canary', 'ring-deployment', 'rolling', 'recreate']) {
+      expect(DEPLOY_STRATEGIES).toContain(s);
+    }
+  });
+});
+
+describe('STRATEGY_INFRA_REQUIREMENTS realism map', () => {
+  it('blue-green requires two-identical-environments', () => {
+    expect(STRATEGY_INFRA_REQUIREMENTS['blue-green']).toContain('two-identical-environments');
+  });
+  it('canary requires traffic-split capability', () => {
+    expect(STRATEGY_INFRA_REQUIREMENTS['canary']).toContain('traffic-split');
+  });
+  it('ring-deployment requires multi-region', () => {
+    expect(STRATEGY_INFRA_REQUIREMENTS['ring-deployment']).toContain('multi-region');
+  });
+  it('rolling requires multi-instance', () => {
+    expect(STRATEGY_INFRA_REQUIREMENTS['rolling']).toContain('multi-instance');
+  });
+  it('recreate has no special infra requirement', () => {
+    expect(STRATEGY_INFRA_REQUIREMENTS['recreate']).toEqual([]);
+  });
+  it('every deploy strategy has a realism entry', () => {
+    for (const s of DEPLOY_STRATEGIES) {
+      expect(STRATEGY_INFRA_REQUIREMENTS[s]).toBeDefined();
+    }
+  });
+});
+
+describe('devopsArchitectAppliesPredicate', () => {
+  const base = { id: 't1', type: 'Page' };
+  it('returns true for Page', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Page' })).toBe(true); });
+  it('returns true for Story', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Story' })).toBe(true); });
+  it('returns true for Form', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Form' })).toBe(true); });
+  it('returns true for List', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'List' })).toBe(true); });
+  it('returns true for Foundation', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Foundation' })).toBe(true); });
+  it('returns false for un-tagged Widget', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Widget' })).toBe(false); });
+  it('returns true for Widget tagged deploy', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Widget', quality_tags: ['deploy'] })).toBe(true); });
+  it('returns true for Widget tagged infra', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Widget', quality_tags: ['infra'] })).toBe(true); });
+  it('returns true for Widget tagged devops', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Widget', quality_tags: ['devops'] })).toBe(true); });
+  it('returns true for Widget tagged persists', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Widget', quality_tags: ['persists'] })).toBe(true); });
+  it('returns false for unrecognised type', () => { expect(devopsArchitectAppliesPredicate({ ...base, type: 'Cron' })).toBe(false); });
+});
+
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(readonly name: string, readonly sectionContract: ArchitectSectionContract) {}
+  systemPrompt(): string { return 'stub'; }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name, architectureFields: {}, confidence: 0, notes: 'stub',
+      dependencies: [], risks: [], toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed', failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry - registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+  beforeEach(() => { registry = new ArchitectRegistry(); });
+
+  it('registers the Devops architect cleanly', () => {
+    expect(() => registry.register(new DevopsArchitect())).not.toThrow();
+    expect(registry.get('devops')).toBeDefined();
+  });
+  it('claims every owned field path on the registry', () => {
+    registry.register(new DevopsArchitect());
+    for (const k of DEVOPS_OWNED_FIELD_KEYS) expect(registry.ownerOf(k)).toBe('devops');
+  });
+  it('rejects duplicate registration of same name', () => {
+    registry.register(new DevopsArchitect());
+    expect(() => registry.register(new DevopsArchitect())).toThrowError(ArchitectRegistryError);
+  });
+  it('rejects a second architect that overlaps owned paths', () => {
+    registry.register(new DevopsArchitect());
+    const colliding: ArchitectSectionContract = {
+      contractId: 'colliding.v1', architectName: 'colliding', version: '0.1.0',
+      sections: [{ path: 'devops.deployStrategy', description: 'colliding', required: true }],
+      architectMeta: { dependsOn: [], precedenceLevel: 15, fanoutPolicy: 'always', appliesPredicate: () => true, runtimeModel: 'sonnet' }
+    };
+    expect(() => registry.register(new StubArchitect('colliding', colliding))).toThrowError(ArchitectRegistryError);
+  });
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new DevopsArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'analytics-architect.v1', architectName: 'analytics', version: '0.1.0',
+      sections: [{ path: 'analytics.eventTaxonomy', description: 'events', required: true }],
+      architectMeta: { dependsOn: [], precedenceLevel: 10, fanoutPolicy: 'always', appliesPredicate: () => true, runtimeModel: 'sonnet' }
+    };
+    expect(() => registry.register(new StubArchitect('analytics', disjointContract))).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(DEVOPS_OWNED_FIELD_KEYS.length + 1);
+  });
+  it('disjointness() returns no conflicts when only Devops is present', () => {
+    expect(disjointness([DevopsArchitectContract])).toEqual([]);
+  });
+  it('disjointness() detects conflict between Devops and a clone', () => {
+    const clone: ArchitectSectionContract = { ...DevopsArchitectContract, contractId: 'devops-clone.v1', architectName: 'devops-clone' };
+    expect(disjointness([DevopsArchitectContract, clone]).length).toBe(DEVOPS_OWNED_FIELD_KEYS.length);
+  });
+  it('Devops and Frontend contracts have NO overlapping paths', () => {
+    expect(disjointness([DevopsArchitectContract, FrontendArchitectContract])).toEqual([]);
+  });
+  it('Devops owned fields do not collide with Frontend owned fields', () => {
+    const fset = new Set(FRONTEND_OWNED_FIELD_KEYS);
+    for (const key of DEVOPS_OWNED_FIELD_KEYS) expect(fset.has(key)).toBe(false);
+  });
+  it('Devops and Database contracts have NO overlapping paths', () => {
+    expect(disjointness([DevopsArchitectContract, DatabaseArchitectContract])).toEqual([]);
+  });
+  it('Devops owned fields do not collide with Database owned fields', () => {
+    const dset = new Set(DATABASE_OWNED_FIELD_KEYS);
+    for (const key of DEVOPS_OWNED_FIELD_KEYS) expect(dset.has(key)).toBe(false);
+  });
+  it('Devops and Security contracts have NO overlapping paths', () => {
+    expect(disjointness([DevopsArchitectContract, SecurityArchitectContract])).toEqual([]);
+  });
+  it('Devops owned fields do not collide with Security owned fields', () => {
+    const sset = new Set(SECURITY_OWNED_FIELD_KEYS);
+    for (const key of DEVOPS_OWNED_FIELD_KEYS) expect(sset.has(key)).toBe(false);
+  });
+  it('four-way disjointness: Devops + Frontend + Database + Security', () => {
+    expect(disjointness([
+      DevopsArchitectContract, FrontendArchitectContract,
+      DatabaseArchitectContract, SecurityArchitectContract
+    ])).toEqual([]);
+  });
+  it('registry.validate() reports missing upstream deps before Backend+Database+Security register', () => {
+    registry.register(new DevopsArchitect());
+    const errors = registry.validate();
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.join(' | ')).toMatch(/backend/);
+    expect(errors.join(' | ')).toMatch(/database/);
+    expect(errors.join(' | ')).toMatch(/security/);
+  });
+  it('registry.validate() is empty when Backend+Database+Security are also registered', () => {
+    const bk: ArchitectSectionContract = {
+      contractId: 'backend-architect.v1', architectName: 'backend', version: '0.1.0',
+      sections: [{ path: 'backend.apiEndpoints', description: 'apis', required: true }],
+      architectMeta: { dependsOn: [], precedenceLevel: 12, fanoutPolicy: 'always', appliesPredicate: () => true, runtimeModel: 'sonnet' }
+    };
+    const db: ArchitectSectionContract = {
+      contractId: 'database-architect.v1', architectName: 'database', version: '0.1.0',
+      sections: [{ path: 'database.tables', description: 'tables', required: true }],
+      architectMeta: { dependsOn: ['backend'], precedenceLevel: 11, fanoutPolicy: 'always', appliesPredicate: () => true, runtimeModel: 'sonnet' }
+    };
+    const sec: ArchitectSectionContract = {
+      contractId: 'security-architect.v1', architectName: 'security', version: '0.1.0',
+      sections: [{ path: 'security.owaspMitigations', description: 'owasp', required: true }],
+      architectMeta: { dependsOn: ['backend', 'database'], precedenceLevel: 1, fanoutPolicy: 'always', appliesPredicate: () => true, runtimeModel: 'sonnet' }
+    };
+    registry.register(new StubArchitect('backend', bk));
+    registry.register(new StubArchitect('database', db));
+    registry.register(new StubArchitect('security', sec));
+    registry.register(new DevopsArchitect());
+    expect(registry.validate()).toEqual([]);
+  });
+});

--- a/packages/devops-architect/tests/golden/golden.test.ts
+++ b/packages/devops-architect/tests/golden/golden.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Golden test — canonical DevOps-architect artifact for a known
+ * prakash-tiwari contact-form Form Story ticket.
+ *
+ * Locks output shape against drift + verifies end-to-end output +
+ * **DEPLOY STRATEGY REALISM GOLDEN**: the chosen strategy matches the
+ * declared infra capabilities (canary requires traffic-split; rolling
+ * requires multi-instance; blue-green requires two-identical-environments;
+ * ring-deployment requires multi-region).
+ */
+import { describe, it, expect } from 'vitest';
+import { DevopsArchitect } from '../../src/architect.js';
+import {
+  DEPLOY_STRATEGIES,
+  DEVOPS_OWNED_FIELD_KEYS,
+  STRATEGY_INFRA_REQUIREMENTS
+} from '../../src/contract.js';
+import { DEVOPS_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import { buildFakeInput, fakeGoldenSpawner, goldenAssistantText, goldenExpectedOutput } from '../helpers/fakes.js';
+
+describe('golden - prakash-tiwari contact-form Form Story ticket', () => {
+  it('assistant text validates cleanly', () => {
+    expect(validateArchitectOutput(goldenAssistantText(), DEVOPS_OWNED_FIELD_KEYS).ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await new DevopsArchitect({ spawner }).run(buildFakeInput());
+    expect(out.architectName).toBe('devops');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+    for (const k of DEVOPS_OWNED_FIELD_KEYS) expect(out.architectureFields).toHaveProperty(k);
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.risks).toEqual(expected.risks);
+    expect(out.dependencies).toEqual(expected.dependencies);
+  });
+
+  it('output passes every DevOps invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await new DevopsArchitect({ spawner }).run(buildFakeInput());
+    for (const inv of DEVOPS_INVARIANTS) {
+      expect(inv.detect(out.architectureFields), `invariant ${inv.id}`).toBe(true);
+    }
+  });
+
+  it('idempotent - running twice yields equivalent output', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new DevopsArchitect({ spawner });
+    expect(await arch.run(buildFakeInput())).toEqual(await arch.run(buildFakeInput()));
+  });
+
+  it('always declares [backend, database, security] as dependencies', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await new DevopsArchitect({ spawner }).run(buildFakeInput());
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+    expect(out.dependencies).toContain('security');
+  });
+});
+
+describe('golden - DEPLOY STRATEGY REALISM (canonical assertion)', () => {
+  const arch = goldenExpectedOutput().architectureFields;
+  const ds = arch['devops.deployStrategy'] as Record<string, unknown>;
+  const iac = arch['devops.infrastructureAsCode'] as Record<string, unknown>;
+  const caps = iac.capabilities as string[];
+
+  it('chosen deploy strategy is one of the canonical kinds', () => {
+    expect(DEPLOY_STRATEGIES).toContain(ds.kind);
+  });
+
+  it('infra capabilities include every requirement of the chosen strategy', () => {
+    const required = STRATEGY_INFRA_REQUIREMENTS[ds.kind as string] ?? [];
+    for (const r of required) {
+      expect(caps, `capability ${r} required by ${ds.kind}`).toContain(r);
+    }
+  });
+
+  it('canary strategy explicitly requires traffic-split', () => {
+    if (ds.kind === 'canary') {
+      expect(caps).toContain('traffic-split');
+    }
+  });
+
+  it('every strategy in the realism table has at least the declared capability when that strategy is chosen (smoke check)', () => {
+    for (const strat of DEPLOY_STRATEGIES) {
+      const required = STRATEGY_INFRA_REQUIREMENTS[strat];
+      expect(Array.isArray(required)).toBe(true);
+    }
+  });
+
+  it('traffic shift is monotonically non-decreasing', () => {
+    const shift = ds.trafficShift as Array<{ pct: number }>;
+    let last = -Infinity;
+    for (const phase of shift) {
+      expect(phase.pct).toBeGreaterThanOrEqual(last);
+      last = phase.pct;
+    }
+  });
+
+  it('last traffic-shift phase reaches 100%', () => {
+    const shift = ds.trafficShift as Array<{ pct: number }>;
+    expect(shift[shift.length - 1].pct).toBe(100);
+  });
+
+  it('healthcheck gate is /_health with HTTP 200', () => {
+    const gate = ds.healthcheckGate as Record<string, unknown>;
+    expect(gate.path).toBe('/_health');
+    expect(gate.expectStatus).toBe(200);
+    expect(gate.timeoutSec).toBeGreaterThan(0);
+  });
+
+  it('rollback contract has auto-revert window <= 5 min', () => {
+    const rb = arch['devops.rollbackContract'] as Record<string, unknown>;
+    const trigger = rb.trigger as Record<string, unknown>;
+    expect(trigger.kind).toBe('healthcheck-failure');
+    expect(trigger.windowMin).toBeLessThanOrEqual(5);
+  });
+
+  it('rollback method falls back to Time Machine snapshot key', () => {
+    const rb = arch['devops.rollbackContract'] as Record<string, unknown>;
+    expect(['time-machine', 'hybrid']).toContain(rb.method);
+    expect(rb.timeMachineSnapshotKey).toBeDefined();
+  });
+});
+
+describe('golden - upstream cross-validation', () => {
+  it('input includes Backend upstream output', () => {
+    const input = buildFakeInput();
+    expect(input.upstream.outputs.backend).toBeDefined();
+    expect(input.upstream.outputs.backend!.architectureFields['backend.apiEndpoints']).toBeDefined();
+  });
+
+  it('input includes Database upstream output', () => {
+    const input = buildFakeInput();
+    expect(input.upstream.outputs.database).toBeDefined();
+    expect(input.upstream.outputs.database!.architectureFields['database.migrations']).toBeDefined();
+  });
+
+  it('input includes Security upstream output', () => {
+    const input = buildFakeInput();
+    expect(input.upstream.outputs.security).toBeDefined();
+    expect(input.upstream.outputs.security!.architectureFields['security.secretsHandling']).toBeDefined();
+  });
+
+  it('golden deploymentObservability sink forward-references Security', () => {
+    const obs = goldenExpectedOutput().architectureFields['devops.deploymentObservability'] as Record<string, unknown>;
+    expect(obs.sinkRef).toContain('security.auditLogRequirements');
+  });
+
+  it('golden secretsManagementInPipeline forward-references Security', () => {
+    const sec = goldenExpectedOutput().architectureFields['devops.secretsManagementInPipeline'] as Record<string, unknown>;
+    expect(sec.provider).toBe('vault-via-security-architect');
+    expect(sec.securityArchitectRef).toBe('security.secretsHandling');
+  });
+
+  it('golden cicdPipeline provider matches onboarding `businessPlan.infrastructure.ciProvider`', () => {
+    const input = buildFakeInput();
+    const onboardingCi = ((input.businessPlan as Record<string, unknown>).infrastructure as Record<string, unknown>).ciProvider;
+    const ci = goldenExpectedOutput().architectureFields['devops.cicdPipeline'] as Record<string, unknown>;
+    expect(ci.provider).toBe(onboardingCi);
+  });
+
+  it('golden infrastructureAsCode tool matches onboarding `businessPlan.infrastructure.iacTool`', () => {
+    const input = buildFakeInput();
+    const onboardingIac = ((input.businessPlan as Record<string, unknown>).infrastructure as Record<string, unknown>).iacTool;
+    const iac = goldenExpectedOutput().architectureFields['devops.infrastructureAsCode'] as Record<string, unknown>;
+    expect(iac.tool).toBe(onboardingIac);
+  });
+
+  it('golden environmentPromotion includes `fail-on-database-review` blocker', () => {
+    const ep = goldenExpectedOutput().architectureFields['devops.environmentPromotion'] as Record<string, unknown>;
+    expect(ep.blockers as string[]).toContain('fail-on-database-review');
+  });
+});

--- a/packages/devops-architect/tests/helpers/fakes.ts
+++ b/packages/devops-architect/tests/helpers/fakes.ts
@@ -1,0 +1,410 @@
+/**
+ * Test fixtures + fake spawner factory for the DevOps Architect.
+ *
+ * The canonical fixture is a prakash-tiwari contact-form Form Story
+ * ticket with wave-1/2 Backend + Database + Security upstream outputs.
+ *
+ * The golden output is deliberately constructed so the deploy strategy
+ * (canary) matches the declared infrastructure capabilities
+ * (traffic-split + multi-instance). The realism invariant verifies
+ * the match.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { DEVOPS_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+function fakeBackendUpstream(): ArchitectOutput {
+  return {
+    architectName: 'backend',
+    architectureFields: {
+      'backend.framework': {
+        name: 'next', version: '15.x', runtime: 'edge+node',
+        handlerStyle: 'app-router-route-handlers+server-actions'
+      },
+      'backend.serviceBoundaries': { style: 'monolith-with-modules', modules: ['contacts'] },
+      'backend.apiEndpoints': [
+        {
+          method: 'POST', path: '/api/contacts', op: 'create',
+          requestSchemaRef: 'ContactCreate', responseSchemaRef: 'Contact',
+          persistsTo: ['contacts'], auth: 'public',
+          rateLimit: { windowSec: 60, max: 10, scope: 'ip' }
+        }
+      ]
+    },
+    confidence: 0.9,
+    notes: 'Form Story.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+function fakeDatabaseUpstream(): ArchitectOutput {
+  return {
+    architectName: 'database',
+    architectureFields: {
+      'database.engine': { name: 'postgres', version: '16.x', orm: 'drizzle' },
+      'database.migrations': [
+        {
+          id: '0001_create_contacts',
+          description: 'Create contacts table.',
+          up: 'CREATE TABLE contacts (...);',
+          down: 'DROP TABLE contacts;',
+          ordering: 1,
+          requiresOperatorReview: false
+        }
+      ],
+      'database.tenantIsolationStrategy': {
+        model: 'schema-per-tenant',
+        justification: 'matches CAIA meta cluster',
+        schemaNameTemplate: 'tenant_{{tenantId}}',
+        sharedTables: ['tenants', 'plans']
+      }
+    },
+    confidence: 0.9,
+    notes: 'Single tenant-scoped table.',
+    dependencies: ['backend'],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+function fakeSecurityUpstream(): ArchitectOutput {
+  return {
+    architectName: 'security',
+    architectureFields: {
+      'security.secretsHandling': {
+        provider: 'vault',
+        namespace: 'tenant/{{tenantId}}',
+        rotationPolicy: { kind: 'scheduled', intervalDays: 90 },
+        injection: 'env-at-runtime',
+        neverLog: ['password', 'token', 'secret', 'authorization', 'cookie']
+      },
+      'security.auditLogRequirements': {
+        sink: 'central-secure-store',
+        retentionDays: 365,
+        perEventType: {
+          'auth.login.failure': { fields: ['ip', 'reason'], sensitivity: 'internal' },
+          'authz.deny': { fields: ['userId', 'action', 'resource'], sensitivity: 'internal' },
+          'secrets.access': { fields: ['actor', 'secretName'], sensitivity: 'sensitive' },
+          'tenant.isolation.breach.attempt': { fields: ['actor'], sensitivity: 'sensitive' }
+        },
+        redactionRules: ['password', 'token', 'secret', 'authorization', 'cookie']
+      },
+      'security.tenantIsolationGuarantees': {
+        model: 'schema-per-tenant',
+        enforcement: ['scoped-db-credentials', 'rls-defence-in-depth', 'tenant-id-on-every-row'],
+        credentialScope: 'per-tenant-app-role',
+        crossTenantAccess: 'forbidden-without-operator-elevation'
+      }
+    },
+    confidence: 0.9,
+    notes: 'Security baseline.',
+    dependencies: ['backend', 'database'],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-devops-001',
+      type: 'Form',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'Production deploy completes in <10 min p95.',
+        'Failed deploys auto-revert within 5 min of healthcheck failure.',
+        'Staging→prod requires manual operator click.',
+        'Build artifact is deterministic (pinned lockfile).',
+        'Secrets never appear in repo or build artifact.'
+      ],
+      business_requirements: {
+        title: 'Contact form submission deploy',
+        description: 'Ship the public marketing contact-form endpoint to production via canary.'
+      },
+      quality_tags: ['form', 'public', 'persists', 'deploy']
+    },
+    upstream: {
+      outputs: {
+        backend: fakeBackendUpstream(),
+        database: fakeDatabaseUpstream(),
+        security: fakeSecurityUpstream()
+      }
+    },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking.',
+      audience: 'High-intent prospective sitters.',
+      goals: ['Drive contact-form submissions'],
+      brandVoice: 'warm + grounded',
+      // Customer onboarding choices live here in V1.
+      infrastructure: {
+        ciProvider: 'github-actions',
+        cloudProvider: 'cloudflare',
+        iacTool: 'terraform',
+        repoProvider: 'github'
+      }
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      anchors: [{ anchorId: 'contact-form', kind: 'form' }],
+      tokens: {}
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'tenant_prakash_tiwari',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+/**
+ * The known-good output for the prakash-tiwari contact-form fixture.
+ *
+ * Deploy strategy is `canary`; infra capabilities include
+ * `traffic-split` + `multi-instance` — strategy/infra realism MATCHES.
+ */
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'devops',
+    architectureFields: {
+      'devops.cicdPipeline': {
+        provider: 'github-actions',
+        triggers: ['push', 'pull_request'],
+        stages: [
+          {
+            name: 'lint',
+            runs: ['pnpm install --frozen-lockfile', 'pnpm lint'],
+            qualityGates: ['eslint-no-errors']
+          },
+          {
+            name: 'typecheck',
+            runs: ['pnpm typecheck'],
+            qualityGates: ['tsc-no-errors']
+          },
+          {
+            name: 'test',
+            runs: ['pnpm test'],
+            qualityGates: ['vitest-pass', 'coverage>=80']
+          },
+          {
+            name: 'build',
+            runs: ['pnpm build'],
+            qualityGates: ['deterministic-artifact', 'lockfile-pinned']
+          },
+          {
+            name: 'deploy',
+            runs: ['pnpm deploy:canary'],
+            qualityGates: [
+              'lighthouse>=95',
+              'axe-zero-violations',
+              'csp-strict-dynamic',
+              'healthcheck-passes'
+            ]
+          }
+        ],
+        retryPolicy: { maxRetries: 2, backoffSec: 30 }
+      },
+      'devops.deployStrategy': {
+        kind: 'canary',
+        trafficShift: [
+          { phase: 'p10', pct: 10, dwellMin: 10 },
+          { phase: 'p50', pct: 50, dwellMin: 10 },
+          { phase: 'p100', pct: 100, dwellMin: 10 }
+        ],
+        healthcheckGate: {
+          path: '/_health',
+          timeoutSec: 30,
+          expectStatus: 200
+        },
+        abortConditions: ['healthcheck-failure', 'error-rate>1%', 'p95-latency>2s']
+      },
+      'devops.rollbackContract': {
+        trigger: { kind: 'healthcheck-failure', windowMin: 5 },
+        method: 'hybrid',
+        timeMachineSnapshotKey: 'ticket-pt-devops-001@pre-deploy',
+        rtoMin: 5,
+        dataMigrationRollback: {
+          additive: 'auto',
+          destructive: 'operator-forward-fix'
+        }
+      },
+      'devops.infrastructureAsCode': {
+        tool: 'terraform',
+        modules: [
+          {
+            name: 'cloudflare-pages',
+            source: 'caia-modules/cloudflare-pages',
+            version: '1.x',
+            purpose: 'Pages project + DNS routing'
+          },
+          {
+            name: 'cloudflare-workers',
+            source: 'caia-modules/cloudflare-workers',
+            version: '1.x',
+            purpose: 'API route handlers'
+          },
+          {
+            name: 'vault-tenant-namespace',
+            source: 'caia-modules/vault-tenant-namespace',
+            version: '1.x',
+            purpose: 'Per-tenant Vault AppRole + namespace provisioning'
+          },
+          {
+            name: 'r2-archive',
+            source: 'caia-modules/r2-archive',
+            version: '1.x',
+            purpose: 'GDPR archival sink for contacts table'
+          }
+        ],
+        capabilities: ['traffic-split', 'multi-instance', 'multi-region']
+      },
+      'devops.environmentPromotion': {
+        environments: [
+          {
+            name: 'dev',
+            purpose: 'Feature-branch previews',
+            autoPromote: true,
+            gateKind: 'none'
+          },
+          {
+            name: 'staging',
+            purpose: 'Pre-prod integration',
+            autoPromote: true,
+            gateKind: 'none'
+          },
+          {
+            name: 'prod',
+            purpose: 'Production traffic',
+            autoPromote: false,
+            gateKind: 'manual',
+            gateOwner: 'operator',
+            perTenant: true
+          }
+        ],
+        promotionFlow: [
+          { from: 'dev', to: 'staging', condition: 'auto-on-merge-to-main' },
+          { from: 'staging', to: 'prod', condition: 'manual-operator-click' }
+        ],
+        blockers: [
+          'fail-on-test',
+          'fail-on-lighthouse',
+          'fail-on-security-deny',
+          'fail-on-database-review'
+        ]
+      },
+      'devops.deploymentObservability': {
+        sinkRef: 'security.auditLogRequirements.sink',
+        events: [
+          {
+            name: 'deploy.started',
+            attributes: ['tenantId', 'ticketId', 'gitSha', 'environment', 'strategy'],
+            retentionDays: 365
+          },
+          {
+            name: 'deploy.succeeded',
+            attributes: ['tenantId', 'ticketId', 'gitSha', 'environment', 'strategy', 'durationMs', 'healthcheckLatencyMs'],
+            retentionDays: 365
+          },
+          {
+            name: 'deploy.failed',
+            attributes: ['tenantId', 'ticketId', 'gitSha', 'environment', 'strategy', 'durationMs', 'reason'],
+            retentionDays: 365,
+            alertThreshold: { count: 1, windowSec: 60 }
+          },
+          {
+            name: 'deploy.rollback.triggered',
+            attributes: ['tenantId', 'ticketId', 'gitSha', 'environment', 'rollbackReason'],
+            retentionDays: 365,
+            alertThreshold: { count: 1, windowSec: 60 }
+          },
+          {
+            name: 'deploy.healthcheck.failed',
+            attributes: ['tenantId', 'ticketId', 'environment', 'healthcheckLatencyMs', 'status'],
+            retentionDays: 365,
+            alertThreshold: { count: 3, windowSec: 300 }
+          }
+        ]
+      },
+      'devops.secretsManagementInPipeline': {
+        provider: 'vault-via-security-architect',
+        securityArchitectRef: 'security.secretsHandling',
+        injectionPoint: 'env-at-runtime',
+        tokenLifetimeMin: 60,
+        neverInArtifact: ['password', 'token', 'secret', 'authorization', 'api-key'],
+        rotationOnRoleChange: true
+      }
+    },
+    confidence: 0.9,
+    notes:
+      'Canary deploy strategy locked to GitHub Actions + Terraform + Cloudflare per onboarding. Traffic shift 10%→50%→100% with /_health gate + 5-min auto-revert window using Time Machine snapshot key. Manual operator gate at staging→prod. Secrets forward-referenced to Security Architect; never in artifact. All 5 deploy event types emit to Security audit sink with 365-day retention.',
+    dependencies: ['backend', 'database', 'security'],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of DEVOPS_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/devops-architect/tests/invariants.test.ts
+++ b/packages/devops-architect/tests/invariants.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Cross-architect invariants — verifies DevOps's contributions to the
+ * EA Reviewer's invariant registry (per spec §6.2).
+ */
+import { describe, it, expect } from 'vitest';
+import { DEVOPS_INVARIANTS } from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('DEVOPS_INVARIANTS - structural', () => {
+  it('declares at least one invariant', () => {
+    expect(DEVOPS_INVARIANTS.length).toBeGreaterThan(0);
+  });
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of DEVOPS_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+  it('every invariant is contributed by `devops`', () => {
+    for (const inv of DEVOPS_INVARIANTS) {
+      expect(inv.contributor).toBe('devops');
+    }
+  });
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of DEVOPS_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+  it('every invariant has a valid severity', () => {
+    for (const inv of DEVOPS_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+  it('every invariant has a non-empty description', () => {
+    for (const inv of DEVOPS_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('DEVOPS_INVARIANTS - predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of DEVOPS_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('deployStrategy-kind-allowed fails on an unknown strategy', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.deployStrategy-kind-allowed');
+    expect(inv).toBeDefined();
+    const corrupted = { ...goldenArch, 'devops.deployStrategy': { kind: 'yolo-deploy' } };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('deployStrategy-requires-realistic-infra fails when canary lacks traffic-split', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.deployStrategy-requires-realistic-infra');
+    expect(inv).toBeDefined();
+    const iac = goldenArch['devops.infrastructureAsCode'] as Record<string, unknown>;
+    const corrupted = {
+      ...goldenArch,
+      'devops.infrastructureAsCode': { ...iac, capabilities: ['multi-instance'] }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('deployStrategy-requires-realistic-infra fails when blue-green lacks two-identical-environments', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.deployStrategy-requires-realistic-infra');
+    const iac = goldenArch['devops.infrastructureAsCode'] as Record<string, unknown>;
+    const corrupted = {
+      ...goldenArch,
+      'devops.deployStrategy': {
+        ...(goldenArch['devops.deployStrategy'] as Record<string, unknown>),
+        kind: 'blue-green'
+      },
+      'devops.infrastructureAsCode': { ...iac, capabilities: ['traffic-split', 'multi-instance'] }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('deployStrategy-requires-realistic-infra fails when ring-deployment lacks multi-region', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.deployStrategy-requires-realistic-infra');
+    const iac = goldenArch['devops.infrastructureAsCode'] as Record<string, unknown>;
+    const corrupted = {
+      ...goldenArch,
+      'devops.deployStrategy': {
+        ...(goldenArch['devops.deployStrategy'] as Record<string, unknown>),
+        kind: 'ring-deployment'
+      },
+      'devops.infrastructureAsCode': { ...iac, capabilities: ['traffic-split'] }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('deployStrategy-requires-realistic-infra fails when rolling lacks multi-instance', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.deployStrategy-requires-realistic-infra');
+    const iac = goldenArch['devops.infrastructureAsCode'] as Record<string, unknown>;
+    const corrupted = {
+      ...goldenArch,
+      'devops.deployStrategy': {
+        ...(goldenArch['devops.deployStrategy'] as Record<string, unknown>),
+        kind: 'rolling'
+      },
+      'devops.infrastructureAsCode': { ...iac, capabilities: ['traffic-split'] }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('deployStrategy-requires-realistic-infra passes when recreate has no required capabilities', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.deployStrategy-requires-realistic-infra');
+    const iac = goldenArch['devops.infrastructureAsCode'] as Record<string, unknown>;
+    const variant = {
+      ...goldenArch,
+      'devops.deployStrategy': {
+        ...(goldenArch['devops.deployStrategy'] as Record<string, unknown>),
+        kind: 'recreate'
+      },
+      'devops.infrastructureAsCode': { ...iac, capabilities: [] }
+    };
+    expect(inv!.detect(variant)).toBe(true);
+  });
+
+  it('healthcheck-gate-declared fails when path is missing', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.healthcheck-gate-declared');
+    const ds = goldenArch['devops.deployStrategy'] as Record<string, unknown>;
+    const corrupted = {
+      ...goldenArch,
+      'devops.deployStrategy': { ...ds, healthcheckGate: { timeoutSec: 30, expectStatus: 200 } }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('rollback-auto-revert-window fails when window exceeds 5 min', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.rollback-auto-revert-window');
+    const corrupted = {
+      ...goldenArch,
+      'devops.rollbackContract': {
+        ...(goldenArch['devops.rollbackContract'] as Record<string, unknown>),
+        trigger: { kind: 'healthcheck-failure', windowMin: 15 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('rollback-method-allowed fails on `pray-and-wait`', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.rollback-method-allowed');
+    const corrupted = {
+      ...goldenArch,
+      'devops.rollbackContract': {
+        ...(goldenArch['devops.rollbackContract'] as Record<string, unknown>),
+        method: 'pray-and-wait'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('env-promotion-manual-staging-to-prod fails when prod auto-promotes', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.env-promotion-manual-staging-to-prod');
+    const ep = goldenArch['devops.environmentPromotion'] as Record<string, unknown>;
+    const envs = (ep.environments as Array<Record<string, unknown>>).map(e =>
+      e.name === 'prod' ? { ...e, autoPromote: true, gateKind: 'none' } : e
+    );
+    const corrupted = { ...goldenArch, 'devops.environmentPromotion': { ...ep, environments: envs } };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('observability-required-events fails when an event is missing', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.observability-required-events');
+    const obs = goldenArch['devops.deploymentObservability'] as Record<string, unknown>;
+    const events = (obs.events as Array<Record<string, unknown>>).filter(e => e.name !== 'deploy.rollback.triggered');
+    const corrupted = { ...goldenArch, 'devops.deploymentObservability': { ...obs, events } };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('observability-sink-via-security fails when sinkRef is custom', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.observability-sink-via-security');
+    const obs = goldenArch['devops.deploymentObservability'] as Record<string, unknown>;
+    const corrupted = { ...goldenArch, 'devops.deploymentObservability': { ...obs, sinkRef: 'my-own-sink' } };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('secrets-forward-reference-security fails on a DIY secrets store', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.secrets-forward-reference-security');
+    const sec = goldenArch['devops.secretsManagementInPipeline'] as Record<string, unknown>;
+    const corrupted = { ...goldenArch, 'devops.secretsManagementInPipeline': { ...sec, provider: 'env-files' } };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('secrets-never-in-artifact fails when password is missing from the list', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.secrets-never-in-artifact');
+    const sec = goldenArch['devops.secretsManagementInPipeline'] as Record<string, unknown>;
+    const corrupted = { ...goldenArch, 'devops.secretsManagementInPipeline': { ...sec, neverInArtifact: ['token', 'secret', 'authorization'] } };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('cicd-pipeline-canonical-stages fails when a stage is missing', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.cicd-pipeline-canonical-stages');
+    const ci = goldenArch['devops.cicdPipeline'] as Record<string, unknown>;
+    const stages = (ci.stages as Array<Record<string, unknown>>).filter(s => s.name !== 'typecheck');
+    const corrupted = { ...goldenArch, 'devops.cicdPipeline': { ...ci, stages } };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('deploy-strategy-traffic-shift-monotonic fails when pcts decrease', () => {
+    const inv = DEVOPS_INVARIANTS.find(i => i.id === 'devops.deploy-strategy-traffic-shift-monotonic');
+    const ds = goldenArch['devops.deployStrategy'] as Record<string, unknown>;
+    const corrupted = {
+      ...goldenArch,
+      'devops.deployStrategy': {
+        ...ds,
+        trafficShift: [
+          { phase: 'p50', pct: 50, dwellMin: 10 },
+          { phase: 'p10', pct: 10, dwellMin: 10 }
+        ]
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+});

--- a/packages/devops-architect/tests/run.test.ts
+++ b/packages/devops-architect/tests/run.test.ts
@@ -1,0 +1,175 @@
+/**
+ * `run()` tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { DEVOPS_ARCHITECT_NAME, DevopsArchitect } from '../src/architect.js';
+import { DEVOPS_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runDevopsArchitect } from '../src/run.js';
+import { buildDevopsSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput, fakeGoldenSpawner, fakeSpawnerReturning,
+  goldenAssistantText, goldenExpectedOutput
+} from './helpers/fakes.js';
+
+describe('runDevopsArchitect - happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.architectName).toBe('devops');
+  });
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    for (const k of DEVOPS_OWNED_FIELD_KEYS) expect(out.architectureFields).toHaveProperty(k);
+  });
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.status).toBe('ok');
+  });
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(calls[0]?.systemPrompt).toBe(buildDevopsSystemPrompt());
+  });
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runDevopsArchitect(input, { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runDevopsArchitect(input, { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runDevopsArchitect - idempotency', () => {
+  it('same input -> same output', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    const b = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(a).toEqual(b);
+  });
+  it('re-run REPLACES architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const r1 = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    const r2 = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(Object.keys(r1.architectureFields).sort());
+    expect(Object.keys(r2.architectureFields).length).toBe(DEVOPS_OWNED_FIELD_KEYS.length);
+  });
+});
+
+describe('runDevopsArchitect - failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+  it('failed-spawn output still declares [backend,database,security] dependencies', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.dependencies).toEqual(['backend', 'database', 'security']);
+  });
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"devops"}');
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+  it('partial-validation output still declares [backend,database,security] dependencies', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"devops"}');
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.dependencies).toEqual(['backend', 'database', 'security']);
+  });
+  it('returns status=partial when assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runDevopsArchitect - dependency declaration', () => {
+  it('always declares [backend, database, security] as upstream', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+    expect(out.dependencies).toContain('security');
+  });
+  it('preserves sibling-ticket IDs alongside upstream architects', async () => {
+    const c = { ...goldenExpectedOutput(), dependencies: ['ticket-pt-001'] };
+    const { fn: spawner } = fakeSpawnerReturning(JSON.stringify(c));
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+    expect(out.dependencies).toContain('security');
+    expect(out.dependencies).toContain('ticket-pt-001');
+  });
+  it('does not duplicate upstream architects in dependencies', async () => {
+    const c = { ...goldenExpectedOutput(), dependencies: ['backend', 'database', 'security', 'backend'] };
+    const { fn: spawner } = fakeSpawnerReturning(JSON.stringify(c));
+    const out = await runDevopsArchitect(buildFakeInput(), { spawner, systemPrompt: buildDevopsSystemPrompt(), architectName: DEVOPS_ARCHITECT_NAME });
+    const counts = new Map<string, number>();
+    for (const d of out.dependencies) counts.set(d, (counts.get(d) ?? 0) + 1);
+    expect(counts.get('backend')).toBe(1);
+    expect(counts.get('database')).toBe(1);
+    expect(counts.get('security')).toBe(1);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => { expect(buildUserPrompt(buildFakeInput())).toContain('ticket-pt-devops-001'); });
+  it('serialises Backend upstream (apiEndpoints)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('POST');
+    expect(p).toContain('/api/contacts');
+    expect(p).toContain('backend.apiEndpoints');
+  });
+  it('serialises Database upstream (migrations)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('database.migrations');
+    expect(p).toContain('0001_create_contacts');
+  });
+  it('serialises Security upstream (secretsHandling)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('security.secretsHandling');
+  });
+  it('includes vaultNamespace', () => { expect(buildUserPrompt(buildFakeInput())).toContain('tenant/prakash-tiwari'); });
+  it('includes schemaName', () => { expect(buildUserPrompt(buildFakeInput())).toContain('tenant_prakash_tiwari'); });
+  it('includes tenantId', () => { expect(buildUserPrompt(buildFakeInput())).toContain('tenant-prakash-tiwari'); });
+  it('includes onboarding infrastructure choices', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('github-actions');
+    expect(p).toContain('cloudflare');
+    expect(p).toContain('terraform');
+  });
+  it('passes through reviewer feedback', () => {
+    const input = { ...buildFakeInput(), reviewerFeedback: { reason: 'pick rolling instead of canary', severity: 'P1' as const } };
+    expect(buildUserPrompt(input)).toContain('pick rolling instead of canary');
+  });
+});
+
+describe('DevopsArchitect - class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new DevopsArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('devops');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/devops-architect/tests/system-prompt.test.ts
+++ b/packages/devops-architect/tests/system-prompt.test.ts
@@ -1,0 +1,108 @@
+/**
+ * System-prompt tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { CICD_PROVIDERS, DEPLOY_STRATEGIES, DEVOPS_OWNED_FIELD_KEYS, IAC_TOOLS } from '../src/contract.js';
+import { buildDevopsSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildDevopsSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+  it('is deterministic across calls', () => {
+    expect(buildDevopsSystemPrompt()).toBe(buildDevopsSystemPrompt());
+  });
+  it('contains the Role section', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's DevOps/Deployment Architect");
+  });
+  it('mentions that it is DISTINCT from deploy-steward', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('deploy-steward');
+    expect(p).toContain('EXECUTES');
+  });
+  it('mentions that it is DISTINCT from QA Engineer', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('QA Engineer');
+  });
+  it('contains the Locked stack section', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('GitHub Actions');
+    expect(p).toContain('Terraform');
+    expect(p).toContain('Cloudflare');
+  });
+  it('lists every CI/CD provider', () => {
+    const p = buildDevopsSystemPrompt();
+    for (const pr of CICD_PROVIDERS) expect(p).toContain(pr);
+  });
+  it('lists every IaC tool', () => {
+    const p = buildDevopsSystemPrompt();
+    for (const t of IAC_TOOLS) expect(p).toContain(t);
+  });
+  it('lists every deploy strategy', () => {
+    const p = buildDevopsSystemPrompt();
+    for (const s of DEPLOY_STRATEGIES) expect(p).toContain(s);
+  });
+  it('declares the deploy-strategy realism table', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('two-identical-environments');
+    expect(p).toContain('traffic-split');
+    expect(p).toContain('multi-region');
+    expect(p).toContain('multi-instance');
+  });
+  it('contains the Output JSON schema section', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+  it('references every declared owned field at least once', () => {
+    const p = buildDevopsSystemPrompt();
+    for (const key of DEVOPS_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+  it('contains the Decision heuristics section', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('Healthcheck gate is non-negotiable');
+  });
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('devops.*');
+  });
+  it('contains a Self-check section', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildDevopsSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+  it('does not refer to fields outside the `devops.*` namespace as owned', () => {
+    const p = buildDevopsSystemPrompt();
+    // While `devops.*` may reference other architects' fields by name for
+    // cross-validation, none of the foreign field paths should appear in
+    // the architectureFields schema list.
+    const foreignAsOwned = [
+      '"frontend.componentTree"',
+      '"backend.apiEndpoints" :',
+      '"database.tables" :',
+      '"a11y.conformanceMap"'
+    ];
+    for (const k of foreignAsOwned) expect(p).not.toContain(k);
+  });
+  it('size is bounded (token-budget proxy: < 24k chars)', () => {
+    expect(buildDevopsSystemPrompt().length).toBeLessThan(24_000);
+  });
+});

--- a/packages/devops-architect/tests/validation.test.ts
+++ b/packages/devops-architect/tests/validation.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Output validation tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { DEVOPS_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput - happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), DEVOPS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('devops');
+    expect(result.parsed?.status).toBe('ok');
+  });
+  it('accepts JSON wrapped in ```json fences', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    expect(validateArchitectOutput(fenced, DEVOPS_OWNED_FIELD_KEYS).ok).toBe(true);
+  });
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    expect(validateArchitectOutput(fenced, DEVOPS_OWNED_FIELD_KEYS).ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput - error paths', () => {
+  it('rejects invalid JSON', () => {
+    const r = validateArchitectOutput('{not json', DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]?.code).toBe('invalid-json');
+  });
+  it('rejects a top-level array', () => {
+    const r = validateArchitectOutput('[1,2,3]', DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+  it('rejects null top-level', () => {
+    const r = validateArchitectOutput('null', DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+  it('flags missing top-level keys', () => {
+    const r = validateArchitectOutput('{"architectName":"devops"}', DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.map(e => e.code)).toContain('missing-top-level-key');
+  });
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['devops.deployStrategy'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const r = validateArchitectOutput(JSON.stringify(corrupted), DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields, 'backend.apiShape': 'not yours' };
+    const corrupted = { ...golden, architectureFields: fields };
+    const r = validateArchitectOutput(JSON.stringify(corrupted), DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const r = validateArchitectOutput(JSON.stringify(corrupted), DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const r = validateArchitectOutput(JSON.stringify(corrupted), DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const r = validateArchitectOutput(JSON.stringify(corrupted), DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+  it('flags too many risk entries', () => {
+    const corrupted = { ...goldenExpectedOutput(), risks: ['a', 'b', 'c', 'd', 'e', 'f'] };
+    const r = validateArchitectOutput(JSON.stringify(corrupted), DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const r = validateArchitectOutput(JSON.stringify(corrupted), DEVOPS_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      expect(validateArchitectOutput(JSON.stringify(variant), DEVOPS_OWNED_FIELD_KEYS).ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    expect(stripFences('```json\n{"x":1}\n```')).toBe('{"x":1}');
+  });
+  it('strips plain ``` fences', () => {
+    expect(stripFences('```\n{"x":1}\n```')).toBe('{"x":1}');
+  });
+  it('passes plain JSON through unchanged', () => {
+    expect(stripFences('{"x":1}')).toBe('{"x":1}');
+  });
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/devops-architect/tsconfig.build.json
+++ b/packages/devops-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/devops-architect/tsconfig.json
+++ b/packages/devops-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/devops-architect/vitest.config.ts
+++ b/packages/devops-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1590,6 +1590,37 @@ importers:
         specifier: ^4.2.0
         version: 4.2.4
 
+  packages/devops-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@caia/backend-architect':
+        specifier: workspace:*
+        version: link:../backend-architect
+      '@caia/database-architect':
+        specifier: workspace:*
+        version: link:../database-architect
+      '@caia/frontend-architect':
+        specifier: workspace:*
+        version: link:../frontend-architect
+      '@caia/security-architect':
+        specifier: workspace:*
+        version: link:../security-architect
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/dspy-bridge:
     devDependencies:
       '@chiefaia/eslint-config':


### PR DESCRIPTION
## Summary

Builds **DevOps Architect** — architect **#17 of 17** in CAIA's EA fan-out. **This PR completes the roster.** Once merged, every architect contract is in place and the EA Dispatcher can fan-out across all 17 in parallel for any ticket.

Wave-3 specialist that consumes Backend + Database + Security upstream outputs and produces a per-ticket DEPLOY STRATEGY spec.

Implements \`SpecialistArchitect\` from \`@caia/architect-kit\` (PR #535).

## Owned fields (\`devops.*\`)

- \`cicdPipeline\` — GitHub Actions default; lint→typecheck→test→build→deploy stages with quality gates from Performance + Security + Testing architects
- \`deployStrategy\` — canary | blue-green | ring-deployment | rolling | recreate
- \`rollbackContract\` — 5-min auto-revert on healthcheck failure; Time Machine snapshot key or git revert + redeploy
- \`infrastructureAsCode\` — Terraform default; capabilities cross-checked against the chosen deploy strategy
- \`environmentPromotion\` — dev → staging → prod with manual operator gate at prod
- \`deploymentObservability\` — 5 required deploy events; sink forward-references Security audit log
- \`secretsManagementInPipeline\` — forward-references Security Architect's \`secretsHandling\` (no DIY secret stores)

## Distinct from neighbouring packages

This architect SPECIFIES how deploys should happen. It does NOT execute deploys.

- **\`caia/packages/deploy-steward\`** EXECUTES deploys (it's a launchd bin/shell tool, not a TS package per V2 audit).
- **QA Engineer agent** validates production AFTER deploy.
- **DevOps Architect (this PR)** sets the strategy.

## Per-customer onboarding choices

The architect reads infrastructure choices from \`businessPlan.infrastructure\`:

- CI/CD provider — github-actions (default), gitlab-ci, circleci, buildkite, azure-pipelines
- Cloud provider — cloudflare (default), aws, gcp, azure, fly-io, render
- IaC tool — terraform (default), pulumi, kubernetes-manifests, cdk, cloudformation
- Repo provider — github (default), gitlab, bitbucket

Defaults applied with a \`risks[]\` annotation when no choice is provided.

## Deploy-strategy realism

Enforced by the \`devops.deployStrategy-requires-realistic-infra\` invariant:

| Strategy | Required infra capability |
|---|---|
| blue-green | two-identical-environments |
| canary | traffic-split |
| ring-deployment | multi-region |
| rolling | multi-instance |
| recreate | (no special capability) |

The architect MUST flag mismatches and fall back to a strategy that fits the available infra.

## Wave + precedence

- **Wave 3** — depends on Backend + Database + Security
- **Precedence rank 2** — only Security outranks DevOps (the operator is on the hook for a bad deploy contract)

## Tests

**180 vitest tests** covering:

- Interface compliance (\`SpecialistArchitect\` structural)
- Contract structure + per-field fix-hint coverage
- **Four-way registry disjointness** vs frontend + backend + database + security
- Apply predicate (Page/Story/Form/List/Foundation + tagged Widgets)
- Onboarding-choice enumerations (CI/cloud/IaC/repo provider domains)
- Strategy/infra realism map (every strategy ↔ capability pair)
- System prompt completeness (every owned field + every strategy + every onboarding domain)
- Output validation (every validation error class + happy path)
- run() pipeline (idempotency + REPLACE-not-append + failure modes + dependency declaration always includes \`[backend, database, security]\`)
- **12 cross-architect invariants** — deploy strategy kind allowed, **strategy/infra realism for every strategy**, healthcheck gate declared, rollback window ≤ 5 min, rollback method allowed, manual staging→prod gate, required deploy events, observability sink via Security, secrets forward-reference Security, never-in-artifact list complete, canonical CI stages present, traffic-shift monotonic
- **Golden test** — canonical prakash-tiwari contact-form Form Story ticket with Backend + Database + Security upstream cross-validated; explicitly verifies deploy-strategy realism (canary matches infra capabilities traffic-split + multi-instance + multi-region)

## Quality gates

- ✅ TypeScript strict clean
- ✅ ESLint clean
- ✅ \`tsc --noEmit\` passes
- ✅ \`pnpm build\` emits dist/
- ✅ \`pnpm test\` — 180/180 pass

## Mirrors

Modelled on \`@caia/frontend-architect\` template (architect #1, PR #537) and \`@caia/security-architect\` template (architect #10, fellow upstream-Backend-dependent).

## Subscription-only

Spawns Claude via \`@chiefaia/claude-spawner\` (no \`ANTHROPIC_API_KEY\`). True-Zero rule observed.

---

**🎉 17 of 17 — milestone**

With this merged, the canonical 17-architect roster is complete:

\`\`\`
Wave 1: Frontend, Backend, SEO, Feature Flagging, Time Machine, UX Version Control, AI/ML
Wave 2: Database, Accessibility, Performance, Analytics, Observability, Security, API Gateway, Testing
Wave 3: A/B Testing, DevOps   ← this PR completes wave 3
\`\`\`

The EA Dispatcher can now fan-out across all 17 in parallel for any ticket. 🚀