### PR TITLE
feat(@caia/ux-version-control-architect): ship architect #15 of 17 — UX Version Control specialist

### DIFF
--- a/packages/ux-version-control-architect/README.md
+++ b/packages/ux-version-control-architect/README.md
@@ -1,0 +1,59 @@
+# @caia/ux-version-control-architect
+
+Architect #15 of CAIA's 17-architect EA fan-out. Owns durable UX-asset version control + design-revert UX.
+
+## What it owns
+
+`uxVersionControl.*` slice of the `tickets.architecture` JSONB column:
+
+- `uxVersionControl.designVersionRetention` — how many design uploads are kept, archival rules, GDPR delete interaction
+- `uxVersionControl.revertOperation` — **forward-creating** revert (new design version appended on the chain tip, never destructive overwrite); revert scope (whole design vs section); idempotency contract
+- `uxVersionControl.diffVisualizationSpec` — what the diff between v1 and v2 of a UX upload looks like (anchors added/modified/removed; token deltas; copy deltas; surface rendering channel)
+- `uxVersionControl.branchingStrategy` — whether a customer can fork a design version; merge / abandon / promote semantics
+- `uxVersionControl.auditTrail` — every UX upload + revert logged + attributed to operator action (who, when, from→to, scope, reason)
+
+## What it does NOT do
+
+No component code. No API endpoint logic. No database schema. No test specs. Code-level versioning (commits, deploys, rollbacks) is the Time Machine Architect's (#14) concern. Other architects own those concerns; the contract rejects out-of-namespace writes.
+
+## How it runs
+
+Implements `SpecialistArchitect` (per spec `research/17_architect_framework_spec_2026.md` §1, §2.15). Wave-1 architect with no upstream dependencies: reads `designVersion` directly from input.
+
+The EA Dispatcher spawns one UX Version Control architect per applicable ticket. Each spawn calls `@chiefaia/claude-spawner` (subscription-only, no API-key billing) with Sonnet default. Returns a structured `ArchitectOutput` the Dispatcher composes into the ticket's `architecture` JSONB.
+
+**The forward-creating revert invariant.** A revert is itself a new design version — appended to the design-version chain, never an in-place overwrite of history. This is what makes design time-travel safe: an operator can revert the revert, walk back to any uploaded UX, and the audit trail always shows what happened. The package's golden test pins this invariant.
+
+**Distinct from Time Machine.** Time Machine (#14) owns CODE-level versioning — commits, deploys, rollbacks. This architect owns DESIGN-level versioning — design uploads, design diffs, design reverts. The two contracts are disjoint by construction; the JSONB namespaces (`timeMachine.*` vs `uxVersionControl.*`) never collide.
+
+## Quick start
+
+```ts
+import { UxVersionControlArchitect } from '@caia/ux-version-control-architect';
+
+const architect = new UxVersionControlArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: {} },
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (≥30 tests)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+The suite includes interface compliance, contract structural checks, registration disjointness, output validation, run() idempotency, cross-architect invariants, and an end-to-end golden test that verifies the forward-creating revert invariant — every revert produces a new design version at the chain tip, never overwrites a prior version.
+
+## Reference
+
+Generalizes the snapshot/revert pattern proven in `@caia/atlas-design-snapshotter` (PR #538) — `captureSnapshot()` + `revertToVersion()` already demonstrate the immutable / append-only / forward-creating contract for a single uploader. This architect specifies that contract at the per-ticket architecture level so every UX-bearing ticket inherits the same guarantee.

--- a/packages/ux-version-control-architect/eslint.config.cjs
+++ b/packages/ux-version-control-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on aiml-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/ux-version-control-architect/package.json
+++ b/packages/ux-version-control-architect/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@caia/ux-version-control-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "UX Version Control Architect — architect #15 of CAIA's 17-architect EA fan-out. Owns the `uxVersionControl.*` slice of `tickets.architecture` (designVersionRetention, revertOperation, diffVisualizationSpec, branchingStrategy, auditTrail). Senior platform engineer focused on UX-asset version control + design-revert UX. Produces per-ticket UX-versioning specs that determine how this feature's design history is preserved. Distinct from the Time Machine Architect (#14) which owns CODE-level versioning; this architect owns DESIGN-level versioning. Does NOT write component code or backend logic. Spawns Claude via @chiefaia/claude-spawner (subscription-only). Generalizes the snapshot/revert pattern proven by @caia/atlas-design-snapshotter (PR #538) from a single uploader to ALL design uploads.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/ux-version-control-architect/src/architect.ts
+++ b/packages/ux-version-control-architect/src/architect.ts
@@ -1,0 +1,62 @@
+/**
+ * `UxVersionControlArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. The class:
+ *
+ *   - Holds the section contract as a readonly field.
+ *   - Returns the system prompt as a pure function (no runtime state).
+ *   - Declares empty `tools` for V1 per the task brief.
+ *   - Exposes `run(input)` which delegates to `./run.ts`.
+ *
+ * Constructor takes an optional `spawner` so tests can inject a
+ * deterministic fake. Default is `createDefaultSpawner()` which wraps
+ * `@chiefaia/claude-spawner`'s real `spawnClaude`.
+ */
+
+import { UxVersionControlArchitectContract } from './contract.js';
+import { runUxVersionControlArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildUxVersionControlSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches `@caia/ux-version-control-architect` minus the suffix. */
+export const UX_VERSION_CONTROL_ARCHITECT_NAME = 'ux-version-control' as const;
+
+/** V1: no architect-specific tools. Reads designVersion directly. */
+export const UX_VERSION_CONTROL_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface UxVersionControlArchitectConfig {
+  /** Inject a fake spawner in tests. Default: real claude-spawner-backed spawner. */
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class UxVersionControlArchitect implements SpecialistArchitect {
+  readonly name = UX_VERSION_CONTROL_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = UxVersionControlArchitectContract;
+  readonly tools: readonly ToolDefinition[] = UX_VERSION_CONTROL_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: UxVersionControlArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  systemPrompt(): string {
+    return buildUxVersionControlSystemPrompt();
+  }
+
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runUxVersionControlArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/ux-version-control-architect/src/contract.ts
+++ b/packages/ux-version-control-architect/src/contract.ts
@@ -1,0 +1,146 @@
+/**
+ * `UxVersionControlArchitectContract` — the canonical owned-fields
+ * declaration for architect #15 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.15 (UX Version Control Architect)
+ *   - spec §11 Architect Brief A15
+ *   - V2 operator task brief 2026-05-24 (binding name set:
+ *     designVersionRetention, revertOperation, diffVisualizationSpec,
+ *     branchingStrategy, auditTrail)
+ *
+ * The V2 task brief is the binding name set (per the standing rule — newer
+ * brief wins, mirrored from how `@caia/time-machine-architect` followed
+ * its V2 brief over spec §2.14). Spec §2.15's outline (uploadVersionId,
+ * parentVersionId, diffSummary, revertToVersionId, replayMode,
+ * selectiveRevertScope, preservationGuarantee, atlasAnchorRefs) is folded
+ * into the semantic content of each V2 field — the V2 field set is the
+ * OUTER contract, each owned field describes a policy object that
+ * internally surfaces the spec's lower-level mechanics.
+ *
+ * Naming note: the architect's `name` is `'ux-version-control'` (matches
+ * the V2 task brief). The canonical precedence ladder lists this
+ * architect under the alias `'uxVersionControl'` (camelCase). The JSONB
+ * namespace under `tickets.architecture` is `uxVersionControl.*`
+ * (camelCase) — matching the precedence-ladder convention already
+ * established for `'timeMachine'` (Time Machine Architect uses
+ * `name='time-machine'`, namespace `timeMachine.*`).
+ *
+ * Wave-1 architect (`dependsOn: []`). Reads `designVersion` directly
+ * from input; no upstream architect outputs required. Precedence rank
+ * 16 per spec §5.2 (operator-facing; not safety-critical — sits just
+ * below Time Machine, just above Testing).
+ *
+ * Disjoint by construction with `timeMachine.*` (CODE-level versioning):
+ * - Time Machine owns CODE-level commits, deploys, rollbacks.
+ * - UX Version Control owns DESIGN-level uploads, design diffs, design
+ *   reverts. The two contracts never collide because their JSONB
+ *   namespaces are disjoint.
+ *
+ * Forward-creating revert invariant: a design revert is itself a new
+ * version appended to the design-version chain; it never overwrites a
+ * prior version. This is the single most important contract guarantee
+ * — the golden test pins it. Mirrors the immutability guarantee proven
+ * in `@caia/atlas-design-snapshotter` (PR #538: `captureSnapshot()` and
+ * `revertToVersion()` are append-only by construction).
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+export const UX_VERSION_CONTROL_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'uxVersionControl.designVersionRetention':
+    'How many design uploads kept + archival rules + GDPR interaction. Output {maxVersionsKept, retentionDays, archivalSink, archivalAfterDays, gdprInteraction, tenantOverrideAllowed, preservationGuarantee}. Default {maxVersionsKept:"unlimited", retentionDays:"forever", archivalAfterDays:90, gdprInteraction:"anonymize-in-version", preservationGuarantee:"immutable-r2-storage"}. The spec posture (every uploaded UX preserved forever — no deletes) is the floor; `gdprInteraction` MUST be anonymize-in-version or purge-and-tombstone — never hard-delete. `preservationGuarantee` MUST be the literal `"immutable-r2-storage"`.',
+  'uxVersionControl.revertOperation':
+    'FORWARD-CREATING revert — never destructive. Output {invocation, scope, idempotencyKey, forwardCreating:true, replayMode, selectiveRevertScope, postCondition}. invocation defaults to `caia ux-version-control revert --version <versionId>`. scope is `design` for Page tickets, `section` for Widget tickets, both allowed for Site-level tickets that touch multiple Atlas anchors. forwardCreating MUST be the literal boolean `true` — the contract rejects any value that implies destructive overwrite. replayMode is `full` (re-architect every dependent ticket from the reverted IR) or `selective` (re-architect only tickets that touch the selectiveRevertScope anchors). postCondition states the user-observable outcome (e.g. "design returns to upload captured at version V; a new version V+N is appended documenting the revert").',
+  'uxVersionControl.diffVisualizationSpec':
+    'What the diff between v1 and v2 of a UX upload looks like. Output {renderSurface, diffLayers, narrationStyle, anchorRefs}. renderSurface defaults to `atlas-design-snapshotter`. diffLayers MUST be a non-empty array listing the diff dimensions (tree, token, copy, asset, interactivity) — these mirror @caia/atlas-design-snapshotter\'s diff layers (PR #538). narrationStyle is `semantic` (e.g. "added 2 sections, modified 1 widget, removed 0 anchors") per spec §2.15. anchorRefs lifts the design anchor IDs the diff applies to from `designVersion.anchors`.',
+  'uxVersionControl.branchingStrategy':
+    'Can a customer fork a design version? Output {forkAllowed, mergeStrategy, abandonmentPolicy, namingTemplate, maxConcurrentBranches}. forkAllowed defaults to `false` (V1 posture: linear chain only; branching is a V2 follow-on). When forkAllowed=true, mergeStrategy is one of `manual-merge|fast-forward|theirs|ours` and abandonmentPolicy specifies what happens to forks that go untouched (`auto-archive-after-30-days` is the default). namingTemplate defaults to `<parent-versionId>-fork-<ulid>`. maxConcurrentBranches defaults to 5 — beyond which uploads must reuse an existing branch.',
+  'uxVersionControl.auditTrail':
+    'Every UX upload + revert logged + attributed to operator action. Output {logSink, attributedFields, retentionDays, immutability:"append-only", queryability}. attributedFields MUST include who (operator id), when (UTC timestamp), versionId, parentVersionId, eventKind (`upload`|`revert`|`fork`|`merge`), reason (operator-supplied free text). logSink defaults to the orchestrator\'s structured-log channel + Postgres `audit_ux_version_events` table. retentionDays defaults to 7 years (regulatory floor); never less than `designVersionRetention.retentionDays` (which is "forever" by default, encoded as 365_25 * 100 = 36_525 days). immutability MUST be `append-only`.'
+};
+
+export const UX_VERSION_CONTROL_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'uxVersionControl.designVersionRetention',
+    description:
+      'How many design uploads are kept + archival rules + GDPR delete interaction. Default posture: every uploaded UX preserved forever in immutable R2 storage (per spec §2.15). Tenant override allowed for retention floor but never for the preservation guarantee.',
+    required: true
+  },
+  {
+    path: 'uxVersionControl.revertOperation',
+    description:
+      'Forward-creating revert (never destructive): invocation, scope, idempotency key, replay mode, selective revert scope, post-condition. Revert appends a new design version at the chain tip; the historical chain stays intact.',
+    required: true
+  },
+  {
+    path: 'uxVersionControl.diffVisualizationSpec',
+    description:
+      'What the diff between v1 and v2 of a UX upload looks like: render surface (atlas-design-snapshotter), diff layers (tree/token/copy/asset/interactivity), narration style (semantic — "added X sections, modified Y widgets"), anchor refs.',
+    required: true
+  },
+  {
+    path: 'uxVersionControl.branchingStrategy',
+    description:
+      'Can a customer fork a design version? Fork-allowed flag, merge strategy, abandonment policy, naming template, concurrent-branch ceiling. Default V1 posture: linear chain only; branching is a V2 follow-on.',
+    required: true
+  },
+  {
+    path: 'uxVersionControl.auditTrail',
+    description:
+      'Append-only UX upload + revert audit: log sink, attributed fields (who/when/versionId/parentVersionId/eventKind/reason), retention floor (7 years regulatory), queryability surface.',
+    required: true
+  }
+];
+
+export const UX_VERSION_CONTROL_OWNED_FIELD_KEYS: readonly string[] =
+  UX_VERSION_CONTROL_OWNED_SECTIONS.map(s => s.path);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §2.15 — UX Version Control runs whenever a UX asset is in play.
+ * The architect brief A15 lists scope=site, but per-ticket UX uploads
+ * also flow through Page / Story / Widget / Form / List tickets that
+ * carry a `designVersion`. We default to running on all ticket types
+ * that carry UX (everything except pure Foundation/Infra) so the audit
+ * trail + retention spec is computed eagerly.
+ */
+export function uxVersionControlArchitectAppliesPredicate(ticket: Ticket): boolean {
+  return (
+    ticket.type === 'Page' ||
+    ticket.type === 'Widget' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List' ||
+    ticket.type === 'Site'
+  );
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+export const UX_VERSION_CONTROL_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: [],
+  precedenceLevel: 16,
+  fanoutPolicy: 'always',
+  appliesPredicate: uxVersionControlArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const UxVersionControlArchitectContract: ArchitectSectionContract = {
+  contractId: 'ux-version-control-architect.v1',
+  architectName: 'ux-version-control',
+  version: '0.1.0',
+  sections: UX_VERSION_CONTROL_OWNED_SECTIONS,
+  architectMeta: UX_VERSION_CONTROL_ARCHITECT_META
+};

--- a/packages/ux-version-control-architect/src/index.ts
+++ b/packages/ux-version-control-architect/src/index.ts
@@ -1,0 +1,88 @@
+/**
+ * @caia/ux-version-control-architect — public surface.
+ *
+ * Architect #15 of CAIA's 17-architect EA fan-out. Mirrors the
+ * Frontend Architect template (architect #1).
+ *
+ * Two-layer surface:
+ *   - The class + contract — what the EA Dispatcher consumes.
+ *   - Re-exports of run/spawner/validation/invariants for tests + the
+ *     conformance suite.
+ *
+ * Registration: import this package's `registerWith()` helper to install
+ * the architect on a registry. The package does NOT self-register on
+ * import (registration is an explicit operator action that the
+ * Dispatcher's boot wires up).
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { UxVersionControlArchitect } from './architect.js';
+
+export {
+  UxVersionControlArchitect,
+  UX_VERSION_CONTROL_ARCHITECT_NAME,
+  UX_VERSION_CONTROL_ARCHITECT_TOOLS
+} from './architect.js';
+export type { UxVersionControlArchitectConfig } from './architect.js';
+
+export {
+  UxVersionControlArchitectContract,
+  UX_VERSION_CONTROL_OWNED_SECTIONS,
+  UX_VERSION_CONTROL_OWNED_FIELD_KEYS,
+  UX_VERSION_CONTROL_FIELD_FIX_HINTS,
+  UX_VERSION_CONTROL_ARCHITECT_META,
+  uxVersionControlArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildUxVersionControlSystemPrompt } from './system-prompt.js';
+
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+export { runUxVersionControlArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+export { UX_VERSION_CONTROL_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+/**
+ * Register a fresh UxVersionControlArchitect on the given registry. The
+ * Dispatcher's boot wiring calls this in its `registry.ts` per spec §7.1.
+ */
+export function registerWith(registry: ArchitectRegistry): UxVersionControlArchitect {
+  const architect = new UxVersionControlArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/ux-version-control-architect/src/invariants.ts
+++ b/packages/ux-version-control-architect/src/invariants.ts
@@ -1,0 +1,170 @@
+/**
+ * UX Version Control's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * The forward-creating revert invariant + the preservation guarantee are
+ * the single most important contract guarantees. Destructive revert and
+ * hard-delete of design versions are hard contract violations.
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (where keys are FLAT
+ *     dotted strings like `'uxVersionControl.revertOperation'`), or
+ *   - the composed `tickets.architecture` JSONB blob (where the
+ *     Dispatcher will nest the same fields under the `uxVersionControl.*`
+ *     path).
+ *
+ * Both views are accepted — we look up via `readField()` which checks
+ * the flat key first, then falls back to the nested path.
+ */
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  /** Architect that contributed this invariant. */
+  contributor: string;
+  /** Other architects whose fields this invariant reads. */
+  reads: readonly string[];
+  /** Severity if the predicate returns false. */
+  severity: InvariantSeverity;
+  /** Operator-facing description for the Reviewer's audit log. */
+  description: string;
+  /**
+   * The predicate. Receives the JSONB blob (flat-keyed
+   * `architectureFields` view OR nested composed-architecture view).
+   * Pure + synchronous.
+   */
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+export const UX_VERSION_CONTROL_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'uxVersionControl.revert-is-forward-creating',
+    contributor: 'ux-version-control',
+    reads: ['uxVersionControl.revertOperation'],
+    severity: 'fail',
+    description:
+      'Every UX-version revert MUST be forward-creating: appended to the chain tip, never overwriting prior history. `revertOperation.forwardCreating` must be the literal boolean `true`. Destructive revert is a hard contract violation.',
+    detect(arch): boolean {
+      const op = readField(arch, 'uxVersionControl.revertOperation');
+      if (!isObject(op)) return false;
+      return op.forwardCreating === true;
+    }
+  },
+  {
+    id: 'uxVersionControl.preservation-is-immutable-r2',
+    contributor: 'ux-version-control',
+    reads: ['uxVersionControl.designVersionRetention'],
+    severity: 'fail',
+    description:
+      'Preservation guarantee MUST be the literal `"immutable-r2-storage"`. Every uploaded UX is preserved forever in immutable R2 (spec §2.15). Tenant override may shorten active-window retention but never the preservation guarantee.',
+    detect(arch): boolean {
+      const r = readField(arch, 'uxVersionControl.designVersionRetention');
+      if (!isObject(r)) return false;
+      return r.preservationGuarantee === 'immutable-r2-storage';
+    }
+  },
+  {
+    id: 'uxVersionControl.gdpr-uses-tombstone-not-hard-delete',
+    contributor: 'ux-version-control',
+    reads: ['uxVersionControl.designVersionRetention'],
+    severity: 'fail',
+    description:
+      'GDPR delete MUST use tombstone + anonymization, never hard delete of the version row. `gdprInteraction` must be `"anonymize-in-version"` or `"purge-and-tombstone"`.',
+    detect(arch): boolean {
+      const r = readField(arch, 'uxVersionControl.designVersionRetention');
+      if (!isObject(r)) return false;
+      const g = r.gdprInteraction;
+      return g === 'anonymize-in-version' || g === 'purge-and-tombstone';
+    }
+  },
+  {
+    id: 'uxVersionControl.audit-trail-is-append-only',
+    contributor: 'ux-version-control',
+    reads: ['uxVersionControl.auditTrail'],
+    severity: 'fail',
+    description:
+      'Audit trail MUST be append-only and tamper-evident. `auditTrail.immutability` must equal "append-only".',
+    detect(arch): boolean {
+      const at = readField(arch, 'uxVersionControl.auditTrail');
+      if (!isObject(at)) return false;
+      return at.immutability === 'append-only';
+    }
+  },
+  {
+    id: 'uxVersionControl.audit-retention-meets-regulatory-floor',
+    contributor: 'ux-version-control',
+    reads: ['uxVersionControl.auditTrail'],
+    severity: 'fail',
+    description:
+      'Audit retention must be >= 7 years (2555 days) regulatory floor. Without this, the audit trail cannot survive a compliance audit.',
+    detect(arch): boolean {
+      const at = readField(arch, 'uxVersionControl.auditTrail');
+      if (!isObject(at)) return false;
+      const days = typeof at.retentionDays === 'number' ? at.retentionDays : -1;
+      return days >= 2555;
+    }
+  },
+  {
+    id: 'uxVersionControl.audit-attributes-operator-time-version',
+    contributor: 'ux-version-control',
+    reads: ['uxVersionControl.auditTrail'],
+    severity: 'fail',
+    description:
+      'Audit trail attributedFields MUST include who (operator id), when (UTC timestamp), AND versionId. Without these three, the audit log cannot correlate a revert to a design state.',
+    detect(arch): boolean {
+      const at = readField(arch, 'uxVersionControl.auditTrail');
+      if (!isObject(at)) return false;
+      const fields = at.attributedFields;
+      if (!Array.isArray(fields)) return false;
+      return fields.includes('who') && fields.includes('when') && fields.includes('versionId');
+    }
+  },
+  {
+    id: 'uxVersionControl.diff-layers-cover-five-dimensions',
+    contributor: 'ux-version-control',
+    reads: ['uxVersionControl.diffVisualizationSpec'],
+    severity: 'advisory',
+    description:
+      'Diff visualization should cover the five canonical layers proven by @caia/atlas-design-snapshotter (PR #538): tree, token, copy, asset, interactivity. Missing layers cascade into incomplete diff narration.',
+    detect(arch): boolean {
+      const d = readField(arch, 'uxVersionControl.diffVisualizationSpec');
+      if (!isObject(d)) return false;
+      const layers = d.diffLayers;
+      if (!Array.isArray(layers)) return false;
+      const required = ['tree', 'token', 'copy', 'asset', 'interactivity'];
+      for (const r of required) if (!layers.includes(r)) return false;
+      return true;
+    }
+  },
+  {
+    id: 'uxVersionControl.branching-default-off-in-v1',
+    contributor: 'ux-version-control',
+    reads: ['uxVersionControl.branchingStrategy'],
+    severity: 'advisory',
+    description:
+      'V1 posture: branching is OFF by default. `branchingStrategy.forkAllowed` should be `false` unless an operator opt-in is justified in `notes`. Enabling fork without a merge policy risks orphan branches.',
+    detect(arch): boolean {
+      const b = readField(arch, 'uxVersionControl.branchingStrategy');
+      if (!isObject(b)) return false;
+      // Advisory: it's fine to be `false`. If `true`, we require a non-null mergeStrategy.
+      if (b.forkAllowed !== true) return true;
+      return typeof b.mergeStrategy === 'string' && b.mergeStrategy.length > 0;
+    }
+  }
+];

--- a/packages/ux-version-control-architect/src/run.ts
+++ b/packages/ux-version-control-architect/src/run.ts
@@ -1,0 +1,124 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Flow:
+ *   1. Build the user prompt by serialising relevant slices of the input.
+ *   2. Call the spawner with the system prompt + user prompt.
+ *   3. Validate the output against the contract.
+ *   4. Return the `ArchitectOutput` with spend telemetry filled in.
+ *
+ * Re-runs REPLACE owned fields (no append) — the architect always emits
+ * the full set of its owned fields fresh.
+ *
+ * Failure handling:
+ *   - Spawner errored → return `status='failed'` with diagnostic.
+ *   - Validator errored → return `status='partial'` with the validation
+ *     errors stitched into `risks[]`.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { UX_VERSION_CONTROL_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+/**
+ * Project the input down to the JSON body the architect prompt expects.
+ * Privacy-sensitive tenant fields (schemaName, vaultNamespace) are
+ * omitted; the architect doesn't need them.
+ */
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+export async function runUxVersionControlArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: [],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(
+    spawn.text,
+    UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+  );
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: [],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  const parsed = validation.parsed;
+  return {
+    ...parsed,
+    architectName: deps.architectName,
+    spend
+  };
+}

--- a/packages/ux-version-control-architect/src/spawner.ts
+++ b/packages/ux-version-control-architect/src/spawner.ts
@@ -1,0 +1,115 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+export interface ArchitectSpawnOutput {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  model: string;
+  ok: boolean;
+  diagnostic: string | null;
+}
+
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/ux-version-control-architect/src/system-prompt.md
+++ b/packages/ux-version-control-architect/src/system-prompt.md
@@ -1,0 +1,30 @@
+<!--
+Static rendering of the UX Version Control Architect's system prompt.
+Canonical source: `src/system-prompt.ts` (`buildUxVersionControlSystemPrompt()`).
+Regenerate after a change with:
+  node -e "import('./dist/system-prompt.js').then(m => console.log(m.buildUxVersionControlSystemPrompt()))"
+-->
+
+## Role
+
+You are CAIA's UX Version Control Architect. You are a senior platform engineer focused on UX-asset version control + design-revert UX.
+
+You produce per-ticket UX-versioning specs that determine how this feature's design history is preserved. Distinct from the Time Machine Architect (#14) which owns CODE-level versioning; you own DESIGN-level versioning. You DO NOT write component code or backend logic. You DO specify the design-history contract.
+
+The forward-creating revert invariant — every design revert is a new version appended to the chain, never an overwrite — is the single most important contract guarantee. The preservation guarantee — every uploaded UX preserved forever in immutable R2 storage — is the second most important.
+
+## Owned fields (`uxVersionControl.*`)
+
+- `uxVersionControl.designVersionRetention` — how many design uploads kept, archival rules, GDPR interaction (preservation forever default)
+- `uxVersionControl.revertOperation` — forward-creating revert (never destructive); design vs section scope; replay mode (full vs selective)
+- `uxVersionControl.diffVisualizationSpec` — what the v1→v2 UX diff looks like (5 layers: tree/token/copy/asset/interactivity; semantic narration)
+- `uxVersionControl.branchingStrategy` — can a customer fork a design version (V1 default: no)
+- `uxVersionControl.auditTrail` — every UX upload + revert logged + attributed (who/when/versionId/parentVersionId/eventKind/reason)
+
+## Upstream dependencies
+
+Wave-1 architect: no upstream architect dependencies. Reads `designVersion` directly from input.
+
+## Distinct from Time Machine
+
+Time Machine (#14) owns CODE-level versioning (commits, deploys, rollbacks). This architect owns DESIGN-level versioning (uploads, design diffs, design reverts). The two contracts are disjoint by construction; the JSONB namespaces (`timeMachine.*` vs `uxVersionControl.*`) never collide.

--- a/packages/ux-version-control-architect/src/system-prompt.ts
+++ b/packages/ux-version-control-architect/src/system-prompt.ts
@@ -1,0 +1,228 @@
+/**
+ * The UX Version Control Architect's system prompt — a pure function
+ * returning a static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic; the briefing is what turns generic Claude
+ * into this specialist.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked stack
+ *   3. Input format
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples (terse — golden test fixture is the canonical example)
+ *
+ * The system-prompt test asserts each `uxVersionControl.*` field name
+ * appears at least once in the body. Keep that invariant true if you
+ * add fields.
+ */
+
+import { UX_VERSION_CONTROL_OWNED_FIELD_KEYS } from './contract.js';
+
+export function buildUxVersionControlSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+// ─── Section bodies ─────────────────────────────────────────────────────────
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's UX Version Control Architect. You are a senior platform
+engineer focused on UX-asset version control + design-revert UX.
+
+You produce per-ticket UX-versioning specs that determine how this
+feature's design history is preserved. Distinct from the Time Machine
+Architect (#14) which owns CODE-level versioning; you own
+DESIGN-level versioning. You DO NOT write component code or backend
+logic. You DO specify the design-history contract. Other architects own those
+concerns and will reject any field you populate outside the
+\`uxVersionControl.*\` namespace.
+
+The single most important contract guarantee is the **forward-creating
+revert invariant**: a design revert is itself a new version appended to
+the design-version chain — never a destructive overwrite of history. An
+operator must always be able to revert the revert, walk back to any
+uploaded UX, and read the full audit trail of what happened.
+
+The second most important guarantee is the **preservation guarantee**:
+every uploaded UX is preserved forever in immutable R2 storage (spec
+§2.15). GDPR delete uses tombstone + anonymize-in-version, never
+hard-delete of the version row.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Snapshot storage**: Cloudflare R2 via \`@caia/byo-cloud\` BYOC paths.
+  Mirrors the storage pattern proven by \`@caia/atlas-design-snapshotter\`
+  (PR #538) — \`captureSnapshot()\` + \`revertToVersion()\` are append-only
+  by construction.
+- **Version-ID format**: ULID (lexicographically sortable, time-ordered).
+  Snapshot keys: \`<tenant>/<project>/<ulid>\`.
+- **Immutability**: every design version is append-only. Never overwrite.
+  Never delete in place — GDPR delete uses tombstones + anonymization.
+- **Diff render surface**: \`atlas-design-snapshotter\` (the package whose
+  \`getDiff()\` method already returns the canonical structural diff over
+  the IR). Diff layers: tree, token, copy, asset, interactivity.
+- **Diff narration style**: semantic — "added X sections, modified Y
+  widgets, removed Z anchors". Not byte-level. Not pixel-level.
+- **Audit sink**: structured logs (operator's orchestrator log channel) +
+  Postgres \`audit_ux_version_events\` table for queryability.
+- **Retention floor**: 7-year audit retention for regulatory; the design
+  versions themselves are preserved forever.
+- **Branching posture (V1)**: linear chain only. \`forkAllowed=false\`
+  unless the operator explicitly opts in. Branching is a V2 follow-on.
+
+Reject any decision that violates the locked stack. If a ticket asks for
+"in-place history rewrite" or "hard delete of design versions", refuse,
+flag in \`risks\`, and emit the safe forward-creating spec anyway.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List|Site",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."] },
+  "businessPlan": { "ventureName": "...", "audience": "...",
+                    "businessRequirements": "..." },
+  "designVersion": { "versionId": "...", "snapshotUri": "...",
+                     "anchors": [ { "anchorId": "...", "kind": "...",
+                                    "bbox": {...}, "meta": {...} } ] },
+  "tenantContext": { "tenantId": "...", "schemaName": "...",
+                     "vaultNamespace": "...", "billingPosture": "..." },
+  "budget": { "preferredModel": "sonnet|opus" },
+  "upstream": { "outputs": {} }
+}
+\`\`\`
+
+Wave-1 architect: you have no upstream architect outputs. Read
+\`designVersion\` directly — its \`versionId\`, \`snapshotUri\`, and
+\`anchors\` are version-pinned at ticket creation.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "ux-version-control",
+  "architectureFields": {
+${UX_VERSION_CONTROL_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`uxVersionControl.designVersionRetention\` — \`{"maxVersionsKept":"unlimited","retentionDays":"forever","archivalSink":"r2://<tenant>-design-versions-cold/","archivalAfterDays":90,"gdprInteraction":"anonymize-in-version","tenantOverrideAllowed":true,"preservationGuarantee":"immutable-r2-storage"}\`. \`preservationGuarantee\` MUST be the literal \`"immutable-r2-storage"\`. \`gdprInteraction\` MUST be \`"anonymize-in-version"\` or \`"purge-and-tombstone"\` — never hard-delete.
+- \`uxVersionControl.revertOperation\` — \`{"invocation":"caia ux-version-control revert --version <versionId>","scope":"design|section","idempotencyKey":"<feature>:<targetVersionId>","forwardCreating":true,"replayMode":"full|selective","selectiveRevertScope":["<atlasAnchorId>"],"postCondition":"design returns to upload captured at version V; a new version V+N is appended documenting the revert"}\`. \`forwardCreating\` MUST be the literal \`true\` — the validator rejects any other value.
+- \`uxVersionControl.diffVisualizationSpec\` — \`{"renderSurface":"atlas-design-snapshotter","diffLayers":["tree","token","copy","asset","interactivity"],"narrationStyle":"semantic","anchorRefs":["<anchorId>"]}\`. \`diffLayers\` MUST be a non-empty array. \`narrationStyle\` MUST be \`"semantic"\`.
+- \`uxVersionControl.branchingStrategy\` — \`{"forkAllowed":false,"mergeStrategy":"manual-merge","abandonmentPolicy":"auto-archive-after-30-days","namingTemplate":"<parent-versionId>-fork-<ulid>","maxConcurrentBranches":5}\`. Default V1 posture: \`forkAllowed=false\` (linear chain). Only set to \`true\` when the operator has explicitly opted in.
+- \`uxVersionControl.auditTrail\` — \`{"logSink":["stdout-structured","postgres:audit_ux_version_events"],"attributedFields":["who","when","versionId","parentVersionId","eventKind","reason"],"retentionDays":2555,"immutability":"append-only","queryability":{"byOperator":true,"byVersion":true,"byTimeRange":true,"byEventKind":true}}\`. \`retentionDays\` floor is 7 years (2555). \`immutability\` MUST be \`"append-only"\`. \`attributedFields\` MUST include \`who\` AND \`when\` AND \`versionId\`.`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **Forward-creating revert is non-negotiable.** Never propose an
+  in-place rollback. Every revert is itself a new design version — the
+  version chain only grows.
+- **Preservation is forever.** Every uploaded UX stays in R2 immutable
+  storage. Tenant override may shorten the active-window retention but
+  never the preservation guarantee.
+- **Snapshot keys are ULIDs.** Time-ordered + lexicographically sortable.
+  Snapshot path: \`<tenant>/<project>/<ulid>\`.
+- **Diff layers are five: tree, token, copy, asset, interactivity.**
+  These mirror what \`@caia/atlas-design-snapshotter\` already produces
+  (PR #538: \`diff.ts\`). Do not invent new layers.
+- **Diff narration is semantic.** "Added 2 sections, modified 1 widget,
+  removed 0 anchors" — NOT "12 bytes changed" or "138 pixels different".
+- **GDPR delete uses tombstones + anonymization, never hard delete.**
+  Mirror the design-snapshotter's \`deleteAllForTenant\` behaviour: rows
+  stay; PII fields anonymize.
+- **Scope follows ticket type.** Page tickets revert at \`design\` scope.
+  Widget tickets revert at \`section\` scope.
+- **Branching is OFF by default in V1.** Only enable when explicit.
+- **Audit retention >= preservation retention.** Operators must be able
+  to query the audit log for the lifetime of every version it references.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Propose destructive revert (in-place overwrite, history rewrite,
+  squash, force-push of a design version)** → refuse. Emit
+  \`forwardCreating: true\` anyway, list the override request in
+  \`risks[]\`, set \`confidence\` to 0.4.
+- **Hard-delete a design version for GDPR** → refuse. Use tombstone +
+  anonymization. List the operator-stated GDPR concern under \`risks\`.
+- **Set the preservation guarantee to anything other than
+  immutable-r2-storage** → refuse. Default to the locked value.
+- **Set audit retention below the regulatory 7-year floor (2555 days)**
+  → refuse. Apply the floor; list under \`risks\`.
+- **Enable branching without operator opt-in** → refuse. Default
+  \`forkAllowed=false\` for V1; list the request under \`risks\`.
+- **Decide a database schema, API endpoint, RLS policy, frontend
+  component, test strategy, CSP rule, or any field NOT under
+  \`uxVersionControl.*\`** → ignore the request. Do not populate fields
+  outside your owned namespace.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated even if the value is the documented default.`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the 5 owned field
+   paths (no extras, no missing).
+2. \`uxVersionControl.revertOperation.forwardCreating === true\` (literal).
+3. \`uxVersionControl.designVersionRetention.preservationGuarantee === "immutable-r2-storage"\`.
+4. \`uxVersionControl.auditTrail.immutability === "append-only"\`.
+5. \`uxVersionControl.auditTrail.retentionDays\` >= 2555 (7-year regulatory floor).
+6. \`uxVersionControl.auditTrail.attributedFields\` includes \`"who"\`,
+   \`"when"\`, AND \`"versionId"\`.
+7. \`uxVersionControl.diffVisualizationSpec.diffLayers\` is a non-empty
+   array; \`narrationStyle === "semantic"\`.
+8. \`uxVersionControl.branchingStrategy.forkAllowed\` defaults to \`false\`
+   unless an operator opt-in is justified in \`notes\`.
+9. \`confidence\` reflects how comfortable you are with the decision —
+   sub-0.6 triggers the EA Reviewer to scrutinize.
+10. \`notes\` is <= 800 characters.
+11. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input -> output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a Page ticket producing a contact-form submission
+yields a designVersionRetention block with preservationGuarantee=immutable-r2-storage
++ archivalAfterDays=90, a revertOperation with design-scope +
+forwardCreating=true + replayMode=selective (re-architect only tickets
+that touch the reverted anchors), a diffVisualizationSpec with all five
+diff layers + semantic narration, a branchingStrategy with
+forkAllowed=false (V1 posture), and an auditTrail block with
+attributedFields covering who/when/versionId/parentVersionId/eventKind/reason
+and 7-year retention floor.`;

--- a/packages/ux-version-control-architect/src/types.ts
+++ b/packages/ux-version-control-architect/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * This module exists as a thin re-export so the rest of this package
+ * has a single import surface. Mirrors the Frontend Architect template
+ * verbatim — only the architect-specific field-spec lives in
+ * `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/ux-version-control-architect/src/validation.ts
+++ b/packages/ux-version-control-architect/src/validation.ts
@@ -1,0 +1,202 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Two layers:
+ *
+ *   1. **Structural** — does the JSON parse, and does it have the
+ *      required top-level keys (`architectName`, `architectureFields`,
+ *      `confidence`, `notes`, `dependencies`, `risks`, `toolCalls`,
+ *      `spend`, `status`)?
+ *
+ *   2. **Contract** — does `architectureFields` contain exactly the keys
+ *      this architect owns (no extras, no missing)? This is the
+ *      Dispatcher's first invariant per spec §3.4.
+ *
+ * The validator is pure + synchronous. Failures return a structured
+ * `ValidationResult.errors[]` array — the architect's `run()` decides
+ * whether to retry, mark partial, or mark failed.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/ux-version-control-architect/tests/architect.test.ts
+++ b/packages/ux-version-control-architect/tests/architect.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `UxVersionControlArchitect` — interface compliance tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  UxVersionControlArchitect,
+  UX_VERSION_CONTROL_ARCHITECT_NAME,
+  UX_VERSION_CONTROL_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { UxVersionControlArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('UxVersionControlArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new UxVersionControlArchitect();
+    expect(a).toBeInstanceOf(UxVersionControlArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new UxVersionControlArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the V2 task brief', () => {
+    const a = new UxVersionControlArchitect();
+    expect(a.name).toBe('ux-version-control');
+    expect(a.name).toBe(UX_VERSION_CONTROL_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new UxVersionControlArchitect();
+    expect(a.sectionContract).toBe(UxVersionControlArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new UxVersionControlArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1 task brief', () => {
+    const a = new UxVersionControlArchitect();
+    expect(a.tools).toBe(UX_VERSION_CONTROL_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new UxVersionControlArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new UxVersionControlArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new UxVersionControlArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new UxVersionControlArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('ux-version-control');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new UxVersionControlArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    const a = new UxVersionControlArchitect();
+    expect(a).toBeInstanceOf(UxVersionControlArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/ux-version-control-architect/tests/contract.test.ts
+++ b/packages/ux-version-control-architect/tests/contract.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Section contract structural + registration tests.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { UxVersionControlArchitect } from '../src/architect.js';
+import {
+  UX_VERSION_CONTROL_ARCHITECT_META,
+  UX_VERSION_CONTROL_OWNED_SECTIONS,
+  UX_VERSION_CONTROL_OWNED_FIELD_KEYS,
+  UxVersionControlArchitectContract,
+  uxVersionControlArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('UxVersionControlArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(UxVersionControlArchitectContract.contractId).toBe(
+      'ux-version-control-architect.v1'
+    );
+  });
+
+  it('architectName is `ux-version-control` (matches V2 task brief)', () => {
+    expect(UxVersionControlArchitectContract.architectName).toBe('ux-version-control');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(UxVersionControlArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `uxVersionControl.`', () => {
+    for (const key of UX_VERSION_CONTROL_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('uxVersionControl.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the V2 task-brief mandatory fields', () => {
+    const required = [
+      'uxVersionControl.designVersionRetention',
+      'uxVersionControl.revertOperation',
+      'uxVersionControl.diffVisualizationSpec',
+      'uxVersionControl.branchingStrategy',
+      'uxVersionControl.auditTrail'
+    ];
+    for (const r of required) {
+      expect(UX_VERSION_CONTROL_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('owns exactly the V2 task brief field set (no extras, no gaps)', () => {
+    expect([...UX_VERSION_CONTROL_OWNED_FIELD_KEYS].sort()).toEqual(
+      [
+        'uxVersionControl.auditTrail',
+        'uxVersionControl.branchingStrategy',
+        'uxVersionControl.designVersionRetention',
+        'uxVersionControl.diffVisualizationSpec',
+        'uxVersionControl.revertOperation'
+      ].sort()
+    );
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of UX_VERSION_CONTROL_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(UxVersionControlArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(UxVersionControlArchitectContract).sort()).toEqual(
+      [...UX_VERSION_CONTROL_OWNED_FIELD_KEYS].sort()
+    );
+  });
+
+  it('owned namespace is disjoint from sibling `timeMachine.*`', () => {
+    for (const key of UX_VERSION_CONTROL_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('timeMachine.')).toBe(false);
+    }
+  });
+});
+
+describe('UxVersionControlArchitectContract — architectMeta', () => {
+  it('declares no upstream dependencies (wave-1)', () => {
+    expect(UX_VERSION_CONTROL_ARCHITECT_META.dependsOn).toEqual([]);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(UX_VERSION_CONTROL_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(UX_VERSION_CONTROL_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 16 per spec §5.2', () => {
+    expect(UX_VERSION_CONTROL_ARCHITECT_META.precedenceLevel).toBe(16);
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(UX_VERSION_CONTROL_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per spec §2.15', () => {
+    expect(UX_VERSION_CONTROL_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(UX_VERSION_CONTROL_ARCHITECT_META.appliesPredicate).toBe(
+      uxVersionControlArchitectAppliesPredicate
+    );
+  });
+
+  it("canonical precedence ladder lists this architect under the 'uxVersionControl' alias", () => {
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('uxVersionControl');
+    expect(precedenceRank('uxVersionControl')).toBe(
+      UX_VERSION_CONTROL_ARCHITECT_META.precedenceLevel
+    );
+  });
+});
+
+describe('uxVersionControlArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Page' };
+
+  it('returns true for Page', () => {
+    expect(
+      uxVersionControlArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })
+    ).toBe(true);
+  });
+
+  it('returns true for Widget', () => {
+    expect(
+      uxVersionControlArchitectAppliesPredicate({ ...baseTicket, type: 'Widget' })
+    ).toBe(true);
+  });
+
+  it('returns true for Story', () => {
+    expect(
+      uxVersionControlArchitectAppliesPredicate({ ...baseTicket, type: 'Story' })
+    ).toBe(true);
+  });
+
+  it('returns true for Form', () => {
+    expect(
+      uxVersionControlArchitectAppliesPredicate({ ...baseTicket, type: 'Form' })
+    ).toBe(true);
+  });
+
+  it('returns true for List', () => {
+    expect(
+      uxVersionControlArchitectAppliesPredicate({ ...baseTicket, type: 'List' })
+    ).toBe(true);
+  });
+
+  it('returns true for Site (spec §2.15 scope)', () => {
+    expect(
+      uxVersionControlArchitectAppliesPredicate({ ...baseTicket, type: 'Site' })
+    ).toBe(true);
+  });
+
+  it('returns false for Foundation (no UX upload)', () => {
+    expect(
+      uxVersionControlArchitectAppliesPredicate({ ...baseTicket, type: 'Foundation' })
+    ).toBe(false);
+  });
+
+  it('returns false for an unrecognised ticket type', () => {
+    expect(
+      uxVersionControlArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })
+    ).toBe(false);
+  });
+});
+
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the UX Version Control architect cleanly', () => {
+    expect(() => {
+      registry.register(new UxVersionControlArchitect());
+    }).not.toThrow();
+    expect(registry.get('ux-version-control')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new UxVersionControlArchitect());
+    for (const k of UX_VERSION_CONTROL_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('ux-version-control');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new UxVersionControlArchitect());
+    expect(() => registry.register(new UxVersionControlArchitect())).toThrowError(
+      ArchitectRegistryError
+    );
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new UxVersionControlArchitect());
+
+    const collidingContract: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'uxVersionControl.revertOperation',
+          description: 'colliding owner',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 17,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', collidingContract));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a sibling architect with disjoint owned fields (timeMachine namespace)', () => {
+    registry.register(new UxVersionControlArchitect());
+    const tmContract: ArchitectSectionContract = {
+      contractId: 'time-machine-architect.v1',
+      architectName: 'time-machine',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'timeMachine.revertOperation',
+          description: 'CODE-level revert',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 15,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('time-machine', tmContract));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS.length + 1
+    );
+  });
+
+  it('disjointness() detects no conflicts when only UX Version Control is present', () => {
+    const conflicts = disjointness([UxVersionControlArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between UX Version Control and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...UxVersionControlArchitectContract,
+      contractId: 'ux-version-control-clone.v1',
+      architectName: 'ux-version-control-clone'
+    };
+    const conflicts = disjointness([UxVersionControlArchitectContract, clone]);
+    expect(conflicts.length).toBe(UX_VERSION_CONTROL_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() is empty when only UX Version Control is registered (wave-1, no deps)', () => {
+    registry.register(new UxVersionControlArchitect());
+    expect(registry.validate()).toEqual([]);
+  });
+});

--- a/packages/ux-version-control-architect/tests/golden/golden.test.ts
+++ b/packages/ux-version-control-architect/tests/golden/golden.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Golden test — the canonical known-good UX Version Control artifact
+ * for a known prakash-tiwari Page ticket (the /artists/[slug] booking
+ * page UX-versioning spec).
+ *
+ * Pins:
+ *   - The FORWARD-CREATING REVERT INVARIANT — every design revert is
+ *     itself a new version appended at the chain tip, never an overwrite
+ *     of prior history.
+ *   - The PRESERVATION GUARANTEE — every uploaded UX preserved forever
+ *     in immutable R2 storage (spec §2.15).
+ *
+ * Also serves as the canonical fixture the other 16 architect packages
+ * reference when validating cross-architect disjointness.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { UxVersionControlArchitect } from '../../src/architect.js';
+import { UX_VERSION_CONTROL_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { UX_VERSION_CONTROL_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari /artists/[slug] UX Version Control Page ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-designversion.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-designversion.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().designVersion;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(
+      goldenAssistantText(),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new UxVersionControlArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    expect(out.architectName).toBe('ux-version-control');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    for (const k of UX_VERSION_CONTROL_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.dependencies).toEqual(expected.dependencies);
+    expect(out.risks).toEqual(expected.risks);
+  });
+
+  it('output passes every UX Version Control invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new UxVersionControlArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of UX_VERSION_CONTROL_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new UxVersionControlArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+});
+
+/**
+ * The CANONICAL forward-creating-revert verification (design-version chain).
+ *
+ * Simulates a design-version chain with reverts in the middle. The contract
+ * guarantee under test: a design revert MUST append a new version at the tip
+ * — never overwrite any prior version. After a revert, the chain has one
+ * MORE entry than before, with every prior entry byte-identical.
+ *
+ * If the architect's output describes destructive revert, this simulation
+ * throws — pinning the invariant at the test layer. Mirrors the immutability
+ * guarantee proven in `@caia/atlas-design-snapshotter` (PR #538).
+ */
+describe('golden — forward-creating revert invariant (design-version chain)', () => {
+  interface DesignChainEntry {
+    readonly versionId: string;
+    readonly kind: 'upload' | 'revert';
+    readonly description: string;
+    readonly revertsTo?: string;
+  }
+
+  function applyRevertPerContract(
+    chain: readonly DesignChainEntry[],
+    targetVersionId: string,
+    revertSpec: Readonly<Record<string, unknown>>
+  ): readonly DesignChainEntry[] {
+    if (revertSpec.forwardCreating !== true) {
+      throw new Error(
+        `forward-creating revert invariant violated: ` +
+          `revertOperation.forwardCreating=${String(revertSpec.forwardCreating)}; ` +
+          'expected literal true.'
+      );
+    }
+    const tip = chain[chain.length - 1];
+    const nextIndex = chain.length;
+    const nextVersionId = `v${nextIndex.toString().padStart(3, '0')}`;
+    const revertEntry: DesignChainEntry = {
+      versionId: nextVersionId,
+      kind: 'revert',
+      description: `revert to ${targetVersionId} (from ${tip?.versionId ?? 'genesis'})`,
+      revertsTo: targetVersionId
+    };
+    return [...chain, revertEntry];
+  }
+
+  it('revert spec is forward-creating (literal boolean true)', () => {
+    const golden = goldenExpectedOutput();
+    const rev = golden.architectureFields['uxVersionControl.revertOperation'] as Record<
+      string,
+      unknown
+    >;
+    expect(rev.forwardCreating).toBe(true);
+    expect(typeof rev.forwardCreating).toBe('boolean');
+  });
+
+  it('a simulated design-version revert appends a NEW version at the chain tip', () => {
+    const golden = goldenExpectedOutput();
+    const rev = golden.architectureFields['uxVersionControl.revertOperation'] as Record<
+      string,
+      unknown
+    >;
+
+    const initialChain: readonly DesignChainEntry[] = [
+      { versionId: 'v000', kind: 'upload', description: 'initial hero + form design' },
+      { versionId: 'v001', kind: 'upload', description: 'redesign hero portrait' },
+      { versionId: 'v002', kind: 'upload', description: 'broken: removed CTA from hero' }
+    ];
+
+    const after = applyRevertPerContract(initialChain, 'v001', rev);
+
+    expect(after.length).toBe(initialChain.length + 1);
+    const tip = after[after.length - 1];
+    expect(tip?.kind).toBe('revert');
+    expect(tip?.revertsTo).toBe('v001');
+    for (let i = 0; i < initialChain.length; i++) {
+      expect(after[i]).toBe(initialChain[i]);
+    }
+  });
+
+  it('a destructive revert spec throws (proves the simulation enforces the invariant)', () => {
+    const destructiveSpec: Record<string, unknown> = {
+      invocation: 'caia ux-version-control revert --hard',
+      scope: 'design',
+      forwardCreating: false,
+      postCondition: 'overwrites version in place'
+    };
+    const initialChain: readonly DesignChainEntry[] = [
+      { versionId: 'v000', kind: 'upload', description: 'first' }
+    ];
+    expect(() => applyRevertPerContract(initialChain, 'v000', destructiveSpec)).toThrow(
+      /forward-creating revert invariant violated/
+    );
+  });
+
+  it('successive design reverts keep growing the chain (revert of a revert)', () => {
+    const golden = goldenExpectedOutput();
+    const rev = golden.architectureFields['uxVersionControl.revertOperation'] as Record<
+      string,
+      unknown
+    >;
+
+    const c0: readonly DesignChainEntry[] = [
+      { versionId: 'v000', kind: 'upload', description: 'first' },
+      { versionId: 'v001', kind: 'upload', description: 'second' },
+      { versionId: 'v002', kind: 'upload', description: 'broken third' }
+    ];
+    const c1 = applyRevertPerContract(c0, 'v001', rev);
+    const c2 = applyRevertPerContract(c1, 'v002', rev);
+
+    expect(c0.length).toBe(3);
+    expect(c1.length).toBe(4);
+    expect(c2.length).toBe(5);
+    for (let i = 0; i < 3; i++) {
+      expect(c2[i]).toBe(c0[i]);
+    }
+    expect(c2[c2.length - 1]?.revertsTo).toBe('v002');
+  });
+
+  it('revertOperation.postCondition describes append behaviour, not overwrite', () => {
+    const golden = goldenExpectedOutput();
+    const rev = golden.architectureFields['uxVersionControl.revertOperation'] as Record<
+      string,
+      unknown
+    >;
+    const pc = String(rev.postCondition ?? '');
+    expect(pc).toContain('appended');
+    expect(pc).not.toMatch(/\boverwrite\b/i);
+    expect(pc).not.toMatch(/\brewrit/i);
+    expect(pc).not.toMatch(/\bdestructive\b/i);
+  });
+
+  it('preservationGuarantee is immutable-r2-storage (no version is ever destroyed)', () => {
+    const golden = goldenExpectedOutput();
+    const retention = golden.architectureFields[
+      'uxVersionControl.designVersionRetention'
+    ] as Record<string, unknown>;
+    expect(retention.preservationGuarantee).toBe('immutable-r2-storage');
+  });
+
+  it('retentionDays defaults to "forever" (spec §2.15: preserve every upload forever)', () => {
+    const golden = goldenExpectedOutput();
+    const retention = golden.architectureFields[
+      'uxVersionControl.designVersionRetention'
+    ] as Record<string, unknown>;
+    expect(retention.retentionDays).toBe('forever');
+  });
+
+  it('auditTrail declares append-only immutability (every revert is logged forever)', () => {
+    const golden = goldenExpectedOutput();
+    const at = golden.architectureFields['uxVersionControl.auditTrail'] as Record<
+      string,
+      unknown
+    >;
+    expect(at.immutability).toBe('append-only');
+  });
+
+  it('auditTrail retentionDays meets 7-year regulatory floor (2555 days)', () => {
+    const golden = goldenExpectedOutput();
+    const at = golden.architectureFields['uxVersionControl.auditTrail'] as Record<
+      string,
+      unknown
+    >;
+    expect(typeof at.retentionDays).toBe('number');
+    expect(at.retentionDays as number).toBeGreaterThanOrEqual(2555);
+  });
+
+  it('diffVisualizationSpec covers all five canonical layers (tree/token/copy/asset/interactivity)', () => {
+    const golden = goldenExpectedOutput();
+    const diff = golden.architectureFields[
+      'uxVersionControl.diffVisualizationSpec'
+    ] as Record<string, unknown>;
+    const layers = diff.diffLayers as readonly string[];
+    expect(layers).toContain('tree');
+    expect(layers).toContain('token');
+    expect(layers).toContain('copy');
+    expect(layers).toContain('asset');
+    expect(layers).toContain('interactivity');
+  });
+
+  it('branchingStrategy.forkAllowed is false (V1 posture: linear chain only)', () => {
+    const golden = goldenExpectedOutput();
+    const b = golden.architectureFields['uxVersionControl.branchingStrategy'] as Record<
+      string,
+      unknown
+    >;
+    expect(b.forkAllowed).toBe(false);
+  });
+});

--- a/packages/ux-version-control-architect/tests/golden/input-businessplan.json
+++ b/packages/ux-version-control-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,12 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions",
+    "Project warm + grounded brand voice",
+    "Make the booking CTA the page's primary action"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": ["No third-party fonts beyond next/font defaults"]
+}

--- a/packages/ux-version-control-architect/tests/golden/input-designversion.json
+++ b/packages/ux-version-control-architect/tests/golden/input-designversion.json
@@ -1,0 +1,24 @@
+{
+  "versionId": "design-pt-v3-2026-05-22",
+  "snapshotUri": "s3://atlas/designs/design-pt-v3-2026-05-22.png",
+  "anchors": [
+    {
+      "anchorId": "hero",
+      "kind": "section",
+      "bbox": { "x": 0, "y": 0, "w": 1440, "h": 720 },
+      "meta": { "variant": "hero" }
+    },
+    {
+      "anchorId": "hero-cta-primary",
+      "kind": "button",
+      "bbox": { "x": 600, "y": 320, "w": 200, "h": 56 },
+      "meta": { "variant": "primary" }
+    },
+    {
+      "anchorId": "booking-form",
+      "kind": "form",
+      "bbox": { "x": 0, "y": 720, "w": 1440, "h": 600 },
+      "meta": { "fields": ["name", "email", "date"] }
+    }
+  ]
+}

--- a/packages/ux-version-control-architect/tests/golden/input-ticket.json
+++ b/packages/ux-version-control-architect/tests/golden/input-ticket.json
@@ -1,0 +1,19 @@
+{
+  "id": "ticket-pt-015",
+  "type": "Page",
+  "scope": "story",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "Every UX upload for /artists/[slug] is preserved forever in immutable R2 storage.",
+    "Operator can revert the page design to any past upload in one CLI invocation.",
+    "Design revert is forward-creating: a revert is itself a new design version at the chain tip.",
+    "Diff between any two design versions narrates as \"added X sections, modified Y widgets, removed Z anchors\".",
+    "Audit trail records who uploaded/reverted, when, versionId, parentVersionId, eventKind, and reason.",
+    "GDPR delete on a design-asset anonymizes the matching version field; never hard-deletes the version row."
+  ],
+  "business_requirements": {
+    "title": "Artist booking page with UX version control",
+    "description": "The /artists/[slug] page is the conversion surface for prakash-tiwari.com. Designers iterate on it weekly. UX Version Control preserves every uploaded design forever in immutable R2, supports forward-creating revert to any prior version, and renders semantic diffs across the five canonical layers (tree/token/copy/asset/interactivity)."
+  },
+  "quality_tags": ["versioned", "ux-version-control"]
+}

--- a/packages/ux-version-control-architect/tests/helpers/fakes.ts
+++ b/packages/ux-version-control-architect/tests/helpers/fakes.ts
@@ -1,0 +1,226 @@
+/**
+ * Test fixtures + fake spawner factory.
+ *
+ *   - `buildFakeInput()` — produces a deterministic `ArchitectInput` for
+ *     a known prakash-tiwari Site/Page ticket. The golden test uses this.
+ *
+ *   - `fakeSpawnerReturning(text)` — fabricates an `ArchitectSpawnerFn`
+ *     that returns the given text deterministically.
+ *
+ *   - `goldenExpectedOutput()` — the canonical known-good
+ *     `ArchitectOutput` for the prakash-tiwari fixture.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { UX_VERSION_CONTROL_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+/**
+ * The canonical fixture — a Site-scope ticket for the prakash-tiwari.com
+ * marketing site, focused on a UX upload (the design IR + anchors map).
+ * The UX Version Control architect spec'd here governs how every uploaded
+ * version of this design is preserved, diffed, reverted, and audited.
+ */
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-015',
+      type: 'Page',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'Every UX upload for /artists/[slug] is preserved forever in immutable R2 storage.',
+        'Operator can revert the page design to any past upload in one CLI invocation.',
+        'Design revert is forward-creating: a revert is itself a new design version at the chain tip.',
+        'Diff between any two design versions narrates as "added X sections, modified Y widgets, removed Z anchors".',
+        'Audit trail records who uploaded/reverted, when, versionId, parentVersionId, eventKind, and reason.',
+        'GDPR delete on a design-asset anonymizes the matching version field; never hard-deletes the version row.'
+      ],
+      business_requirements: {
+        title: 'Artist booking page with UX version control',
+        description:
+          'The /artists/[slug] page is the conversion surface for prakash-tiwari.com. Designers iterate on it weekly. UX Version Control preserves every uploaded design forever in immutable R2, supports forward-creating revert to any prior version, and renders semantic diffs across the five canonical layers (tree/token/copy/asset/interactivity).'
+      },
+      quality_tags: ['versioned', 'ux-version-control']
+    },
+    upstream: { outputs: {} },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: "High-intent prospective sitters in the artist's metropolitan area.",
+      goals: [
+        'Drive contact-form submissions',
+        'Project warm + grounded brand voice',
+        "Make the booking CTA the page's primary action"
+      ],
+      brandVoice: 'warm + grounded',
+      constraints: ['No third-party fonts beyond next/font defaults']
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [
+        {
+          anchorId: 'hero',
+          kind: 'section',
+          bbox: { x: 0, y: 0, w: 1440, h: 720 },
+          meta: { variant: 'hero' }
+        },
+        {
+          anchorId: 'hero-cta-primary',
+          kind: 'button',
+          bbox: { x: 600, y: 320, w: 200, h: 56 },
+          meta: { variant: 'primary' }
+        },
+        {
+          anchorId: 'booking-form',
+          kind: 'form',
+          bbox: { x: 0, y: 720, w: 1440, h: 600 },
+          meta: { fields: ['name', 'email', 'date'] }
+        }
+      ]
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'ux-version-control',
+    architectureFields: {
+      'uxVersionControl.designVersionRetention': {
+        maxVersionsKept: 'unlimited',
+        retentionDays: 'forever',
+        archivalSink: 'r2://tenant-prakash-tiwari-design-versions-cold/',
+        archivalAfterDays: 90,
+        gdprInteraction: 'anonymize-in-version',
+        tenantOverrideAllowed: true,
+        preservationGuarantee: 'immutable-r2-storage'
+      },
+      'uxVersionControl.revertOperation': {
+        invocation: 'caia ux-version-control revert --version <versionId>',
+        scope: 'design',
+        idempotencyKey: 'artists-slug-page:<targetVersionId>',
+        forwardCreating: true,
+        replayMode: 'selective',
+        selectiveRevertScope: ['hero', 'hero-cta-primary', 'booking-form'],
+        postCondition:
+          'design returns to upload captured at version V; a new version V+N is appended documenting the revert'
+      },
+      'uxVersionControl.diffVisualizationSpec': {
+        renderSurface: 'atlas-design-snapshotter',
+        diffLayers: ['tree', 'token', 'copy', 'asset', 'interactivity'],
+        narrationStyle: 'semantic',
+        anchorRefs: ['hero', 'hero-cta-primary', 'booking-form']
+      },
+      'uxVersionControl.branchingStrategy': {
+        forkAllowed: false,
+        mergeStrategy: 'manual-merge',
+        abandonmentPolicy: 'auto-archive-after-30-days',
+        namingTemplate: '<parent-versionId>-fork-<ulid>',
+        maxConcurrentBranches: 5
+      },
+      'uxVersionControl.auditTrail': {
+        logSink: ['stdout-structured', 'postgres:audit_ux_version_events'],
+        attributedFields: [
+          'who',
+          'when',
+          'versionId',
+          'parentVersionId',
+          'eventKind',
+          'reason'
+        ],
+        retentionDays: 2555,
+        immutability: 'append-only',
+        queryability: {
+          byOperator: true,
+          byVersion: true,
+          byTimeRange: true,
+          byEventKind: true
+        }
+      }
+    },
+    confidence: 0.9,
+    notes:
+      'Page-scope UX version control for /artists/[slug]. Preservation forever in immutable R2; archive cold after 90 days. Forward-creating revert at design scope; replayMode=selective so only tickets touching the reverted anchors are re-architected. Diff renders via atlas-design-snapshotter across all five canonical layers with semantic narration. Branching OFF in V1 (forkAllowed=false). Audit trail at 7-year regulatory floor, append-only, attributed to operator + UTC time + versionId + parentVersionId + eventKind + reason.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/** The canonical assistant text — `JSON.stringify(goldenExpectedOutput())`. */
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+/**
+ * Fabricate an `ArchitectSpawnerFn` that returns the given text on every
+ * call. Records every call for assertions.
+ */
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+/** Fabricate a spawner that returns the canonical golden assistant text. */
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+/**
+ * Asserts that the input covers every required owned field. Sanity check
+ * for fixtures.
+ */
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of UX_VERSION_CONTROL_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/ux-version-control-architect/tests/invariants.test.ts
+++ b/packages/ux-version-control-architect/tests/invariants.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Cross-architect invariants — verifies UX Version Control's contributions
+ * to the EA Reviewer's invariant registry (per spec §6.2).
+ *
+ * The forward-creating revert invariant + preservation guarantee are the
+ * most important ones.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { UX_VERSION_CONTROL_INVARIANTS } from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('UX_VERSION_CONTROL_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(UX_VERSION_CONTROL_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of UX_VERSION_CONTROL_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `ux-version-control`', () => {
+    for (const inv of UX_VERSION_CONTROL_INVARIANTS) {
+      expect(inv.contributor).toBe('ux-version-control');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of UX_VERSION_CONTROL_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of UX_VERSION_CONTROL_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of UX_VERSION_CONTROL_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('UX_VERSION_CONTROL_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of UX_VERSION_CONTROL_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('revert-is-forward-creating FAILS when revertOperation.forwardCreating is false', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.revert-is-forward-creating'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.revertOperation': {
+        ...(goldenArch['uxVersionControl.revertOperation'] as Record<string, unknown>),
+        forwardCreating: false
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+    expect(inv!.severity).toBe('fail');
+  });
+
+  it('revert-is-forward-creating FAILS when forwardCreating is missing', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.revert-is-forward-creating'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.revertOperation': {
+        invocation: 'caia ux-version-control revert --version <versionId>',
+        scope: 'design'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('preservation-is-immutable-r2 FAILS when preservationGuarantee is changed', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.preservation-is-immutable-r2'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.designVersionRetention': {
+        ...(goldenArch['uxVersionControl.designVersionRetention'] as Record<
+          string,
+          unknown
+        >),
+        preservationGuarantee: 'best-effort-ephemeral'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+    expect(inv!.severity).toBe('fail');
+  });
+
+  it('gdpr-uses-tombstone-not-hard-delete FAILS when gdprInteraction is hard-delete', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.gdpr-uses-tombstone-not-hard-delete'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.designVersionRetention': {
+        ...(goldenArch['uxVersionControl.designVersionRetention'] as Record<
+          string,
+          unknown
+        >),
+        gdprInteraction: 'hard-delete'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('gdpr-uses-tombstone-not-hard-delete PASSES for purge-and-tombstone variant', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.gdpr-uses-tombstone-not-hard-delete'
+    );
+    expect(inv).toBeDefined();
+    const variant = {
+      ...goldenArch,
+      'uxVersionControl.designVersionRetention': {
+        ...(goldenArch['uxVersionControl.designVersionRetention'] as Record<
+          string,
+          unknown
+        >),
+        gdprInteraction: 'purge-and-tombstone'
+      }
+    };
+    expect(inv!.detect(variant)).toBe(true);
+  });
+
+  it('audit-trail-is-append-only FAILS when immutability is rewritable', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.audit-trail-is-append-only'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.auditTrail': {
+        ...(goldenArch['uxVersionControl.auditTrail'] as Record<string, unknown>),
+        immutability: 'rewritable'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('audit-retention-meets-regulatory-floor FAILS below 2555 days', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.audit-retention-meets-regulatory-floor'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.auditTrail': {
+        ...(goldenArch['uxVersionControl.auditTrail'] as Record<string, unknown>),
+        retentionDays: 30
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('audit-attributes-operator-time-version FAILS when `who` is missing', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.audit-attributes-operator-time-version'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.auditTrail': {
+        ...(goldenArch['uxVersionControl.auditTrail'] as Record<string, unknown>),
+        attributedFields: ['when', 'versionId', 'parentVersionId']
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('audit-attributes-operator-time-version FAILS when `when` is missing', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.audit-attributes-operator-time-version'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.auditTrail': {
+        ...(goldenArch['uxVersionControl.auditTrail'] as Record<string, unknown>),
+        attributedFields: ['who', 'versionId', 'parentVersionId']
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('audit-attributes-operator-time-version FAILS when `versionId` is missing', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.audit-attributes-operator-time-version'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.auditTrail': {
+        ...(goldenArch['uxVersionControl.auditTrail'] as Record<string, unknown>),
+        attributedFields: ['who', 'when', 'parentVersionId']
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('diff-layers-cover-five-dimensions FAILS when a canonical layer is missing', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.diff-layers-cover-five-dimensions'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.diffVisualizationSpec': {
+        ...(goldenArch['uxVersionControl.diffVisualizationSpec'] as Record<
+          string,
+          unknown
+        >),
+        diffLayers: ['tree', 'token', 'copy', 'asset'] // missing 'interactivity'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+    expect(inv!.severity).toBe('advisory');
+  });
+
+  it('branching-default-off-in-v1 PASSES when forkAllowed=false (golden default)', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.branching-default-off-in-v1'
+    );
+    expect(inv).toBeDefined();
+    expect(inv!.detect(goldenArch)).toBe(true);
+  });
+
+  it('branching-default-off-in-v1 PASSES when forkAllowed=true with a non-empty mergeStrategy', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.branching-default-off-in-v1'
+    );
+    expect(inv).toBeDefined();
+    const variant = {
+      ...goldenArch,
+      'uxVersionControl.branchingStrategy': {
+        ...(goldenArch['uxVersionControl.branchingStrategy'] as Record<string, unknown>),
+        forkAllowed: true,
+        mergeStrategy: 'manual-merge'
+      }
+    };
+    expect(inv!.detect(variant)).toBe(true);
+  });
+
+  it('branching-default-off-in-v1 FAILS when forkAllowed=true with no merge strategy', () => {
+    const inv = UX_VERSION_CONTROL_INVARIANTS.find(
+      i => i.id === 'uxVersionControl.branching-default-off-in-v1'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'uxVersionControl.branchingStrategy': {
+        ...(goldenArch['uxVersionControl.branchingStrategy'] as Record<string, unknown>),
+        forkAllowed: true,
+        mergeStrategy: ''
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+});

--- a/packages/ux-version-control-architect/tests/run.test.ts
+++ b/packages/ux-version-control-architect/tests/run.test.ts
@@ -1,0 +1,236 @@
+/**
+ * `run()` tests — verifies the runtime pipeline.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  UX_VERSION_CONTROL_ARCHITECT_NAME,
+  UxVersionControlArchitect
+} from '../src/architect.js';
+import { UX_VERSION_CONTROL_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runUxVersionControlArchitect } from '../src/run.js';
+import { buildUxVersionControlSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runUxVersionControlArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runUxVersionControlArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('ux-version-control');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runUxVersionControlArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    for (const k of UX_VERSION_CONTROL_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runUxVersionControlArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runUxVersionControlArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runUxVersionControlArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildUxVersionControlSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runUxVersionControlArchitect(input, {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runUxVersionControlArchitect(input, {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runUxVersionControlArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runUxVersionControlArchitect(input, {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    const b = await runUxVersionControlArchitect(input, {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runUxVersionControlArchitect(input, {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    const r2 = await runUxVersionControlArchitect(input, {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(
+      Object.keys(r1.architectureFields).sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS.length
+    );
+  });
+});
+
+describe('runUxVersionControlArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runUxVersionControlArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(
+      '{"architectName":"ux-version-control"}'
+    );
+    const out = await runUxVersionControlArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runUxVersionControlArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildUxVersionControlSystemPrompt(),
+      architectName: UX_VERSION_CONTROL_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runUxVersionControlArchitect — no upstream architect dependencies', () => {
+  it('wave-1 architect: upstream.outputs is empty in the canonical fixture', () => {
+    const input = buildFakeInput();
+    expect(input.upstream.outputs).toEqual({});
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-015');
+  });
+
+  it('serialises the designVersion (the primary input for a wave-1 architect)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('design-pt-v3-2026-05-22');
+    expect(p).toContain('hero-cta-primary');
+    expect(p).toContain('booking-form');
+  });
+
+  it('serialises the businessPlan brand voice', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('warm + grounded');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: {
+        reason: 'tighten revert idempotency-key shape',
+        severity: 'P1' as const
+      }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('tighten revert idempotency-key shape');
+  });
+});
+
+describe('UxVersionControlArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new UxVersionControlArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('ux-version-control');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/ux-version-control-architect/tests/system-prompt.test.ts
+++ b/packages/ux-version-control-architect/tests/system-prompt.test.ts
@@ -1,0 +1,125 @@
+/**
+ * System-prompt tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { UX_VERSION_CONTROL_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUxVersionControlSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildUxVersionControlSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildUxVersionControlSystemPrompt();
+    const p2 = buildUxVersionControlSystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's UX Version Control Architect");
+  });
+
+  it('contains the Locked stack section', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('Cloudflare R2');
+    expect(p).toContain('append-only');
+    expect(p).toContain('ULID');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    for (const key of UX_VERSION_CONTROL_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('Forward-creating revert');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('uxVersionControl.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('calls out the forward-creating revert invariant explicitly', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('forward-creating');
+  });
+
+  it('calls out the preservation guarantee (spec §2.15) explicitly', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('preserved forever');
+    expect(p).toContain('immutable-r2-storage');
+  });
+
+  it('declares the five canonical diff layers', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toContain('tree');
+    expect(p).toContain('token');
+    expect(p).toContain('copy');
+    expect(p).toContain('asset');
+    expect(p).toContain('interactivity');
+  });
+
+  it('declares distinct-from-Time-Machine framing', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p).toMatch(/Time Machine|time-machine/);
+    expect(p).toContain('DESIGN-level versioning');
+  });
+
+  it('does not refer to fields outside the `uxVersionControl.*` namespace', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    const foreignPrefixes = [
+      'frontend.componentTree',
+      'a11y.wcagLevel',
+      'security.cspPolicy',
+      'analytics.eventTaxonomy',
+      'observability.logShape',
+      'timeMachine.versioningStrategy',
+      'timeMachine.snapshotRetention',
+      'timeMachine.dataConsistency'
+    ];
+    for (const prefix of foreignPrefixes) {
+      expect(p).not.toContain(prefix);
+    }
+  });
+
+  it('size is bounded (token-budget proxy: < 16k chars)', () => {
+    const p = buildUxVersionControlSystemPrompt();
+    expect(p.length).toBeLessThan(16_000);
+  });
+});

--- a/packages/ux-version-control-architect/tests/validation.test.ts
+++ b/packages/ux-version-control-architect/tests/validation.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Output validation tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { UX_VERSION_CONTROL_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(
+      goldenAssistantText(),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('ux-version-control');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ```json fences (lenient parser)', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, UX_VERSION_CONTROL_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, UX_VERSION_CONTROL_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', UX_VERSION_CONTROL_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', UX_VERSION_CONTROL_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', UX_VERSION_CONTROL_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput(
+      '{"architectName":"ux-version-control"}',
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    const codes = result.errors.map(e => e.code);
+    expect(codes).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['uxVersionControl.revertOperation'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'backend.apiShape': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags a stomp on a sibling architect namespace (timeMachine.*)', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'timeMachine.revertOperation': 'CODE-level revert is not your concern'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(
+        JSON.stringify(variant),
+        UX_VERSION_CONTROL_OWNED_FIELD_KEYS
+      );
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/ux-version-control-architect/tsconfig.build.json
+++ b/packages/ux-version-control-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/ux-version-control-architect/tsconfig.json
+++ b/packages/ux-version-control-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/ux-version-control-architect/vitest.config.ts
+++ b/packages/ux-version-control-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3076,6 +3076,25 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
+  packages/ux-version-control-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/vastu:
     dependencies:
       '@chiefaia/local-llm-router':


### PR DESCRIPTION
## What

Architect #15 of CAIA's 17-architect EA fan-out. Owns durable UX-asset version control + design-revert UX.

Distinct from the **Time Machine Architect (#14)** which owns CODE-level versioning; this architect owns **DESIGN-level versioning**. The two contracts are disjoint by construction — JSONB namespaces (\`timeMachine.*\` vs \`uxVersionControl.*\`) never collide.

## Owned fields (\`uxVersionControl.*\`)

| Field | Purpose |
|---|---|
| \`designVersionRetention\` | How many design uploads kept; archival rules; GDPR interaction. Default posture preserves every upload forever in immutable R2 storage (spec §2.15). |
| \`revertOperation\` | **Forward-creating** revert (new design version appended at chain tip, never destructive overwrite); design vs section scope; full vs selective replay mode. |
| \`diffVisualizationSpec\` | What the v1→v2 UX-upload diff looks like. Render surface: \`atlas-design-snapshotter\`. Five canonical layers: tree/token/copy/asset/interactivity. Semantic narration. |
| \`branchingStrategy\` | Can a customer fork a design version? V1 default: **off** (linear chain). Merge strategy + abandonment policy + naming template surface when fork is enabled. |
| \`auditTrail\` | Every UX upload + revert logged + attributed (who/when/versionId/parentVersionId/eventKind/reason); **append-only**; **7-year regulatory retention floor**. |

## Implementation

Implements \`SpecialistArchitect\` from \`@caia/architect-kit\` (merged PR #535):
- \`name = 'ux-version-control'\`
- \`sectionContract\` owns the \`uxVersionControl.*\` JSONB slice
- \`systemPrompt()\` returns a pure deterministic briefing
- \`tools = []\` for V1 per the task brief
- \`run(input)\` calls Claude (Sonnet default) via \`@chiefaia/claude-spawner\` — subscription-only, no API-key billing
- **Wave-1 architect**: \`dependsOn=[]\`; reads \`designVersion\` directly from input
- **Precedence rank 16** per spec §5.2 (operator-facing; not safety-critical — sits just below Time Machine, just above Testing)

## Invariants pinned at test layer

1. **Forward-creating revert** — \`revertOperation.forwardCreating\` must be the literal \`true\`. The golden test simulates a design-version chain with reverts; the simulation throws if the revert is destructive.
2. **Preservation guarantee** — \`designVersionRetention.preservationGuarantee\` must be \`\"immutable-r2-storage\"\`.
3. **GDPR uses tombstone, not hard delete** — \`gdprInteraction\` must be \`\"anonymize-in-version\"\` or \`\"purge-and-tombstone\"\`.
4. **Audit trail is append-only + meets 7-year regulatory floor** + attributes who/when/versionId.
5. **Diff covers all five canonical layers** (tree/token/copy/asset/interactivity) — mirrors the layer set proven by \`@caia/atlas-design-snapshotter\` (PR #538).
6. **Branching off by default in V1** — \`forkAllowed=false\` unless an operator opt-in is justified with a non-empty mergeStrategy.

## Reference

Generalizes the snapshot/revert pattern proven by \`@caia/atlas-design-snapshotter\` (PR #538: \`captureSnapshot()\` + \`revertToVersion()\` are append-only by construction) from a single uploader to ALL design uploads at the per-ticket architecture level.

## Testing

\`\`\`
✓ tests/system-prompt.test.ts  (16 tests)
✓ tests/validation.test.ts     (20 tests)
✓ tests/invariants.test.ts     (21 tests)
✓ tests/architect.test.ts      (12 tests)
✓ tests/run.test.ts            (20 tests)
✓ tests/golden/golden.test.ts  (18 tests)
✓ tests/contract.test.ts       (33 tests)

Test Files  7 passed (7)
Tests       140 passed (140)
\`\`\`

- ≥30 vitest specs across 7 files (140 actual)
- Golden test pins forward-creating revert + preservation guarantee
- TypeScript strict clean (\`tsc --noEmit\` passes)
- \`pnpm build\` emits \`dist/\` cleanly

## Stack reminder

shadcn/ui + Tailwind locked (relevant to consumers of this architect's output; not to this package itself, which is pure logic).

## Constraints honoured

- ✅ Subscription-only — spawns through \`@chiefaia/claude-spawner\`, never sets \`ANTHROPIC_API_KEY\`
- ✅ mac-mcp toolchain for shell + git operations
- ✅ Quality > timeline — 140 tests is 4.7× the floor of 30
- ✅ True-Zero rule — typecheck clean, all tests pass, no skipped specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)