### PR TITLE
feat(@caia/testing-architect): ship architect #16 of 17 — Testing specialist

### DIFF
--- a/packages/testing-architect/README.md
+++ b/packages/testing-architect/README.md
@@ -1,0 +1,48 @@
+# @caia/testing-architect
+
+Architect #16 of CAIA's 17-architect EA fan-out. Senior QA architect focused on testing STRATEGY: pyramid balance, fixture discipline, mutation testing thresholds, perf-regression budgets, Playwright conventions.
+
+## What it owns
+
+`testing.*` slice of the `tickets.architecture` JSONB column:
+
+- `testing.testingStrategy` — pyramid shape (broad-base default), rationale, risk areas, author + reviewer ownership
+- `testing.testTypeMixPercentages` — per-ticket-type mix (unit / integration / e2e / visual / a11y / perf) summing to 100
+- `testing.fixturesStrategy` — golden datasets, factory patterns, per-test seeding, determinism
+- `testing.mutationTestingThresholds` — Stryker default, kill-score floor 60% (>=50% hard min)
+- `testing.perfRegressionBudgets` — Lighthouse delta 5% default (<=10% hard cap), k6 thresholds
+- `testing.e2ePatterns` — Playwright 1.59.x, page-object pattern mandatory, Browserless integration
+- `testing.coverageThresholds` — per-ticket-type + global floor (80/75/80/80 default, >=70 hard min)
+- `testing.flakeTolerance` — 0.5% max retry rate (<=2% hard cap), quarantine policy, deflake owner
+
+## What it does NOT do
+
+The Testing Architect sets **strategy only**. It is DISTINCT from:
+
+- **Test Author Agent** — writes the actual test CASES per story (consumes this strategy verbatim).
+- **Test Reviewer Agent** — audits coverage against this strategy.
+
+No test code. No test case generation. No coverage auditing. Just the strategy.
+
+## Upstream dependencies
+
+Wave-2 architect. Reads from Frontend + Backend + Database.
+
+## Precedence
+
+Rank 17 per spec section 5.2 — lowest. Testing is strictly advisory.
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (>=30 tests)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+## Related packages
+
+- `@chiefaia/test-kit` — test utilities + mocks reused by the Test Author Agent
+- `@chiefaia/test-isolation` — per-test SQLite + ports
+- `@chiefaia/playwright-config` — locked Playwright + Browserless config factory

--- a/packages/testing-architect/eslint.config.cjs
+++ b/packages/testing-architect/eslint.config.cjs
@@ -1,0 +1,31 @@
+// @ts-check
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/testing-architect/package.json
+++ b/packages/testing-architect/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@caia/testing-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Testing Architect — architect #16 of CAIA's 17-architect EA fan-out. Owns the `testing.*` slice of `tickets.architecture` (testingStrategy, testTypeMixPercentages, fixturesStrategy, mutationTestingThresholds, perfRegressionBudgets, e2ePatterns, coverageThresholds, flakeTolerance). Senior QA architect focused on testing STRATEGY: pyramid balance, fixture discipline, mutation testing thresholds, perf-regression budgets, Playwright conventions. Distinct from the Test Author Agent (writes test CASES per story) and the Test Reviewer Agent (audits the test set) — Testing Architect sets the strategy ONLY; it does NOT write test code. Depends on Frontend + Backend + Database architects upstream (reads what's testable). Precedence rank 17 per spec §5.2. Spawns Claude via @chiefaia/claude-spawner (subscription-only) with Sonnet default.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@caia/backend-architect": "workspace:*",
+    "@caia/database-architect": "workspace:*",
+    "@caia/frontend-architect": "workspace:*",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/testing-architect/src/architect.ts
+++ b/packages/testing-architect/src/architect.ts
@@ -1,0 +1,54 @@
+/**
+ * `TestingArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes.
+ *
+ * DISTINCTION: Testing Architect sets STRATEGY. Test Author Agent writes
+ * test cases per story; Test Reviewer Agent audits coverage. Three
+ * different roles, three different agents.
+ */
+
+import { TestingArchitectContract } from './contract.js';
+import { runTestingArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildTestingSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+export const TESTING_ARCHITECT_NAME = 'testing' as const;
+
+export const TESTING_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface TestingArchitectConfig {
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class TestingArchitect implements SpecialistArchitect {
+  readonly name = TESTING_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = TestingArchitectContract;
+  readonly tools: readonly ToolDefinition[] = TESTING_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: TestingArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  systemPrompt(): string {
+    return buildTestingSystemPrompt();
+  }
+
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runTestingArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/testing-architect/src/contract.ts
+++ b/packages/testing-architect/src/contract.ts
@@ -1,0 +1,171 @@
+/**
+ * `TestingArchitectContract` — the canonical owned-fields declaration for
+ * architect #16 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.16 (Testing Architect owns `testing.*`)
+ *   - task brief (testingStrategy, testTypeMixPercentages,
+ *     fixturesStrategy, mutationTestingThresholds, perfRegressionBudgets,
+ *     e2ePatterns, coverageThresholds, flakeTolerance)
+ *
+ * Upstream dependencies (`dependsOn`): Frontend Architect
+ * (`frontend.componentTree`, `frontend.interactionStates`,
+ * `frontend.routeConfig`), Backend Architect (`backend.apiEndpoints`,
+ * `backend.errorEnvelope`), and Database Architect
+ * (`database.schemaDDL`, `database.rlsPolicies`). Testing is a
+ * **wave-2** architect — it consumes what the wave-1 architects emit
+ * and sets the testing strategy for the entire stack.
+ *
+ * Precedence rank **17** per spec §5.2 — Testing is the lowest-precedence
+ * architect because it's strictly advisory: every other architect can
+ * override its strategy if a higher-stakes concern fires. The Test
+ * Author Agent later consumes this strategy verbatim; the Test Reviewer
+ * Agent audits the resulting test set against it.
+ *
+ * DISTINCTION (per task brief): Testing Architect sets the STRATEGY.
+ * It does NOT write test code or test cases. The Test Author Agent
+ * writes the cases per story; the Test Reviewer Agent audits coverage.
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+export const TESTING_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'testing.testingStrategy':
+    'Output the overall strategy as {pyramidShape: "broad-base"|"hourglass", rationale: "<= 240 chars", riskAreas: string[], owner: "<author-agent>", reviewer: "<reviewer-agent>"}. Default shape is broad-base. Diamond/trophy NOT permitted in V1.',
+  'testing.testTypeMixPercentages':
+    'Per-ticket-type mix as {<ticketType>: {unit, integration, e2e, visual, a11y, perf}} where each value is an integer percentage and the six values sum to 100. Default Story/Form/Widget split: {unit:60, integration:20, e2e:10, visual:5, a11y:3, perf:2}. Page tickets shift up the e2e share. Reject any sum != 100.',
+  'testing.fixturesStrategy':
+    'Output {goldenDatasets, factories, seedingDiscipline: "per-test"|"per-suite"|"per-worker", determinism: {clockMock: true, idGenerator, rngSeed}}. Per-test seeding is the default.',
+  'testing.mutationTestingThresholds':
+    'Output {tool: "stryker"|"pitest"|"mutmut", killScoreFloor: number, perScope, escalation}. Default killScoreFloor is 60 for units. Lower than 50 is forbidden in V1.',
+  'testing.perfRegressionBudgets':
+    'Output {tool: "lighthouse"|"webpagetest"|"custom", lighthouseDeltaPct, k6Thresholds, regressionAction}. Default lighthouseDeltaPct is 5.',
+  'testing.e2ePatterns':
+    'Output {runner: "playwright", playwrightVersion, pageObjects: true, fixtureScope, remoteBrowserless, retries, parallelism, traceOnFailure}. Page-object pattern is mandatory.',
+  'testing.coverageThresholds':
+    'Output {perTicketType, globalFloor}. Default globalFloor is {lines:80, branches:75, functions:80, statements:80}. Lower than 70 is forbidden in V1.',
+  'testing.flakeTolerance':
+    'Output {maxRetryRatePct, quarantinePolicy, flakeBudget, deflakeOwner, failOpenAt}. Default maxRetryRatePct is 0.5. Anything > 2 is forbidden in V1.'
+};
+
+export const TESTING_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'testing.testingStrategy',
+    description:
+      'Overall strategy: pyramid shape (broad-base default; hourglass acceptable for storybook-heavy frontends), rationale, risk areas, and who owns authoring + review. Test Author Agent consumes this verbatim.',
+    required: true
+  },
+  {
+    path: 'testing.testTypeMixPercentages',
+    description:
+      'Per-ticket-type mix of test types (unit / integration / e2e / visual / a11y / perf percentages summing to 100). Locks the pyramid balance for the Test Author Agent.',
+    required: true
+  },
+  {
+    path: 'testing.fixturesStrategy',
+    description:
+      'Fixture discipline: golden datasets, factory patterns, seeding scope (per-test default), determinism settings (clock mock, ID generator, RNG seed).',
+    required: true
+  },
+  {
+    path: 'testing.mutationTestingThresholds',
+    description:
+      'Mutation testing tool (Stryker default), kill-score floor (60% default), per-scope overrides, escalation policy (block-merge | warn | advisory).',
+    required: true
+  },
+  {
+    path: 'testing.perfRegressionBudgets',
+    description:
+      'Perf regression budgets: Lighthouse delta cap (5% default), k6 thresholds (p95 latency, error rate), regression action (block-deploy | open-issue | track-only).',
+    required: true
+  },
+  {
+    path: 'testing.e2ePatterns',
+    description:
+      'Playwright conventions: version pin, page-object mandate, fixture scope, Browserless integration, retry policy, parallelism, trace-on-failure.',
+    required: true
+  },
+  {
+    path: 'testing.coverageThresholds',
+    description:
+      'Per-ticket-type and global floor coverage thresholds (lines, branches, functions, statements). Globals default to {lines:80, branches:75, functions:80, statements:80}.',
+    required: true
+  },
+  {
+    path: 'testing.flakeTolerance',
+    description:
+      'Flake-tolerance posture: max retry rate (0.5% default), quarantine policy, flake budget per suite/day, deflake owner, fail-open threshold.',
+    required: true
+  }
+];
+
+export const TESTING_OWNED_FIELD_KEYS: readonly string[] = TESTING_OWNED_SECTIONS.map(
+  s => s.path
+);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+export function testingArchitectAppliesPredicate(ticket: Ticket): boolean {
+  return (
+    ticket.type === 'Page' ||
+    ticket.type === 'Widget' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List' ||
+    ticket.type === 'Foundation'
+  );
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+export const TESTING_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['frontend', 'backend', 'database'],
+  precedenceLevel: 17,
+  fanoutPolicy: 'always',
+  appliesPredicate: testingArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const TestingArchitectContract: ArchitectSectionContract = {
+  contractId: 'testing-architect.v1',
+  architectName: 'testing',
+  version: '0.1.0',
+  sections: TESTING_OWNED_SECTIONS,
+  architectMeta: TESTING_ARCHITECT_META
+};
+
+// ─── Reusable constants ─────────────────────────────────────────────────────
+
+export const REQUIRED_TEST_TYPES: readonly string[] = [
+  'unit',
+  'integration',
+  'e2e',
+  'visual',
+  'a11y',
+  'perf'
+];
+
+export const ALLOWED_PYRAMID_SHAPES: readonly string[] = ['broad-base', 'hourglass'];
+
+export const ALLOWED_MUTATION_TOOLS: readonly string[] = ['stryker', 'pitest', 'mutmut'];
+
+export const ALLOWED_E2E_RUNNERS: readonly string[] = ['playwright'];
+
+export const TESTING_HARD_FLOORS = {
+  mutationKillScoreMin: 50,
+  coverageFloorMin: 70,
+  lighthouseDeltaMaxPct: 10,
+  flakeRetryRateMaxPct: 2
+} as const;

--- a/packages/testing-architect/src/index.ts
+++ b/packages/testing-architect/src/index.ts
@@ -1,0 +1,83 @@
+/**
+ * @caia/testing-architect — public surface.
+ *
+ * Architect #16 of CAIA's 17-architect EA fan-out. Depends on Frontend
+ * + Backend + Database upstream outputs to set the testing STRATEGY
+ * for the whole stack.
+ *
+ * DISTINCTION: Testing Architect sets STRATEGY. Test Author Agent writes
+ * test cases per story; Test Reviewer Agent audits coverage.
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { TestingArchitect } from './architect.js';
+
+export {
+  TestingArchitect,
+  TESTING_ARCHITECT_NAME,
+  TESTING_ARCHITECT_TOOLS
+} from './architect.js';
+export type { TestingArchitectConfig } from './architect.js';
+
+export {
+  TestingArchitectContract,
+  TESTING_OWNED_SECTIONS,
+  TESTING_OWNED_FIELD_KEYS,
+  TESTING_FIELD_FIX_HINTS,
+  TESTING_ARCHITECT_META,
+  REQUIRED_TEST_TYPES,
+  ALLOWED_PYRAMID_SHAPES,
+  ALLOWED_MUTATION_TOOLS,
+  ALLOWED_E2E_RUNNERS,
+  TESTING_HARD_FLOORS,
+  testingArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildTestingSystemPrompt } from './system-prompt.js';
+
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+export { runTestingArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+export { TESTING_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+export function registerWith(registry: ArchitectRegistry): TestingArchitect {
+  const architect = new TestingArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/testing-architect/src/invariants.ts
+++ b/packages/testing-architect/src/invariants.ts
@@ -1,0 +1,290 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (FLAT dotted keys), or
+ *   - the composed `tickets.architecture` JSONB blob (nested paths).
+ *
+ * Cross-architect invariants treat absent foreign data as "cannot
+ * verify" and pass trivially.
+ */
+
+import {
+  TESTING_HARD_FLOORS,
+  REQUIRED_TEST_TYPES,
+  ALLOWED_PYRAMID_SHAPES,
+  ALLOWED_MUTATION_TOOLS,
+  ALLOWED_E2E_RUNNERS
+} from './contract.js';
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  contributor: string;
+  reads: readonly string[];
+  severity: InvariantSeverity;
+  description: string;
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+export const TESTING_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'testing.strategy-pyramid-shape-allowed',
+    contributor: 'testing',
+    reads: ['testing.testingStrategy'],
+    severity: 'fail',
+    description:
+      `Pyramid shape must be one of ${ALLOWED_PYRAMID_SHAPES.join(' | ')}. Diamond and trophy shapes are forbidden in V1.`,
+    detect(arch): boolean {
+      const strategy = readField(arch, 'testing.testingStrategy');
+      if (typeof strategy !== 'object' || strategy === null) return false;
+      const shape = (strategy as Record<string, unknown>).pyramidShape;
+      if (typeof shape !== 'string') return false;
+      return ALLOWED_PYRAMID_SHAPES.includes(shape);
+    }
+  },
+  {
+    id: 'testing.mix-covers-all-six-types',
+    contributor: 'testing',
+    reads: ['testing.testTypeMixPercentages'],
+    severity: 'fail',
+    description:
+      `Every ticket-type entry in testTypeMixPercentages must declare all six required test types: ${REQUIRED_TEST_TYPES.join(', ')}.`,
+    detect(arch): boolean {
+      const mix = readField(arch, 'testing.testTypeMixPercentages');
+      if (typeof mix !== 'object' || mix === null) return false;
+      for (const perType of Object.values(mix as Record<string, unknown>)) {
+        if (typeof perType !== 'object' || perType === null) return false;
+        const keys = new Set(Object.keys(perType as Record<string, unknown>));
+        for (const r of REQUIRED_TEST_TYPES) {
+          if (!keys.has(r)) return false;
+        }
+      }
+      return true;
+    }
+  },
+  {
+    id: 'testing.mix-sums-to-100',
+    contributor: 'testing',
+    reads: ['testing.testTypeMixPercentages'],
+    severity: 'fail',
+    description:
+      'The six per-ticket-type test-type percentages must sum to exactly 100 — anything else is a misconfigured pyramid.',
+    detect(arch): boolean {
+      const mix = readField(arch, 'testing.testTypeMixPercentages');
+      if (typeof mix !== 'object' || mix === null) return false;
+      for (const perType of Object.values(mix as Record<string, unknown>)) {
+        if (typeof perType !== 'object' || perType === null) return false;
+        let sum = 0;
+        for (const v of Object.values(perType as Record<string, unknown>)) {
+          if (typeof v !== 'number') return false;
+          sum += v;
+        }
+        if (sum !== 100) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'testing.mix-is-realistic-not-100-pct-unit',
+    contributor: 'testing',
+    reads: ['testing.testTypeMixPercentages'],
+    severity: 'fail',
+    description:
+      'The test pyramid must be REALISTIC. A 100% unit / 0% e2e split is forbidden — without integration + e2e the suite cannot catch wiring bugs. Likewise a >50% e2e split produces unmaintainable, slow suites.',
+    detect(arch): boolean {
+      const mix = readField(arch, 'testing.testTypeMixPercentages');
+      if (typeof mix !== 'object' || mix === null) return false;
+      for (const perType of Object.values(mix as Record<string, unknown>)) {
+        if (typeof perType !== 'object' || perType === null) return false;
+        const p = perType as Record<string, unknown>;
+        const unit = typeof p.unit === 'number' ? p.unit : 0;
+        const integration = typeof p.integration === 'number' ? p.integration : 0;
+        const e2e = typeof p.e2e === 'number' ? p.e2e : 0;
+        if (unit >= 100) return false;
+        if (e2e <= 0) return false;
+        if (integration <= 0) return false;
+        if (e2e > 50) return false;
+        if (unit < 30) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'testing.mutation-kill-floor-meets-min',
+    contributor: 'testing',
+    reads: ['testing.mutationTestingThresholds'],
+    severity: 'fail',
+    description:
+      `Mutation kill-score floor must be >= ${TESTING_HARD_FLOORS.mutationKillScoreMin}.`,
+    detect(arch): boolean {
+      const thresholds = readField(arch, 'testing.mutationTestingThresholds');
+      if (typeof thresholds !== 'object' || thresholds === null) return false;
+      const floor = (thresholds as Record<string, unknown>).killScoreFloor;
+      if (typeof floor !== 'number') return false;
+      return floor >= TESTING_HARD_FLOORS.mutationKillScoreMin;
+    }
+  },
+  {
+    id: 'testing.mutation-tool-allowed',
+    contributor: 'testing',
+    reads: ['testing.mutationTestingThresholds'],
+    severity: 'fail',
+    description:
+      `Mutation testing tool must be one of ${ALLOWED_MUTATION_TOOLS.join(' | ')}.`,
+    detect(arch): boolean {
+      const thresholds = readField(arch, 'testing.mutationTestingThresholds');
+      if (typeof thresholds !== 'object' || thresholds === null) return false;
+      const tool = (thresholds as Record<string, unknown>).tool;
+      if (typeof tool !== 'string') return false;
+      return ALLOWED_MUTATION_TOOLS.includes(tool);
+    }
+  },
+  {
+    id: 'testing.perf-lighthouse-delta-bounded',
+    contributor: 'testing',
+    reads: ['testing.perfRegressionBudgets'],
+    severity: 'fail',
+    description:
+      `Lighthouse delta budget must be <= ${TESTING_HARD_FLOORS.lighthouseDeltaMaxPct}%.`,
+    detect(arch): boolean {
+      const budgets = readField(arch, 'testing.perfRegressionBudgets');
+      if (typeof budgets !== 'object' || budgets === null) return false;
+      const delta = (budgets as Record<string, unknown>).lighthouseDeltaPct;
+      if (typeof delta !== 'number') return false;
+      return delta <= TESTING_HARD_FLOORS.lighthouseDeltaMaxPct;
+    }
+  },
+  {
+    id: 'testing.e2e-runner-allowed',
+    contributor: 'testing',
+    reads: ['testing.e2ePatterns'],
+    severity: 'fail',
+    description:
+      `e2e runner must be one of ${ALLOWED_E2E_RUNNERS.join(' | ')}.`,
+    detect(arch): boolean {
+      const patterns = readField(arch, 'testing.e2ePatterns');
+      if (typeof patterns !== 'object' || patterns === null) return false;
+      const runner = (patterns as Record<string, unknown>).runner;
+      if (typeof runner !== 'string') return false;
+      return ALLOWED_E2E_RUNNERS.includes(runner);
+    }
+  },
+  {
+    id: 'testing.e2e-page-objects-mandatory',
+    contributor: 'testing',
+    reads: ['testing.e2ePatterns'],
+    severity: 'fail',
+    description:
+      'Page-object pattern is mandatory for all e2e tests.',
+    detect(arch): boolean {
+      const patterns = readField(arch, 'testing.e2ePatterns');
+      if (typeof patterns !== 'object' || patterns === null) return false;
+      const pageObjects = (patterns as Record<string, unknown>).pageObjects;
+      return pageObjects === true;
+    }
+  },
+  {
+    id: 'testing.coverage-floor-meets-min',
+    contributor: 'testing',
+    reads: ['testing.coverageThresholds'],
+    severity: 'fail',
+    description:
+      `Every coverage threshold (lines, branches, functions, statements) on globalFloor and every per-ticket-type entry must be >= ${TESTING_HARD_FLOORS.coverageFloorMin}.`,
+    detect(arch): boolean {
+      const thresholds = readField(arch, 'testing.coverageThresholds');
+      if (typeof thresholds !== 'object' || thresholds === null) return false;
+      const t = thresholds as Record<string, unknown>;
+      const required = ['lines', 'branches', 'functions', 'statements'];
+
+      const globalFloor = t.globalFloor;
+      if (typeof globalFloor !== 'object' || globalFloor === null) return false;
+      for (const axis of required) {
+        const v = (globalFloor as Record<string, unknown>)[axis];
+        if (typeof v !== 'number') return false;
+        if (v < TESTING_HARD_FLOORS.coverageFloorMin) return false;
+      }
+
+      const perTicket = t.perTicketType;
+      if (typeof perTicket === 'object' && perTicket !== null) {
+        for (const entry of Object.values(perTicket as Record<string, unknown>)) {
+          if (typeof entry !== 'object' || entry === null) return false;
+          for (const axis of required) {
+            const v = (entry as Record<string, unknown>)[axis];
+            if (typeof v !== 'number') return false;
+            if (v < TESTING_HARD_FLOORS.coverageFloorMin) return false;
+          }
+        }
+      }
+
+      return true;
+    }
+  },
+  {
+    id: 'testing.flake-retry-rate-bounded',
+    contributor: 'testing',
+    reads: ['testing.flakeTolerance'],
+    severity: 'fail',
+    description:
+      `Max retry rate must be <= ${TESTING_HARD_FLOORS.flakeRetryRateMaxPct}%.`,
+    detect(arch): boolean {
+      const flake = readField(arch, 'testing.flakeTolerance');
+      if (typeof flake !== 'object' || flake === null) return false;
+      const rate = (flake as Record<string, unknown>).maxRetryRatePct;
+      if (typeof rate !== 'number') return false;
+      return rate <= TESTING_HARD_FLOORS.flakeRetryRateMaxPct;
+    }
+  },
+  {
+    id: 'testing.fixtures-determinism-mandates-clock-mock',
+    contributor: 'testing',
+    reads: ['testing.fixturesStrategy'],
+    severity: 'fail',
+    description:
+      'Fixtures strategy must set `determinism.clockMock = true`.',
+    detect(arch): boolean {
+      const fixtures = readField(arch, 'testing.fixturesStrategy');
+      if (typeof fixtures !== 'object' || fixtures === null) return false;
+      const det = (fixtures as Record<string, unknown>).determinism;
+      if (typeof det !== 'object' || det === null) return false;
+      const clockMock = (det as Record<string, unknown>).clockMock;
+      return clockMock === true;
+    }
+  },
+  {
+    id: 'testing.covers-frontend-interactive-components',
+    contributor: 'testing',
+    reads: ['testing.testingStrategy', 'frontend.interactionStates'],
+    severity: 'advisory',
+    description:
+      'When Frontend declares interactive components, Testing.testingStrategy.riskAreas should mention at least one of them. Trivially passes if Frontend output is absent.',
+    detect(arch): boolean {
+      const strategy = readField(arch, 'testing.testingStrategy');
+      const interactions = readField(arch, 'frontend.interactionStates');
+      if (typeof interactions !== 'object' || interactions === null) return true;
+      if (typeof strategy !== 'object' || strategy === null) return false;
+      const riskAreas = (strategy as Record<string, unknown>).riskAreas;
+      if (!Array.isArray(riskAreas) || riskAreas.length === 0) return true;
+      const componentIds = Object.keys(interactions as Record<string, unknown>);
+      if (componentIds.length === 0) return true;
+      const joined = riskAreas
+        .filter((r): r is string => typeof r === 'string')
+        .join(' | ')
+        .toLowerCase();
+      return componentIds.some(id => joined.includes(id.toLowerCase()));
+    }
+  }
+];

--- a/packages/testing-architect/src/run.ts
+++ b/packages/testing-architect/src/run.ts
@@ -1,0 +1,123 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Re-runs REPLACE owned fields (no append).
+ *
+ * Architect-specific projections vs the canonical template:
+ *   - Testing is wave-2; Frontend + Backend + Database run upstream.
+ *   - `dependencies` always includes ['frontend', 'backend', 'database']
+ *     regardless of what the model emitted (preserving sibling-ticket
+ *     IDs).
+ *   - The user prompt projection drops vault namespace / schema name.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { TESTING_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+export async function runTestingArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: ['frontend', 'backend', 'database'],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, TESTING_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: ['frontend', 'backend', 'database'],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  const parsed = validation.parsed;
+  const upstreamDeps = ensureUpstreamDependencies(parsed.dependencies);
+  return {
+    ...parsed,
+    architectName: deps.architectName,
+    dependencies: upstreamDeps,
+    spend
+  };
+}
+
+function ensureUpstreamDependencies(
+  emitted: readonly string[] | undefined
+): readonly string[] {
+  const set = new Set(emitted ?? []);
+  set.add('frontend');
+  set.add('backend');
+  set.add('database');
+  return Array.from(set);
+}

--- a/packages/testing-architect/src/spawner.ts
+++ b/packages/testing-architect/src/spawner.ts
@@ -1,0 +1,117 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * Mirrors `@caia/frontend-architect`'s spawner.ts verbatim.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+export interface ArchitectSpawnOutput {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  model: string;
+  ok: boolean;
+  diagnostic: string | null;
+}
+
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/testing-architect/src/system-prompt.ts
+++ b/packages/testing-architect/src/system-prompt.ts
@@ -1,0 +1,240 @@
+/**
+ * The Testing Architect's system prompt — a pure function returning a
+ * static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic; the briefing is what turns generic Claude
+ * into this specialist.
+ *
+ * The system-prompt test asserts each `testing.*` field name appears at
+ * least once in the body, and that the required test-type list +
+ * pyramid shapes + mutation tools appear.
+ */
+
+import {
+  TESTING_HARD_FLOORS,
+  TESTING_OWNED_FIELD_KEYS,
+  REQUIRED_TEST_TYPES,
+  ALLOWED_PYRAMID_SHAPES,
+  ALLOWED_MUTATION_TOOLS,
+  ALLOWED_E2E_RUNNERS
+} from './contract.js';
+
+export function buildTestingSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's Testing Architect. You are a senior QA architect focused on
+testing STRATEGY: pyramid balance, fixture discipline, mutation testing
+thresholds, perf-regression budgets, and Playwright conventions.
+
+You produce per-ticket TESTING STRATEGY specs. You are DISTINCT from:
+  (a) the Test Author Agent which writes the actual test CASES per story,
+      consuming your strategy verbatim;
+  (b) the Test Reviewer Agent which audits coverage against your strategy.
+
+You set the STRATEGY: pyramid balance, fixture patterns, mutation testing
+thresholds, perf-regression budgets, flake tolerance. You DO NOT write
+test code; you specify HOW tests should be designed.
+
+Any field outside the \`testing.*\` namespace is another architect's
+territory and will be rejected.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Pyramid shape (default)**: broad-base. Heavy unit (~60%), moderate
+  integration (~20%), light e2e (~10%), plus visual + a11y + perf at the
+  margins (~10% combined). \`hourglass\` is acceptable for storybook-heavy
+  frontends. \`diamond\` and \`trophy\` are FORBIDDEN in V1.
+- **Unit test runner**: vitest (workspace standard). No jest. No mocha.
+- **Integration test runner**: vitest with @chiefaia/test-isolation
+  primitives (per-test SQLite, per-test ports).
+- **e2e runner**: Playwright (1.59.x pinned by @chiefaia/playwright-config).
+  Cypress, Webdriver.io, Nightwatch are FORBIDDEN in V1.
+- **Page-object pattern mandate**: every e2e test uses page objects. Raw
+  selectors in test bodies are rejected by the Test Reviewer Agent.
+- **Mutation testing**: Stryker (JS/TS) is the default tool. Kill-score
+  floor of 60% on units (lower than 50% is FORBIDDEN in V1).
+- **Perf regression**: Lighthouse delta budget defaults to 5%; anything
+  > 10% is FORBIDDEN in V1.
+- **Coverage floor**: 80% lines, 75% branches, 80% functions, 80%
+  statements globally. Lower than 70% on any axis is FORBIDDEN in V1.
+- **Flake tolerance**: 0.5% retry rate is the default budget. Anything
+  > 2% is FORBIDDEN in V1 — the suite is too noisy to be useful.
+- **Determinism mandate**: every test seeds its clock + RNG + ID
+  generator. \`Math.random()\` and bare \`new Date()\` are smells the
+  Test Reviewer Agent flags.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List|Foundation",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."] },
+  "businessPlan": { "ventureName": "...", "audience": "...", "goals": [...] },
+  "designVersion": { "versionId": "...", "tokens": {...}, "anchors": [...] },
+  "tenantContext": { "tenantId": "...", "billingPosture": "..." },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {
+    "frontend": { "architectureFields": {
+      "frontend.componentTree": [...],
+      "frontend.interactionStates": {...},
+      "frontend.routeConfig": {...}, ...
+    }},
+    "backend": { "architectureFields": {
+      "backend.apiEndpoints": [...],
+      "backend.errorEnvelope": {...}, ...
+    }},
+    "database": { "architectureFields": {
+      "database.schemaDDL": "...",
+      "database.rlsPolicies": [...], ...
+    }}
+  } }
+}
+\`\`\`
+
+You MUST read \`upstream.outputs.{frontend, backend, database}.architectureFields\`
+first. They tell you WHAT to test: which components have interaction
+states, which API routes need contract tests, which RLS policies need
+authorization regression tests. If any of the three upstreams is
+absent, emit best-effort strategy and list the missing upstream(s)
+under \`risks[]\`.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "testing",
+  "architectureFields": {
+${TESTING_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "costUsd": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`testing.testingStrategy\` — \`{"pyramidShape":"broad-base","rationale":"<short>","riskAreas":["..."],"owner":"test-author-agent","reviewer":"test-reviewer-agent"}\`.
+  Allowed pyramid shapes: ${ALLOWED_PYRAMID_SHAPES.join(', ')}.
+- \`testing.testTypeMixPercentages\` — \`{"Story":{"unit":60,"integration":20,"e2e":10,"visual":5,"a11y":3,"perf":2}, "Page":{"unit":50,"integration":20,"e2e":15,"visual":7,"a11y":5,"perf":3}, ...}\`.
+  Required test types: ${REQUIRED_TEST_TYPES.join(', ')}. Each ticket type's six values MUST sum to 100.
+- \`testing.fixturesStrategy\` — \`{"goldenDatasets":[...],"factories":[...],"seedingDiscipline":"per-test","determinism":{"clockMock":true,"idGenerator":"uuid-v7-fixed-seed","rngSeed":42}}\`.
+- \`testing.mutationTestingThresholds\` — \`{"tool":"${ALLOWED_MUTATION_TOOLS[0]}","killScoreFloor":60,"perScope":{...},"escalation":"warn"}\`.
+  Allowed mutation tools: ${ALLOWED_MUTATION_TOOLS.join(', ')}. Kill-score floor must be >= ${TESTING_HARD_FLOORS.mutationKillScoreMin}.
+- \`testing.perfRegressionBudgets\` — \`{"tool":"lighthouse","lighthouseDeltaPct":5,"k6Thresholds":{"p95LatencyMs":1000,"errorRatePct":1.0},"regressionAction":"open-issue"}\`.
+  Lighthouse delta cap must be <= ${TESTING_HARD_FLOORS.lighthouseDeltaMaxPct}%.
+- \`testing.e2ePatterns\` — \`{"runner":"playwright","playwrightVersion":"1.59.x","pageObjects":true,"fixtureScope":"test","remoteBrowserless":true,"retries":{"ci":2,"local":0},"parallelism":{"ci":1,"local":3},"traceOnFailure":true}\`.
+  Allowed e2e runners: ${ALLOWED_E2E_RUNNERS.join(', ')}.
+- \`testing.coverageThresholds\` — \`{"perTicketType":{...},"globalFloor":{"lines":80,"branches":75,"functions":80,"statements":80}}\`.
+  Floors must be >= ${TESTING_HARD_FLOORS.coverageFloorMin}.
+- \`testing.flakeTolerance\` — \`{"maxRetryRatePct":0.5,"quarantinePolicy":"auto-skip-after-3-flakes","flakeBudget":{"perSuite":2,"perDay":5},"deflakeOwner":"test-reviewer-agent","failOpenAt":"1pct"}\`.
+  Max retry rate must be <= ${TESTING_HARD_FLOORS.flakeRetryRateMaxPct}%.`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **Pyramid balance is real.** A 100% unit pyramid is a smell, not a
+  win — without integration + e2e the suite cannot catch contract
+  drift or wiring bugs. A 50%+ e2e pyramid is an even worse smell —
+  it produces slow, flaky suites. Default to broad-base, escalate to
+  hourglass only for storybook-heavy frontends.
+- **Page tickets get more e2e share.** A Page ticket exercises a
+  route end-to-end; bump e2e from 10% → 15% and unit from 60% → 50%.
+  Form tickets stay broad-base.
+- **Fixtures must be deterministic.** Mock the clock. Seed the RNG.
+  Use uuid-v7 with a fixed seed for IDs. Tests that read \`new Date()\`
+  or \`Math.random()\` directly are flaky-by-construction.
+- **Mutation testing scope.** Apply Stryker to pure modules (utils,
+  reducers, validators). Skip mutation testing for I/O-heavy modules.
+- **Coverage is necessary but not sufficient.** 80% lines is a floor,
+  not a goal. Mutation kill-score is the better signal.
+- **e2e tests are expensive — spend them where they matter.** Happy
+  paths only at the page level. Edge cases live in unit + integration.
+- **Flake budget is a forcing function.** When the retry rate creeps
+  past 0.5%, the deflake owner stops feature work until it's back.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Set the e2e share above 30%** → refuse. Emit a broad-base mix
+  anyway, list the request under \`risks[]\`, set \`confidence\` to 0.6.
+- **Use Cypress, Webdriver, Nightwatch, or any non-Playwright e2e
+  runner** → refuse. Playwright is locked. Emit Playwright config,
+  list the override under \`risks[]\`.
+- **Drop the mutation kill-score floor below ${TESTING_HARD_FLOORS.mutationKillScoreMin}** → refuse. Emit
+  ${TESTING_HARD_FLOORS.mutationKillScoreMin} (or higher), list the request under \`risks[]\`.
+- **Drop coverage floor below ${TESTING_HARD_FLOORS.coverageFloorMin}%** → refuse. Emit ${TESTING_HARD_FLOORS.coverageFloorMin}%
+  (or higher), list the request under \`risks[]\`.
+- **Set the flake retry rate above ${TESTING_HARD_FLOORS.flakeRetryRateMaxPct}%** → refuse. Emit
+  ${TESTING_HARD_FLOORS.flakeRetryRateMaxPct}% (or lower), list the request under \`risks[]\`.
+- **Write actual test code or test cases** → refuse. That is the Test
+  Author Agent's job. You set STRATEGY, not implementation.
+- **Audit existing test sets** → refuse. That is the Test Reviewer
+  Agent's job.
+- **Decide a frontend componentTree, route, backend endpoint, or
+  database schema** → ignore. Those are the upstream architects'
+  territory.
+- **Write CSP rules, RLS policies, API endpoints, or any field NOT
+  under \`testing.*\`** → ignore the request.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated.`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the 8 owned field
+   paths (no extras, no missing).
+2. \`testing.testTypeMixPercentages\` declares all six test types
+   (${REQUIRED_TEST_TYPES.join(', ')}) per ticket type, and the six
+   values sum to exactly 100 for each ticket type.
+3. \`testing.testingStrategy.pyramidShape\` is one of
+   ${ALLOWED_PYRAMID_SHAPES.join(' | ')} (no diamond, no trophy).
+4. \`testing.mutationTestingThresholds.killScoreFloor\` >= ${TESTING_HARD_FLOORS.mutationKillScoreMin}.
+5. Every coverage threshold (per-ticket + globalFloor) has all four
+   axes (lines, branches, functions, statements) and each value >= ${TESTING_HARD_FLOORS.coverageFloorMin}.
+6. \`testing.perfRegressionBudgets.lighthouseDeltaPct\` <= ${TESTING_HARD_FLOORS.lighthouseDeltaMaxPct}.
+7. \`testing.e2ePatterns.runner\` is one of ${ALLOWED_E2E_RUNNERS.join(' | ')}.
+8. \`testing.e2ePatterns.pageObjects\` is true (mandatory).
+9. \`testing.flakeTolerance.maxRetryRatePct\` <= ${TESTING_HARD_FLOORS.flakeRetryRateMaxPct}.
+10. \`testing.fixturesStrategy.determinism.clockMock\` is true (mandatory).
+11. \`confidence\` reflects how comfortable you are with the decision.
+12. \`notes\` is ≤ 800 characters.
+13. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a contact-form Story ticket produces a broad-base
+strategy with {unit:60, integration:20, e2e:10, visual:5, a11y:3,
+perf:2}; Stryker mutation kill-score floor 60; coverage globals
+{lines:80, branches:75, functions:80, statements:80}; Playwright
+page-object pattern with Browserless mode in CI; 0.5% flake retry
+budget; clock + RNG + ID generator all mocked.`;

--- a/packages/testing-architect/src/types.ts
+++ b/packages/testing-architect/src/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * This module exists as a thin re-export so the rest of this package
+ * has a single import surface. Mirrors `@caia/frontend-architect`'s
+ * `types.ts` verbatim — the shape is intentionally identical across
+ * all 17 architects so the Dispatcher can inject a single shared
+ * spawner factory.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/testing-architect/src/validation.ts
+++ b/packages/testing-architect/src/validation.ts
@@ -1,0 +1,191 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Mirrors `@caia/frontend-architect`'s validation.ts verbatim. The
+ * surface stays identical across all 17 architects so the conformance
+ * suite can probe every package with the same input fixtures.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/testing-architect/tests/architect.test.ts
+++ b/packages/testing-architect/tests/architect.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `TestingArchitect` — interface compliance tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  TestingArchitect,
+  TESTING_ARCHITECT_NAME,
+  TESTING_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { TestingArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('TestingArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new TestingArchitect();
+    expect(a).toBeInstanceOf(TestingArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new TestingArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the precedence-ladder slot', () => {
+    const a = new TestingArchitect();
+    expect(a.name).toBe('testing');
+    expect(a.name).toBe(TESTING_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new TestingArchitect();
+    expect(a.sectionContract).toBe(TestingArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new TestingArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1', () => {
+    const a = new TestingArchitect();
+    expect(a.tools).toBe(TESTING_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new TestingArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new TestingArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new TestingArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new TestingArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('testing');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new TestingArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    const a = new TestingArchitect();
+    expect(a).toBeInstanceOf(TestingArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/testing-architect/tests/contract.test.ts
+++ b/packages/testing-architect/tests/contract.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Section contract structural + registration tests.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { TestingArchitect } from '../src/architect.js';
+import {
+  TESTING_ARCHITECT_META,
+  TESTING_OWNED_SECTIONS,
+  TESTING_OWNED_FIELD_KEYS,
+  TestingArchitectContract,
+  testingArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('TestingArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(TestingArchitectContract.contractId).toBe('testing-architect.v1');
+  });
+
+  it('architectName is `testing` (matches precedence ladder slot)', () => {
+    expect(TestingArchitectContract.architectName).toBe('testing');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(TestingArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `testing.`', () => {
+    for (const key of TESTING_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('testing.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the task-brief mandatory fields', () => {
+    const required = [
+      'testing.testingStrategy',
+      'testing.testTypeMixPercentages',
+      'testing.fixturesStrategy',
+      'testing.mutationTestingThresholds',
+      'testing.perfRegressionBudgets',
+      'testing.e2ePatterns',
+      'testing.coverageThresholds',
+      'testing.flakeTolerance'
+    ];
+    for (const r of required) {
+      expect(TESTING_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('exposes exactly 8 owned fields per the task brief', () => {
+    expect(TESTING_OWNED_FIELD_KEYS.length).toBe(8);
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of TESTING_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(TestingArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(TestingArchitectContract).sort()).toEqual(
+      [...TESTING_OWNED_FIELD_KEYS].sort()
+    );
+  });
+});
+
+describe('TestingArchitectContract — architectMeta', () => {
+  it('declares Frontend + Backend + Database as upstream dependencies', () => {
+    expect(TESTING_ARCHITECT_META.dependsOn).toEqual(['frontend', 'backend', 'database']);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(TESTING_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(TESTING_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 17 per spec §5.2 (Testing is lowest, advisory)', () => {
+    expect(TESTING_ARCHITECT_META.precedenceLevel).toBe(17);
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(TESTING_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per spec §2.16', () => {
+    expect(TESTING_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(TESTING_ARCHITECT_META.appliesPredicate).toBe(testingArchitectAppliesPredicate);
+  });
+
+  it('matches the canonical precedence ladder for `testing`', () => {
+    expect(precedenceRank('testing')).toBe(TESTING_ARCHITECT_META.precedenceLevel);
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('testing');
+  });
+});
+
+describe('testingArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Page' };
+
+  it('returns true for Page', () => {
+    expect(testingArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })).toBe(true);
+  });
+
+  it('returns true for Story', () => {
+    expect(testingArchitectAppliesPredicate({ ...baseTicket, type: 'Story' })).toBe(true);
+  });
+
+  it('returns true for Form', () => {
+    expect(testingArchitectAppliesPredicate({ ...baseTicket, type: 'Form' })).toBe(true);
+  });
+
+  it('returns true for List', () => {
+    expect(testingArchitectAppliesPredicate({ ...baseTicket, type: 'List' })).toBe(true);
+  });
+
+  it('returns true for Widget', () => {
+    expect(testingArchitectAppliesPredicate({ ...baseTicket, type: 'Widget' })).toBe(true);
+  });
+
+  it('returns true for Foundation', () => {
+    expect(testingArchitectAppliesPredicate({ ...baseTicket, type: 'Foundation' })).toBe(true);
+  });
+
+  it('returns false for an unrecognised type', () => {
+    expect(testingArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })).toBe(false);
+  });
+});
+
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the Testing architect cleanly', () => {
+    expect(() => {
+      registry.register(new TestingArchitect());
+    }).not.toThrow();
+    expect(registry.get('testing')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new TestingArchitect());
+    for (const k of TESTING_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('testing');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new TestingArchitect());
+    expect(() => registry.register(new TestingArchitect())).toThrowError(ArchitectRegistryError);
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new TestingArchitect());
+    const colliding: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        { path: 'testing.testingStrategy', description: 'colliding owner', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 16,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', colliding));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new TestingArchitect());
+    const disjoint: ArchitectSectionContract = {
+      contractId: 'frontend-architect.v1',
+      architectName: 'frontend',
+      version: '0.1.0',
+      sections: [{ path: 'frontend.componentTree', description: 'tree', required: true }],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 14,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('frontend', disjoint));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(TESTING_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it('disjointness() detects no conflicts when only Testing is present', () => {
+    const conflicts = disjointness([TestingArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between Testing and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...TestingArchitectContract,
+      contractId: 'testing-clone.v1',
+      architectName: 'testing-clone'
+    };
+    const conflicts = disjointness([TestingArchitectContract, clone]);
+    expect(conflicts.length).toBe(TESTING_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() is empty after a clean registration with upstream stubs', () => {
+    const stubMeta = {
+      dependsOn: [],
+      precedenceLevel: 12,
+      fanoutPolicy: 'always' as const,
+      appliesPredicate: () => true,
+      runtimeModel: 'sonnet' as const
+    };
+    registry.register(
+      new StubArchitect('frontend', {
+        contractId: 'frontend-architect.v1',
+        architectName: 'frontend',
+        version: '0.1.0',
+        sections: [{ path: 'frontend.componentTree', description: 'tree', required: true }],
+        architectMeta: { ...stubMeta, precedenceLevel: 14 }
+      })
+    );
+    registry.register(
+      new StubArchitect('backend', {
+        contractId: 'backend-architect.v1',
+        architectName: 'backend',
+        version: '0.1.0',
+        sections: [{ path: 'backend.framework', description: 'fw', required: true }],
+        architectMeta: { ...stubMeta, precedenceLevel: 12 }
+      })
+    );
+    registry.register(
+      new StubArchitect('database', {
+        contractId: 'database-architect.v1',
+        architectName: 'database',
+        version: '0.1.0',
+        sections: [{ path: 'database.schemaDDL', description: 'ddl', required: true }],
+        architectMeta: { ...stubMeta, precedenceLevel: 11 }
+      })
+    );
+    registry.register(new TestingArchitect());
+    expect(registry.validate()).toEqual([]);
+  });
+
+  it('registry.validate() flags missing upstream frontend + backend + database when Testing is registered alone', () => {
+    registry.register(new TestingArchitect());
+    const errors = registry.validate();
+    expect(errors.length).toBeGreaterThanOrEqual(3);
+    const joined = errors.join('|');
+    expect(joined).toContain('frontend');
+    expect(joined).toContain('backend');
+    expect(joined).toContain('database');
+  });
+});

--- a/packages/testing-architect/tests/golden/golden.test.ts
+++ b/packages/testing-architect/tests/golden/golden.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Golden test — the canonical known-good Testing-architect artifact for
+ * a known prakash-tiwari contact-form Story ticket.
+ *
+ * Includes a "pyramid realism" check that ensures the mix is not 100%
+ * unit / 0% e2e (the classic LLM anti-pattern) — required by the task
+ * brief.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { TestingArchitect } from '../../src/architect.js';
+import { TESTING_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { TESTING_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari contact-form Story ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8'));
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-upstream.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-upstream.json'), 'utf-8'));
+    const fixture = buildFakeInput().upstream;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new TestingArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    expect(out.architectName).toBe('testing');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    for (const k of TESTING_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.risks).toEqual(expected.risks);
+    expect(out.dependencies).toContain('frontend');
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+  });
+
+  it('output passes every Testing invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new TestingArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of TESTING_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new TestingArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+});
+
+describe('golden — pyramid realism', () => {
+  /**
+   * The headline check the task brief asks for: verify the golden
+   * pyramid is realistic. Specifically:
+   *   - no 100% unit / 0% e2e degenerate case
+   *   - every ticket type has both integration AND e2e share > 0
+   *   - e2e share does not exceed 50%
+   *   - unit share is at least 30%
+   *   - mix sums to exactly 100 per ticket type
+   *   - all six required test types are present
+   */
+  const golden = goldenExpectedOutput();
+  const mix = golden.architectureFields['testing.testTypeMixPercentages'] as Record<
+    string,
+    Record<string, number>
+  >;
+
+  it('declares mix for at least one ticket type', () => {
+    expect(Object.keys(mix).length).toBeGreaterThan(0);
+  });
+
+  it('every ticket type has non-zero e2e share', () => {
+    for (const [ticketType, perType] of Object.entries(mix)) {
+      expect(perType.e2e, `${ticketType} must have non-zero e2e share`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every ticket type has non-zero integration share', () => {
+    for (const [ticketType, perType] of Object.entries(mix)) {
+      expect(
+        perType.integration,
+        `${ticketType} must have non-zero integration share`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('no ticket type has 100% unit (the classic LLM anti-pattern)', () => {
+    for (const [ticketType, perType] of Object.entries(mix)) {
+      expect(perType.unit, `${ticketType} must not be 100% unit`).toBeLessThan(100);
+    }
+  });
+
+  it('e2e share never exceeds 50% (unmaintainable threshold)', () => {
+    for (const [ticketType, perType] of Object.entries(mix)) {
+      expect(perType.e2e, `${ticketType} e2e share must be <= 50%`).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it('unit share is at least 30% (broad-base pyramid floor)', () => {
+    for (const [ticketType, perType] of Object.entries(mix)) {
+      expect(
+        perType.unit,
+        `${ticketType} unit share must be >= 30% (broad-base floor)`
+      ).toBeGreaterThanOrEqual(30);
+    }
+  });
+
+  it('every ticket type sums to exactly 100', () => {
+    for (const [ticketType, perType] of Object.entries(mix)) {
+      const sum = Object.values(perType).reduce((acc, v) => acc + v, 0);
+      expect(sum, `${ticketType} mix must sum to exactly 100`).toBe(100);
+    }
+  });
+
+  it('every ticket type declares all six required test types', () => {
+    const required = ['unit', 'integration', 'e2e', 'visual', 'a11y', 'perf'];
+    for (const [ticketType, perType] of Object.entries(mix)) {
+      for (const t of required) {
+        expect(perType, `${ticketType} must declare ${t}`).toHaveProperty(t);
+      }
+    }
+  });
+
+  it('pyramid shape is broad-base (V1 default)', () => {
+    const strategy = golden.architectureFields['testing.testingStrategy'] as Record<string, unknown>;
+    expect(strategy.pyramidShape).toBe('broad-base');
+  });
+});

--- a/packages/testing-architect/tests/golden/input-businessplan.json
+++ b/packages/testing-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,10 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": []
+}

--- a/packages/testing-architect/tests/golden/input-ticket.json
+++ b/packages/testing-architect/tests/golden/input-ticket.json
@@ -1,0 +1,21 @@
+{
+  "id": "ticket-pt-test-001",
+  "type": "Story",
+  "scope": "story",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "Submitting valid contact data writes a row to the contacts table.",
+    "Submitting invalid email shows the field-level error message.",
+    "Submit button is disabled while the request is in-flight.",
+    "After successful submission, the form clears and shows a success toast."
+  ],
+  "business_requirements": {
+    "title": "Contact form story",
+    "description": "End-to-end contact-form story spanning the frontend form widget, the POST /v1/contacts API, and the contacts table."
+  },
+  "quality_tags": [
+    "ui",
+    "api",
+    "persists"
+  ]
+}

--- a/packages/testing-architect/tests/golden/input-upstream.json
+++ b/packages/testing-architect/tests/golden/input-upstream.json
@@ -1,0 +1,83 @@
+{
+  "outputs": {
+    "frontend": {
+      "architectName": "frontend",
+      "architectureFields": {
+        "frontend.componentTree": [
+          {
+            "id": "contact-form",
+            "kind": "form",
+            "children": [
+              { "id": "contact-name", "kind": "Input" },
+              { "id": "contact-email", "kind": "Input" },
+              { "id": "contact-message", "kind": "Textarea" },
+              { "id": "contact-submit", "kind": "Button" }
+            ]
+          }
+        ],
+        "frontend.interactionStates": {
+          "contact-name": { "hover": "n/a", "focus": "visible ring", "active": "n/a", "error": "red border + error text", "empty": "placeholder shown", "loading": "n/a", "disabled": "50% opacity" },
+          "contact-email": { "hover": "n/a", "focus": "visible ring", "active": "n/a", "error": "red border + error text", "empty": "placeholder shown", "loading": "n/a", "disabled": "50% opacity" },
+          "contact-message": { "hover": "n/a", "focus": "visible ring", "active": "n/a", "error": "red border + error text", "empty": "placeholder shown", "loading": "n/a", "disabled": "50% opacity" },
+          "contact-submit": { "hover": "darker fill", "focus": "visible ring", "active": "inset shadow", "error": "n/a", "empty": "n/a", "loading": "inline spinner", "disabled": "50% opacity" }
+        },
+        "frontend.routeConfig": {
+          "segment": "app/contact",
+          "layoutSegment": "app",
+          "loadingBoundary": true,
+          "errorBoundary": true,
+          "dynamicSegments": []
+        }
+      },
+      "confidence": 0.9,
+      "notes": "Frontend fixture.",
+      "dependencies": [],
+      "risks": [],
+      "toolCalls": [],
+      "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0, "wallClockMs": 0, "model": "sonnet" },
+      "status": "ok"
+    },
+    "backend": {
+      "architectName": "backend",
+      "architectureFields": {
+        "backend.apiEndpoints": [
+          {
+            "method": "POST",
+            "path": "/v1/contacts",
+            "op": "createContact",
+            "requestSchemaRef": "ContactCreate",
+            "responseSchemaRef": "Contact",
+            "persistsTo": ["contacts"]
+          }
+        ],
+        "backend.errorEnvelope": {
+          "schema": { "error": { "code": "string", "message": "string", "requestId": "string" } },
+          "mapping": { "ValidationError": { "httpStatus": 400, "code": "INVALID_BODY" } }
+        }
+      },
+      "confidence": 0.9,
+      "notes": "Backend fixture.",
+      "dependencies": [],
+      "risks": [],
+      "toolCalls": [],
+      "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0, "wallClockMs": 0, "model": "sonnet" },
+      "status": "ok"
+    },
+    "database": {
+      "architectName": "database",
+      "architectureFields": {
+        "database.schemaDDL": "CREATE TABLE contacts (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), tenant_id text NOT NULL, name text NOT NULL, email text NOT NULL, message text NOT NULL, created_at timestamptz NOT NULL DEFAULT now());",
+        "database.rlsPolicies": [
+          { "table": "contacts", "policy": "tenant_isolation", "check": "tenant_id = current_setting('app.tenant_id')" }
+        ]
+      },
+      "confidence": 0.9,
+      "notes": "Database fixture.",
+      "dependencies": ["backend"],
+      "risks": [],
+      "toolCalls": [],
+      "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0, "wallClockMs": 0, "model": "sonnet" },
+      "status": "ok"
+    }
+  }
+}

--- a/packages/testing-architect/tests/helpers/fakes.ts
+++ b/packages/testing-architect/tests/helpers/fakes.ts
@@ -1,0 +1,278 @@
+/**
+ * Test fixtures + fake spawner factory for the Testing Architect.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { TESTING_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+function buildFrontendUpstreamFields(): Record<string, unknown> {
+  return {
+    'frontend.componentTree': [
+      {
+        id: 'contact-form',
+        kind: 'form',
+        children: [
+          { id: 'contact-name', kind: 'Input' },
+          { id: 'contact-email', kind: 'Input' },
+          { id: 'contact-message', kind: 'Textarea' },
+          { id: 'contact-submit', kind: 'Button' }
+        ]
+      }
+    ],
+    'frontend.interactionStates': {
+      'contact-name': { hover: 'n/a', focus: 'visible ring', active: 'n/a', error: 'red border + error text', empty: 'placeholder shown', loading: 'n/a', disabled: '50% opacity' },
+      'contact-email': { hover: 'n/a', focus: 'visible ring', active: 'n/a', error: 'red border + error text', empty: 'placeholder shown', loading: 'n/a', disabled: '50% opacity' },
+      'contact-message': { hover: 'n/a', focus: 'visible ring', active: 'n/a', error: 'red border + error text', empty: 'placeholder shown', loading: 'n/a', disabled: '50% opacity' },
+      'contact-submit': { hover: 'darker fill', focus: 'visible ring', active: 'inset shadow', error: 'n/a', empty: 'n/a', loading: 'inline spinner', disabled: '50% opacity' }
+    },
+    'frontend.routeConfig': {
+      segment: 'app/contact',
+      layoutSegment: 'app',
+      loadingBoundary: true,
+      errorBoundary: true,
+      dynamicSegments: []
+    }
+  };
+}
+
+function buildBackendUpstreamFields(): Record<string, unknown> {
+  return {
+    'backend.apiEndpoints': [
+      {
+        method: 'POST',
+        path: '/v1/contacts',
+        op: 'createContact',
+        requestSchemaRef: 'ContactCreate',
+        responseSchemaRef: 'Contact',
+        persistsTo: ['contacts']
+      }
+    ],
+    'backend.errorEnvelope': {
+      schema: { error: { code: 'string', message: 'string', requestId: 'string' } },
+      mapping: { ValidationError: { httpStatus: 400, code: 'INVALID_BODY' } }
+    }
+  };
+}
+
+function buildDatabaseUpstreamFields(): Record<string, unknown> {
+  return {
+    'database.schemaDDL':
+      "CREATE TABLE contacts (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), tenant_id text NOT NULL, name text NOT NULL, email text NOT NULL, message text NOT NULL, created_at timestamptz NOT NULL DEFAULT now());",
+    'database.rlsPolicies': [
+      { table: 'contacts', policy: 'tenant_isolation', check: "tenant_id = current_setting('app.tenant_id')" }
+    ]
+  };
+}
+
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-test-001',
+      type: 'Story',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'Submitting valid contact data writes a row to the contacts table.',
+        'Submitting invalid email shows the field-level error message.',
+        'Submit button is disabled while the request is in-flight.',
+        'After successful submission, the form clears and shows a success toast.'
+      ],
+      business_requirements: {
+        title: 'Contact form story',
+        description:
+          'End-to-end contact-form story spanning the frontend form widget, the POST /v1/contacts API, and the contacts table.'
+      },
+      quality_tags: ['ui', 'api', 'persists']
+    },
+    upstream: {
+      outputs: {
+        frontend: {
+          architectName: 'frontend',
+          architectureFields: buildFrontendUpstreamFields(),
+          confidence: 0.9,
+          notes: 'Frontend fixture.',
+          dependencies: [],
+          risks: [],
+          toolCalls: [],
+          spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+          status: 'ok'
+        },
+        backend: {
+          architectName: 'backend',
+          architectureFields: buildBackendUpstreamFields(),
+          confidence: 0.9,
+          notes: 'Backend fixture.',
+          dependencies: [],
+          risks: [],
+          toolCalls: [],
+          spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+          status: 'ok'
+        },
+        database: {
+          architectName: 'database',
+          architectureFields: buildDatabaseUpstreamFields(),
+          confidence: 0.9,
+          notes: 'Database fixture.',
+          dependencies: ['backend'],
+          risks: [],
+          toolCalls: [],
+          spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+          status: 'ok'
+        }
+      }
+    },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: "High-intent prospective sitters in the artist's metropolitan area.",
+      goals: ['Drive contact-form submissions'],
+      brandVoice: 'warm + grounded',
+      constraints: []
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [],
+      tokens: {},
+      breakpoints: ['sm', 'md', 'lg', 'xl']
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'testing',
+    architectureFields: {
+      'testing.testingStrategy': {
+        pyramidShape: 'broad-base',
+        rationale:
+          'Form story: heavy unit on input-validators, moderate integration on the POST /v1/contacts handler, light e2e covering submit-happy-path and one failure-path.',
+        riskAreas: [
+          'contact-email validation regex drift',
+          'contact-submit double-submit race',
+          'contact-form RLS-tenant-leakage in the contacts table'
+        ],
+        owner: 'test-author-agent',
+        reviewer: 'test-reviewer-agent'
+      },
+      'testing.testTypeMixPercentages': {
+        Story: { unit: 60, integration: 20, e2e: 10, visual: 5, a11y: 3, perf: 2 },
+        Page: { unit: 50, integration: 20, e2e: 15, visual: 7, a11y: 5, perf: 3 },
+        Form: { unit: 65, integration: 18, e2e: 8, visual: 4, a11y: 3, perf: 2 },
+        Widget: { unit: 62, integration: 20, e2e: 8, visual: 5, a11y: 3, perf: 2 },
+        List: { unit: 58, integration: 22, e2e: 10, visual: 4, a11y: 4, perf: 2 }
+      },
+      'testing.fixturesStrategy': {
+        goldenDatasets: [{ id: 'contacts-baseline', scope: 'tenant', refreshPolicy: 'per-release' }],
+        factories: [{ kind: 'Contact', library: 'fishery', scope: 'per-test' }],
+        seedingDiscipline: 'per-test',
+        determinism: { clockMock: true, idGenerator: 'uuid-v7-fixed-seed', rngSeed: 42 }
+      },
+      'testing.mutationTestingThresholds': {
+        tool: 'stryker',
+        killScoreFloor: 60,
+        perScope: { 'validators/*': 75, 'handlers/*': 55, 'adapters/*': 50 },
+        escalation: 'warn'
+      },
+      'testing.perfRegressionBudgets': {
+        tool: 'lighthouse',
+        lighthouseDeltaPct: 5,
+        k6Thresholds: { p95LatencyMs: 1000, errorRatePct: 1.0 },
+        regressionAction: 'open-issue'
+      },
+      'testing.e2ePatterns': {
+        runner: 'playwright',
+        playwrightVersion: '1.59.x',
+        pageObjects: true,
+        fixtureScope: 'test',
+        remoteBrowserless: true,
+        retries: { ci: 2, local: 0 },
+        parallelism: { ci: 1, local: 3 },
+        traceOnFailure: true
+      },
+      'testing.coverageThresholds': {
+        perTicketType: {
+          Story: { lines: 80, branches: 75, functions: 80, statements: 80 },
+          Page: { lines: 85, branches: 80, functions: 85, statements: 85 },
+          Form: { lines: 82, branches: 78, functions: 82, statements: 82 },
+          Widget: { lines: 80, branches: 75, functions: 80, statements: 80 },
+          List: { lines: 80, branches: 75, functions: 80, statements: 80 }
+        },
+        globalFloor: { lines: 80, branches: 75, functions: 80, statements: 80 }
+      },
+      'testing.flakeTolerance': {
+        maxRetryRatePct: 0.5,
+        quarantinePolicy: 'auto-skip-after-3-flakes',
+        flakeBudget: { perSuite: 2, perDay: 5 },
+        deflakeOwner: 'test-reviewer-agent',
+        failOpenAt: '1pct'
+      }
+    },
+    confidence: 0.88,
+    notes:
+      'Broad-base pyramid for a Form-typed Story. Stryker mutation 60% kill-score floor. Lighthouse delta budget 5%. Playwright + Browserless e2e with page-object pattern mandatory. 0.5% flake budget.',
+    dependencies: ['frontend', 'backend', 'database'],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of TESTING_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/testing-architect/tests/invariants.test.ts
+++ b/packages/testing-architect/tests/invariants.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Cross-architect invariants tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { TESTING_INVARIANTS } from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('TESTING_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(TESTING_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable, unique id', () => {
+    const seen = new Set<string>();
+    for (const inv of TESTING_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `testing`', () => {
+    for (const inv of TESTING_INVARIANTS) {
+      expect(inv.contributor).toBe('testing');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of TESTING_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of TESTING_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of TESTING_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('TESTING_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of TESTING_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('strategy-pyramid-shape-allowed fails on a forbidden shape (diamond)', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.strategy-pyramid-shape-allowed');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'testing.testingStrategy': {
+        ...(goldenArch['testing.testingStrategy'] as Record<string, unknown>),
+        pyramidShape: 'diamond'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('strategy-pyramid-shape-allowed fails on a forbidden shape (trophy)', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.strategy-pyramid-shape-allowed');
+    const corrupted = {
+      ...goldenArch,
+      'testing.testingStrategy': {
+        ...(goldenArch['testing.testingStrategy'] as Record<string, unknown>),
+        pyramidShape: 'trophy'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('mix-covers-all-six-types fails when a test type is missing', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.mix-covers-all-six-types');
+    const corrupted = {
+      ...goldenArch,
+      'testing.testTypeMixPercentages': {
+        Story: { unit: 70, integration: 20, e2e: 10 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('mix-sums-to-100 fails when percentages do not sum to 100', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.mix-sums-to-100');
+    const corrupted = {
+      ...goldenArch,
+      'testing.testTypeMixPercentages': {
+        Story: { unit: 70, integration: 20, e2e: 10, visual: 5, a11y: 3, perf: 2 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('mix-is-realistic-not-100-pct-unit fails on a 100% unit pyramid', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.mix-is-realistic-not-100-pct-unit');
+    const corrupted = {
+      ...goldenArch,
+      'testing.testTypeMixPercentages': {
+        Story: { unit: 100, integration: 0, e2e: 0, visual: 0, a11y: 0, perf: 0 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('mix-is-realistic-not-100-pct-unit fails on zero e2e share', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.mix-is-realistic-not-100-pct-unit');
+    const corrupted = {
+      ...goldenArch,
+      'testing.testTypeMixPercentages': {
+        Story: { unit: 80, integration: 20, e2e: 0, visual: 0, a11y: 0, perf: 0 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('mix-is-realistic-not-100-pct-unit fails on >50% e2e (unmaintainable)', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.mix-is-realistic-not-100-pct-unit');
+    const corrupted = {
+      ...goldenArch,
+      'testing.testTypeMixPercentages': {
+        Story: { unit: 20, integration: 10, e2e: 60, visual: 5, a11y: 3, perf: 2 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('mix-is-realistic-not-100-pct-unit fails on <30% unit', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.mix-is-realistic-not-100-pct-unit');
+    const corrupted = {
+      ...goldenArch,
+      'testing.testTypeMixPercentages': {
+        Story: { unit: 25, integration: 30, e2e: 30, visual: 5, a11y: 5, perf: 5 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('mutation-kill-floor-meets-min fails on kill score < 50', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.mutation-kill-floor-meets-min');
+    const corrupted = {
+      ...goldenArch,
+      'testing.mutationTestingThresholds': {
+        ...(goldenArch['testing.mutationTestingThresholds'] as Record<string, unknown>),
+        killScoreFloor: 30
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('mutation-tool-allowed fails on an unknown tool', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.mutation-tool-allowed');
+    const corrupted = {
+      ...goldenArch,
+      'testing.mutationTestingThresholds': {
+        ...(goldenArch['testing.mutationTestingThresholds'] as Record<string, unknown>),
+        tool: 'my-custom-mutator'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('perf-lighthouse-delta-bounded fails on > 10% budget', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.perf-lighthouse-delta-bounded');
+    const corrupted = {
+      ...goldenArch,
+      'testing.perfRegressionBudgets': {
+        ...(goldenArch['testing.perfRegressionBudgets'] as Record<string, unknown>),
+        lighthouseDeltaPct: 25
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('e2e-runner-allowed fails on Cypress', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.e2e-runner-allowed');
+    const corrupted = {
+      ...goldenArch,
+      'testing.e2ePatterns': {
+        ...(goldenArch['testing.e2ePatterns'] as Record<string, unknown>),
+        runner: 'cypress'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('e2e-page-objects-mandatory fails when pageObjects is false', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.e2e-page-objects-mandatory');
+    const corrupted = {
+      ...goldenArch,
+      'testing.e2ePatterns': {
+        ...(goldenArch['testing.e2ePatterns'] as Record<string, unknown>),
+        pageObjects: false
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('coverage-floor-meets-min fails when globalFloor.lines < 70', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.coverage-floor-meets-min');
+    const corrupted = {
+      ...goldenArch,
+      'testing.coverageThresholds': {
+        ...(goldenArch['testing.coverageThresholds'] as Record<string, unknown>),
+        globalFloor: { lines: 60, branches: 75, functions: 80, statements: 80 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('coverage-floor-meets-min fails when a per-ticket-type branch is < 70', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.coverage-floor-meets-min');
+    const corrupted = {
+      ...goldenArch,
+      'testing.coverageThresholds': {
+        globalFloor: { lines: 80, branches: 75, functions: 80, statements: 80 },
+        perTicketType: {
+          Story: { lines: 80, branches: 50, functions: 80, statements: 80 }
+        }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('flake-retry-rate-bounded fails on > 2% retry rate', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.flake-retry-rate-bounded');
+    const corrupted = {
+      ...goldenArch,
+      'testing.flakeTolerance': {
+        ...(goldenArch['testing.flakeTolerance'] as Record<string, unknown>),
+        maxRetryRatePct: 5
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('fixtures-determinism-mandates-clock-mock fails when clockMock=false', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.fixtures-determinism-mandates-clock-mock');
+    const corrupted = {
+      ...goldenArch,
+      'testing.fixturesStrategy': {
+        ...(goldenArch['testing.fixturesStrategy'] as Record<string, unknown>),
+        determinism: { clockMock: false, idGenerator: 'uuid-v7-fixed-seed', rngSeed: 42 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('covers-frontend-interactive-components passes trivially when frontend output is absent', () => {
+    const inv = TESTING_INVARIANTS.find(i => i.id === 'testing.covers-frontend-interactive-components');
+    const stripped = { 'testing.testingStrategy': goldenArch['testing.testingStrategy'] };
+    expect(inv!.detect(stripped)).toBe(true);
+  });
+});

--- a/packages/testing-architect/tests/run.test.ts
+++ b/packages/testing-architect/tests/run.test.ts
@@ -1,0 +1,264 @@
+/**
+ * `run()` tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { TESTING_ARCHITECT_NAME, TestingArchitect } from '../src/architect.js';
+import { TESTING_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runTestingArchitect } from '../src/run.js';
+import { buildTestingSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runTestingArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('testing');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    for (const k of TESTING_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildTestingSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runTestingArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    const b = await runTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    const r2 = await runTestingArchitect(input, {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(
+      Object.keys(r1.architectureFields).sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(TESTING_OWNED_FIELD_KEYS.length);
+  });
+});
+
+describe('runTestingArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+    expect(out.dependencies).toContain('frontend');
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"testing"}');
+    const out = await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+    expect(out.dependencies).toContain('frontend');
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runTestingArchitect — dependency declaration', () => {
+  it('Testing is wave-2; ensures frontend + backend + database in dependencies', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(out.dependencies).toContain('frontend');
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+  });
+
+  it('preserves sibling ticket IDs the model emitted alongside the canonical deps', async () => {
+    const fakeWithSiblings = {
+      ...JSON.parse(goldenAssistantText()),
+      dependencies: ['ticket-other-1', 'frontend']
+    };
+    const { fn: spawner } = fakeSpawnerReturning(JSON.stringify(fakeWithSiblings));
+    const out = await runTestingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildTestingSystemPrompt(),
+      architectName: TESTING_ARCHITECT_NAME
+    });
+    expect(out.dependencies).toContain('ticket-other-1');
+    expect(out.dependencies).toContain('frontend');
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+    expect(out.dependencies.filter(d => d === 'frontend').length).toBe(1);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    expect(buildUserPrompt(buildFakeInput())).toContain('ticket-pt-test-001');
+  });
+
+  it('serialises the upstream Frontend output (componentTree)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('frontend.componentTree');
+    expect(p).toContain('contact-form');
+  });
+
+  it('serialises the upstream Backend output (apiEndpoints)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('backend.apiEndpoints');
+    expect(p).toContain('/v1/contacts');
+  });
+
+  it('serialises the upstream Database output (schemaDDL)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('database.schemaDDL');
+    expect(p).toContain('contacts');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    expect(buildUserPrompt(buildFakeInput())).toContain('tenant-prakash-tiwari');
+  });
+
+  it('includes the tenant billingPosture', () => {
+    expect(buildUserPrompt(buildFakeInput())).toContain('subscription');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: { reason: 'bump e2e share to 12%', severity: 'P1' as const }
+    };
+    expect(buildUserPrompt(withFeedback)).toContain('bump e2e share to 12%');
+  });
+});
+
+describe('TestingArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new TestingArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('testing');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/testing-architect/tests/system-prompt.test.ts
+++ b/packages/testing-architect/tests/system-prompt.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  TESTING_OWNED_FIELD_KEYS,
+  REQUIRED_TEST_TYPES,
+  ALLOWED_PYRAMID_SHAPES,
+  ALLOWED_MUTATION_TOOLS,
+  ALLOWED_E2E_RUNNERS
+} from '../src/contract.js';
+import { buildTestingSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildTestingSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildTestingSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    expect(buildTestingSystemPrompt()).toBe(buildTestingSystemPrompt());
+  });
+
+  it('contains the Role section', () => {
+    const p = buildTestingSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's Testing Architect");
+  });
+
+  it('distinguishes itself from Test Author Agent + Test Reviewer Agent', () => {
+    const p = buildTestingSystemPrompt();
+    expect(p).toContain('Test Author Agent');
+    expect(p).toContain('Test Reviewer Agent');
+    expect(p).toContain('STRATEGY');
+  });
+
+  it('contains the Locked stack section', () => {
+    const p = buildTestingSystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('Playwright');
+    expect(p).toContain('Stryker');
+    expect(p).toContain('broad-base');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildTestingSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildTestingSystemPrompt();
+    for (const key of TESTING_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('references every required test type at least once', () => {
+    const p = buildTestingSystemPrompt();
+    for (const t of REQUIRED_TEST_TYPES) {
+      expect(p).toContain(t);
+    }
+  });
+
+  it('references every allowed pyramid shape at least once', () => {
+    const p = buildTestingSystemPrompt();
+    for (const shape of ALLOWED_PYRAMID_SHAPES) {
+      expect(p).toContain(shape);
+    }
+  });
+
+  it('references every allowed mutation tool at least once', () => {
+    const p = buildTestingSystemPrompt();
+    for (const tool of ALLOWED_MUTATION_TOOLS) {
+      expect(p).toContain(tool);
+    }
+  });
+
+  it('references every allowed e2e runner at least once', () => {
+    const p = buildTestingSystemPrompt();
+    for (const runner of ALLOWED_E2E_RUNNERS) {
+      expect(p).toContain(runner);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildTestingSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+  });
+
+  it('contains a Refusal patterns section', () => {
+    const p = buildTestingSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('testing.*');
+  });
+
+  it('contains a Self-check section', () => {
+    expect(buildTestingSystemPrompt()).toContain('## Self-check');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildTestingSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('size is bounded (< 22k chars)', () => {
+    expect(buildTestingSystemPrompt().length).toBeLessThan(22_000);
+  });
+
+  it('declares the upstream Frontend + Backend + Database inputs', () => {
+    const p = buildTestingSystemPrompt();
+    expect(p).toContain('frontend.componentTree');
+    expect(p).toContain('backend.apiEndpoints');
+    expect(p).toContain('database.schemaDDL');
+  });
+
+  it('asserts page-object pattern is mandatory', () => {
+    expect(buildTestingSystemPrompt().toLowerCase()).toContain('page-object');
+  });
+
+  it('asserts the determinism mandate (clockMock + RNG)', () => {
+    const p = buildTestingSystemPrompt();
+    expect(p).toContain('clockMock');
+    expect(p.toLowerCase()).toContain('rng');
+  });
+});

--- a/packages/testing-architect/tests/validation.test.ts
+++ b/packages/testing-architect/tests/validation.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Output validation tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { TESTING_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('testing');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in json fences', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput('{"architectName":"testing"}', TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['testing.testingStrategy'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields, 'frontend.componentTree': 'not yours' };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = { ...goldenExpectedOutput(), risks: ['a', 'b', 'c', 'd', 'e', 'f'] };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), TESTING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(JSON.stringify(variant), TESTING_OWNED_FIELD_KEYS);
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/testing-architect/tsconfig.build.json
+++ b/packages/testing-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/testing-architect/tsconfig.json
+++ b/packages/testing-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/testing-architect/vitest.config.ts
+++ b/packages/testing-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3029,6 +3029,34 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/testing-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@caia/backend-architect':
+        specifier: workspace:*
+        version: link:../backend-architect
+      '@caia/database-architect':
+        specifier: workspace:*
+        version: link:../database-architect
+      '@caia/frontend-architect':
+        specifier: workspace:*
+        version: link:../frontend-architect
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/ticket-template:
     dependencies:
       zod:


### PR DESCRIPTION
## Summary

Ships **architect #16 of 17** in CAIA's EA fan-out: the **Testing Architect** package. Mirrors the canonical Frontend Architect template; owns the `testing.*` slice of `tickets.architecture` and produces per-ticket TESTING STRATEGY specs.

## Owned fields (8 total)

- `testing.testingStrategy` — pyramid shape (broad-base default), rationale, risk areas, author + reviewer ownership
- `testing.testTypeMixPercentages` — per-ticket-type mix (unit / integration / e2e / visual / a11y / perf) summing to 100
- `testing.fixturesStrategy` — golden datasets, factory patterns, per-test seeding, determinism
- `testing.mutationTestingThresholds` — Stryker default, kill-score floor 60% (>=50% hard min)
- `testing.perfRegressionBudgets` — Lighthouse delta 5% default (<=10% hard cap), k6 thresholds
- `testing.e2ePatterns` — Playwright 1.59.x, page-object pattern mandatory, Browserless integration
- `testing.coverageThresholds` — per-ticket-type + global floor (80/75/80/80 default, >=70 hard min)
- `testing.flakeTolerance` — 0.5% max retry rate (<=2% hard cap), quarantine policy, deflake owner

## Distinction (per task brief + spec §2.16)

Testing Architect sets **STRATEGY**. It is DISTINCT from:

- **Test Author Agent** — writes the actual test CASES per story.
- **Test Reviewer Agent** — audits coverage against this strategy.

No test code. No test case generation. No coverage auditing. Just strategy.

## Architecture

- **Wave**: 2
- **Depends on**: Frontend + Backend + Database (reads what's testable)
- **Precedence rank**: 17 (lowest; advisory — any higher-stakes critic can override)
- **Runtime model**: Sonnet
- **Spawner**: `@chiefaia/claude-spawner` (subscription-only, never sets ANTHROPIC_API_KEY)
- **Tools**: empty for V1

## Tests

**146 tests across 7 files, all passing:**

- `tests/architect.test.ts` (12) — SpecialistArchitect interface compliance
- `tests/contract.test.ts` (32) — structural + registry registration + disjointness
- `tests/system-prompt.test.ts` (19) — section coverage + bounds
- `tests/validation.test.ts` (19) — happy + error paths
- `tests/run.test.ts` (23) — happy path + idempotency + failure modes + dependency declaration
- `tests/invariants.test.ts` (25) — 13 cross-architect predicates including the pyramid-realism check
- `tests/golden/golden.test.ts` (16) — end-to-end + the **headline pyramid-realism check**

The pyramid-realism check (per task brief) verifies the golden output is not the classic LLM anti-pattern:

- no ticket type has 100% unit / 0% e2e
- every ticket type has non-zero integration + e2e share
- e2e share never exceeds 50% (unmaintainable threshold)
- unit share is at least 30% (broad-base floor)
- mix sums to exactly 100 per ticket type
- all six required test types declared per ticket type
- pyramid shape is broad-base (V1 default)

## Stack reminders

- shadcn/ui + Tailwind (locked, inherited from the template).
- Quality > timeline; True-Zero rule applied.
- Subscription-only build; spawner never sets `ANTHROPIC_API_KEY`.

## Files

- `packages/testing-architect/src/{architect,contract,run,spawner,system-prompt,validation,invariants,types,index}.ts`
- `packages/testing-architect/tests/{architect,contract,run,spawner,system-prompt,validation,invariants}.test.ts`
- `packages/testing-architect/tests/helpers/fakes.ts`
- `packages/testing-architect/tests/golden/{golden.test.ts,input-ticket.json,input-businessplan.json,input-upstream.json}`
- `packages/testing-architect/{package.json,tsconfig.json,tsconfig.build.json,vitest.config.ts,eslint.config.cjs,README.md}`

Refs: `research/17_architect_framework_spec_2026.md` §2.16, §5.2 (precedence rank 17), §11(b). Roster entry at `agent-memory/project_caia_17_architects.md` #16.

🤖 Generated with Claude Code