### PR TITLE
feat(@caia/state-machine): Solution lifecycle FSM (Real Definition-of-Done) — v0.2.0

### DIFF
--- a/packages/state-machine/migrations/0002_solution_lifecycle.sql
+++ b/packages/state-machine/migrations/0002_solution_lifecycle.sql
@@ -1,0 +1,166 @@
+-- @caia/state-machine — Solution lifecycle (Real Definition-of-Done).
+--
+-- Adds two tables next to the project FSM tables (state_history /
+-- tenant_projects) for the Solution entity. Separate from
+-- caia_meta.state_history to avoid wedging an extra solution_id column
+-- onto every existing project row and to give the lifecycle clear
+-- namespace separation (per ADR-035 + the operator's prompt rec).
+--
+-- Idempotent: every CREATE uses IF NOT EXISTS, the CHECK constraint is
+-- rewritten via DROP+ADD on every run, and indices are guarded by IF
+-- NOT EXISTS. Safe to apply repeatedly.
+
+CREATE SCHEMA IF NOT EXISTS caia_meta;
+
+-- ----------------------------------------------------------------------
+-- solution_lifecycle (per-solution row, mutated atomically with an
+-- optimistic-version check; see PgSolutionStore.advanceAtomic)
+-- ----------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS caia_meta.solution_lifecycle (
+  id                       UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Stable join key across deploy-steward / usage-steward / activation-steward /
+  -- outcome-steward / EA AKG / ADR registry. Format: caia-YYYY-MM-DD-short-slug.
+  solution_id              TEXT         NOT NULL UNIQUE,
+  title                    TEXT         NOT NULL,
+  plan_path                TEXT,
+  approved_by_adr          TEXT,
+  approved_at              TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  status                   TEXT         NOT NULL DEFAULT 'approved',
+  status_since             TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  paused                   BOOLEAN      NOT NULL DEFAULT false,
+  paused_at                TIMESTAMPTZ,
+  paused_by                TEXT,
+  prior_state              TEXT,                              -- saved on pause for resume
+  current_payload          JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  last_attestation         JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  manifest_pointer         TEXT,                              -- agent-memory yaml pointer
+  abandoned_at             TIMESTAMPTZ,
+  done_at                  TIMESTAMPTZ,
+  version                  INTEGER      NOT NULL DEFAULT 1,
+  created_at               TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- Re-assert the status check (23 states: 9 forward + 7 failed + 5 rolled-back + 2 control).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'solution_lifecycle_status_check'
+       AND conrelid = 'caia_meta.solution_lifecycle'::regclass
+  ) THEN
+    ALTER TABLE caia_meta.solution_lifecycle
+      DROP CONSTRAINT solution_lifecycle_status_check;
+  END IF;
+END$$;
+
+ALTER TABLE caia_meta.solution_lifecycle
+  ADD CONSTRAINT solution_lifecycle_status_check
+  CHECK (status IN (
+    -- Forward (9)
+    'approved','implemented','merged','deployed','imported',
+    'called-in-test','called-in-prod','producing-metrics','done',
+    -- Failed (7)
+    'implemented-failed','merged-failed','deployed-failed','imported-failed',
+    'called-in-test-failed','called-in-prod-failed','producing-metrics-failed',
+    -- Rolled-back (5)
+    'deployed-rolled-back','imported-rolled-back','called-in-test-rolled-back',
+    'called-in-prod-rolled-back','producing-metrics-rolled-back',
+    -- Control (2)
+    'paused','abandoned'
+  ));
+
+-- Same check on prior_state (only the non-control, non-terminal states
+-- are valid resume targets, but we allow any solution-state here for
+-- forward compat).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'solution_lifecycle_prior_state_check'
+       AND conrelid = 'caia_meta.solution_lifecycle'::regclass
+  ) THEN
+    ALTER TABLE caia_meta.solution_lifecycle
+      DROP CONSTRAINT solution_lifecycle_prior_state_check;
+  END IF;
+END$$;
+
+ALTER TABLE caia_meta.solution_lifecycle
+  ADD CONSTRAINT solution_lifecycle_prior_state_check
+  CHECK (prior_state IS NULL OR prior_state IN (
+    'approved','implemented','merged','deployed','imported',
+    'called-in-test','called-in-prod','producing-metrics','done',
+    'implemented-failed','merged-failed','deployed-failed','imported-failed',
+    'called-in-test-failed','called-in-prod-failed','producing-metrics-failed',
+    'deployed-rolled-back','imported-rolled-back','called-in-test-rolled-back',
+    'called-in-prod-rolled-back','producing-metrics-rolled-back',
+    'paused','abandoned'
+  ));
+
+-- Index for getStuckSolutions — the conductor enumerates active,
+-- non-paused, non-terminal solutions every 10 min and joins on status +
+-- status_since.
+CREATE INDEX IF NOT EXISTS solution_lifecycle_stuck_idx
+  ON caia_meta.solution_lifecycle(status, status_since)
+  WHERE paused = false AND abandoned_at IS NULL AND done_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS solution_lifecycle_active_idx
+  ON caia_meta.solution_lifecycle(status)
+  WHERE abandoned_at IS NULL AND done_at IS NULL;
+
+-- ----------------------------------------------------------------------
+-- solution_history (append-only audit + idempotency anchor)
+-- ----------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS caia_meta.solution_history (
+  id                BIGSERIAL    PRIMARY KEY,
+  solution_id       TEXT         NOT NULL REFERENCES caia_meta.solution_lifecycle(solution_id),
+  from_state        TEXT,
+  to_state          TEXT         NOT NULL,
+  reason            TEXT         NOT NULL,
+  actor_kind        TEXT         NOT NULL CHECK (actor_kind IN ('system','operator','agent','steward')),
+  actor_id          TEXT         NOT NULL,
+  attestation       JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  evidence          JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  payload           JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  payload_hash      TEXT         NOT NULL,
+  at                TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS solution_history_solution_at_idx
+  ON caia_meta.solution_history(solution_id, at DESC);
+CREATE INDEX IF NOT EXISTS solution_history_to_state_idx
+  ON caia_meta.solution_history(to_state, at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS solution_history_idempotency_idx
+  ON caia_meta.solution_history(solution_id, to_state, payload_hash);
+
+-- ----------------------------------------------------------------------
+-- LISTEN/NOTIFY trigger so subscribers (pipeline-conductor + dashboard)
+-- get realtime advancement events.
+-- ----------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION caia_meta.solution_history_notify()
+RETURNS trigger AS $$
+DECLARE
+  channel TEXT := 'caia_solution_' || NEW.solution_id;
+  payload TEXT;
+BEGIN
+  payload := json_build_object(
+    'kind',        'solution-advanced',
+    'history_id',  NEW.id,
+    'from_state',  NEW.from_state,
+    'to_state',    NEW.to_state,
+    'reason',      NEW.reason,
+    'actor_kind',  NEW.actor_kind,
+    'actor_id',    NEW.actor_id,
+    'at',          NEW.at
+  )::text;
+  PERFORM pg_notify(channel, payload);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS solution_history_notify_trg ON caia_meta.solution_history;
+CREATE TRIGGER solution_history_notify_trg
+  AFTER INSERT ON caia_meta.solution_history
+  FOR EACH ROW EXECUTE FUNCTION caia_meta.solution_history_notify();

--- a/packages/state-machine/package.json
+++ b/packages/state-machine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@caia/state-machine",
-  "version": "0.1.0",
-  "description": "Typed pipeline-status finite-state machine for CAIA projects. Postgres-backed, with optimistic concurrency, atomic worker assignment, and LISTEN/NOTIFY → SSE realtime.",
+  "version": "0.2.0",
+  "description": "Typed pipeline-status FSM (project + solution-lifecycle entities) for CAIA. Postgres-backed, optimistic concurrency, atomic worker assignment, LISTEN/NOTIFY \u2192 SSE realtime. v0.2 adds the Solution lifecycle FSM for the Real Definition-of-Done (research/real_definition_of_done_enforcement_2026.md).",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/state-machine/scripts/dogfood-register-ea-coordinator.mjs
+++ b/packages/state-machine/scripts/dogfood-register-ea-coordinator.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Dogfood: register the EA Coordinator framework build (sibling task)
+ * as the first `Solution` entity in production.
+ *
+ * Usage:
+ *   PG_DSN=postgresql://… node scripts/dogfood-register-ea-coordinator.mjs
+ *
+ * Requires `0002_solution_lifecycle.sql` to be applied on the target db
+ * (PgSolutionStore.init() will apply it idempotently if not already).
+ *
+ * Idempotent — re-running with the same solution_id throws
+ * DuplicateSolutionIdError (which we catch + report as "already
+ * registered"). Re-runs after that point are no-ops.
+ */
+
+import { Pool } from 'pg';
+import {
+  DuplicateSolutionIdError,
+  PgSolutionStore,
+  SolutionLifecycleMachine,
+} from '../dist/index.js';
+
+const PG_DSN = process.env.PG_DSN;
+if (!PG_DSN) {
+  console.error('PG_DSN env var is required (postgresql://user:pw@host:port/db).');
+  process.exit(2);
+}
+
+const pool = new Pool({ connectionString: PG_DSN });
+const store = new PgSolutionStore(pool);
+const machine = new SolutionLifecycleMachine(store);
+await machine.init(); // applies 0002_solution_lifecycle.sql if not yet applied
+
+try {
+  const reg = await machine.registerSolution({
+    solutionId: 'caia-2026-05-24-ea-coordinator-framework',
+    title: 'EA Coordinator Framework build (17-architect roster aggregation + sign-off composer)',
+    planPath: 'research/ea_coordinator_framework_2026.md',
+    approvedByAdr: 'ADR-035', // ADR-035 is the state-machine package ADR; the
+                              // coordinator-specific ADR will be filed by the
+                              // EA Agent on the coordinator-build's submitPlan.
+    manifestPointer:
+      'agent-memory/solutions_manifest.yaml#/solutions/caia-2026-05-24-ea-coordinator-framework',
+    initialPayload: {
+      dogfood: true,
+      dogfooded_at: new Date().toISOString(),
+      purpose:
+        'First Solution entity in production — proves the FSM works on a real, in-flight build before we wire the four stewards behind it.',
+    },
+  });
+  console.log(JSON.stringify({ result: 'registered', solutionId: reg.solutionId, state: reg.currentState }, null, 2));
+} catch (err) {
+  if (err instanceof DuplicateSolutionIdError) {
+    const snap = await machine.getSolutionLifecycle(err.solutionId);
+    console.log(JSON.stringify({
+      result: 'already-registered',
+      solutionId: err.solutionId,
+      currentState: snap.solution.status,
+      ageHoursInState: snap.ageHoursInState,
+      historyLength: snap.history.length,
+    }, null, 2));
+  } else {
+    console.error('register failed:', err);
+    process.exit(1);
+  }
+}
+
+await pool.end();

--- a/packages/state-machine/scripts/submit-plan.mjs
+++ b/packages/state-machine/scripts/submit-plan.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// One-shot script: submit the solution-lifecycle plan to the EA Architect
+// Agent and print the structured outcome to stdout. Used by the
+// state-machine-architect agent per operator directive "EA Agent review:
+// submit plan via submitPlan before proceeding."
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { EaArchitectAgent } from '../../ea-architect/dist/index.js';
+import { createDefaultCritic } from '../../ea-architect/dist/critic.js';
+
+const HOME = homedir();
+const PLAN_PATH = join(
+  HOME,
+  'Documents',
+  'projects',
+  'research',
+  'plan_state_machine_solution_lifecycle_2026.md',
+);
+const OUT_PATH = join(
+  HOME,
+  'Documents',
+  'projects',
+  'research',
+  'plan_state_machine_solution_lifecycle_2026.ea-review.json',
+);
+
+const planMarkdown = readFileSync(PLAN_PATH, 'utf8');
+
+const agent = new EaArchitectAgent({
+  autoFileAdrs: false, // dry-run: don't auto-file ADRs for the internal review submission
+  surfaceEscalations: false, // don't write to operator INBOX for this submission
+  // Bump timeout to 8 minutes — Opus reviews of long architecture-change plans
+  // routinely exceed the default 90s cap.
+  critic: createDefaultCritic({ timeoutMs: 8 * 60 * 1000 }),
+});
+
+console.error('[submit-plan] submitting to EA Architect Agent...');
+const startedAt = Date.now();
+const outcome = await agent.submitPlan({
+  planMarkdown,
+  planType: 'architecture-change',
+  callerAgentId: 'state-machine-architect',
+  submittedBy: 'state-machine-architect',
+  affectedComponents: [
+    '@caia/state-machine',
+    '@chiefaia/events',
+    '@chiefaia/events-taxonomy-internal',
+    '@caia/pipeline-conductor',
+    '@caia/deploy-steward',
+    'caia_meta.solution_lifecycle',
+    'caia_meta.solution_history',
+  ],
+  submissionId: 'sm-solution-lifecycle-2026-05-24',
+});
+const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
+console.error(`[submit-plan] EA Agent returned in ${elapsedSec}s.`);
+
+writeFileSync(OUT_PATH, JSON.stringify(outcome, null, 2), 'utf8');
+console.error(`[submit-plan] wrote outcome JSON to ${OUT_PATH}`);
+
+console.log(JSON.stringify(
+  {
+    status: outcome.status,
+    iteration: outcome.iteration,
+    modelTier: outcome.modelTier,
+    submissionId: outcome.submissionId,
+    cited_adrs: outcome.cited_adrs,
+    cited_principles: outcome.cited_principles,
+    cited_lessons: outcome.cited_lessons,
+    requested_modifications: outcome.requested_modifications ?? [],
+    new_adrs_count: (outcome.new_adrs_to_file ?? []).length,
+    affected_existing_adrs: outcome.affected_existing_adrs ?? [],
+    escalation: outcome.escalation_to_operator ?? null,
+    reasoning: outcome.reasoning,
+  },
+  null,
+  2,
+));

--- a/packages/state-machine/src/entities/in-memory-solution-store.ts
+++ b/packages/state-machine/src/entities/in-memory-solution-store.ts
@@ -1,0 +1,355 @@
+import { randomUUID } from 'node:crypto';
+
+import { DuplicateSolutionIdError } from './solution-errors.js';
+import {
+  isSolutionTerminal,
+  SOLUTION_INITIAL_STATE,
+  type SolutionState,
+} from './solution-states.js';
+import type {
+  SolutionAdvanceAtomicInput,
+  SolutionAdvanceAtomicResult,
+  SolutionStore,
+  ListStuckOpts,
+} from './solution-store.js';
+import type {
+  ApprovedPlanInput,
+  SolutionActorKind,
+  SolutionHistoryRow,
+  SolutionRow,
+  StuckSolution,
+} from './solution-types.js';
+import {
+  availableSolutionTransitions,
+  VALID_SOLUTION_TRANSITIONS,
+} from './solution-transitions.js';
+
+/**
+ * In-memory `SolutionStore` — same concurrency model as the project
+ * FSM's `InMemoryStateStore`: every `advanceAtomic` runs as a single
+ * synchronous block (no awaits between the read and write), so the
+ * advisory-lock + optimistic-version protocol is satisfied by JS's
+ * single-threaded event loop. Tests can reproduce multi-writer races
+ * deterministically by interleaving `await`s between calls.
+ */
+export class InMemorySolutionStore implements SolutionStore {
+  private solutions = new Map<string, SolutionRow>();
+  private history: SolutionHistoryRow[] = [];
+  private historyNextId = 1;
+  private listeners = new Map<string, Set<(payload: string) => void>>();
+
+  async init(): Promise<void> {
+    // no-op
+  }
+
+  async reset(): Promise<void> {
+    this.solutions.clear();
+    this.history = [];
+    this.historyNextId = 1;
+    this.listeners.clear();
+  }
+
+  async registerSolution(input: ApprovedPlanInput, now: Date): Promise<SolutionRow> {
+    const solutionId = input.solutionId ?? defaultSolutionId(now);
+    if (this.solutions.has(solutionId)) {
+      throw new DuplicateSolutionIdError(solutionId);
+    }
+    const approvedAt = input.approvedAt ? new Date(input.approvedAt) : now;
+    const initialState = input.initialState ?? SOLUTION_INITIAL_STATE;
+    const row: SolutionRow = {
+      id: randomUUID(),
+      solutionId,
+      title: input.title,
+      planPath: input.planPath ?? null,
+      approvedByAdr: input.approvedByAdr ?? null,
+      approvedAt,
+      status: initialState,
+      statusSince: now,
+      paused: false,
+      pausedAt: null,
+      pausedBy: null,
+      priorState: null,
+      currentPayload: input.initialPayload ?? {},
+      lastAttestation: {},
+      manifestPointer: input.manifestPointer ?? null,
+      abandonedAt: null,
+      doneAt: null,
+      version: 1,
+      createdAt: now,
+    };
+    this.solutions.set(solutionId, row);
+    return cloneSolution(row);
+  }
+
+  async getSolution(solutionId: string): Promise<SolutionRow | null> {
+    const rec = this.solutions.get(solutionId);
+    return rec ? cloneSolution(rec) : null;
+  }
+
+  async listActiveSolutions(): Promise<SolutionRow[]> {
+    return [...this.solutions.values()]
+      .filter((s) => s.abandonedAt === null && s.doneAt === null)
+      .map(cloneSolution);
+  }
+
+  async setPaused(
+    solutionId: string,
+    by: string,
+    now: Date,
+  ): Promise<SolutionRow | null> {
+    const rec = this.solutions.get(solutionId);
+    if (!rec) return null;
+    if (rec.paused) return cloneSolution(rec); // idempotent
+    if (isSolutionTerminal(rec.status)) return cloneSolution(rec); // can't pause terminal
+    rec.priorState = rec.status;
+    rec.status = 'paused';
+    rec.statusSince = now;
+    rec.paused = true;
+    rec.pausedAt = now;
+    rec.pausedBy = by;
+    rec.version += 1;
+    return cloneSolution(rec);
+  }
+
+  async setResumed(solutionId: string, now: Date): Promise<SolutionRow | null> {
+    const rec = this.solutions.get(solutionId);
+    if (!rec) return null;
+    if (!rec.paused) return cloneSolution(rec); // idempotent
+    const prior = rec.priorState;
+    if (prior !== null) {
+      rec.status = prior;
+    }
+    rec.statusSince = now;
+    rec.paused = false;
+    rec.pausedAt = null;
+    rec.pausedBy = null;
+    rec.priorState = null;
+    rec.version += 1;
+    return cloneSolution(rec);
+  }
+
+  async advanceAtomic(
+    input: SolutionAdvanceAtomicInput,
+  ): Promise<SolutionAdvanceAtomicResult> {
+    const rec = this.solutions.get(input.solutionId);
+    if (!rec) {
+      return { applied: false, newVersion: 0, historyId: null, idempotentReplay: false };
+    }
+
+    // Idempotency rule 1: payload-hash unique by (solution_id, to_state, payload_hash).
+    const dupByHash = this.history.find(
+      (h) =>
+        h.solutionId === input.solutionId &&
+        h.toState === input.toState &&
+        h.payloadHash === input.payloadHash,
+    );
+    if (dupByHash) {
+      return {
+        applied: false,
+        newVersion: rec.version,
+        historyId: dupByHash.id,
+        idempotentReplay: true,
+      };
+    }
+
+    // Idempotency rule 2: time-window dedupe for empty-payload click-storms.
+    if (input.idempotencyWindowMs > 0) {
+      const cutoff = Date.now() - input.idempotencyWindowMs;
+      const dupByWindow = this.history.find(
+        (h) =>
+          h.solutionId === input.solutionId &&
+          h.toState === input.toState &&
+          h.payloadHash === input.payloadHash &&
+          h.at.getTime() >= cutoff,
+      );
+      if (dupByWindow) {
+        return {
+          applied: false,
+          newVersion: rec.version,
+          historyId: dupByWindow.id,
+          idempotentReplay: true,
+        };
+      }
+    }
+
+    // Optimistic lock + status check.
+    if (rec.version !== input.expectedVersion) {
+      return { applied: false, newVersion: rec.version, historyId: null, idempotentReplay: false };
+    }
+    if (rec.status !== input.expectedStatus) {
+      return { applied: false, newVersion: rec.version, historyId: null, idempotentReplay: false };
+    }
+
+    // Apply.
+    const fromState = rec.status;
+    rec.status = input.toState;
+    const transitionAt = input.now;
+    rec.statusSince = transitionAt;
+    rec.currentPayload = input.payload;
+    rec.lastAttestation = input.attestation;
+    rec.version += 1;
+    if (input.toState === 'abandoned') {
+      rec.abandonedAt = transitionAt;
+    } else if (input.toState === 'done') {
+      rec.doneAt = transitionAt;
+    }
+
+    const id = this.historyNextId++;
+    const histRow: SolutionHistoryRow = {
+      id,
+      solutionId: input.solutionId,
+      fromState,
+      toState: input.toState,
+      reason: input.reason,
+      actorKind: input.actorKind as SolutionActorKind,
+      actorId: input.actorId,
+      attestation: input.attestation,
+      evidence: input.evidence,
+      payload: input.payload,
+      payloadHash: input.payloadHash,
+      at: transitionAt,
+    };
+    this.history.push(histRow);
+
+    this.fireNotify('caia_solution_' + input.solutionId, {
+      kind: 'solution-advanced',
+      history_id: id,
+      from_state: fromState,
+      to_state: input.toState,
+      reason: input.reason,
+      actor_kind: input.actorKind,
+      actor_id: input.actorId,
+      at: transitionAt.toISOString(),
+    });
+
+    return {
+      applied: true,
+      newVersion: rec.version,
+      historyId: id,
+      idempotentReplay: false,
+    };
+  }
+
+  async listHistory(
+    solutionId: string,
+    opts: { limit?: number; afterId?: number; toState?: SolutionState } = {},
+  ): Promise<SolutionHistoryRow[]> {
+    let rows = this.history.filter((h) => h.solutionId === solutionId);
+    if (opts.afterId !== undefined) {
+      const after = opts.afterId;
+      rows = rows.filter((h) => h.id > after);
+    }
+    if (opts.toState) {
+      const toState = opts.toState;
+      rows = rows.filter((h) => h.toState === toState);
+    }
+    rows = rows.slice().sort((a, b) => a.id - b.id);
+    if (opts.limit !== undefined) rows = rows.slice(0, opts.limit);
+    return rows.map(cloneHistory);
+  }
+
+  async listStuck(opts: ListStuckOpts): Promise<StuckSolution[]> {
+    const out: StuckSolution[] = [];
+    const nowMs = opts.now.getTime();
+    for (const rec of this.solutions.values()) {
+      if (rec.paused) continue;
+      if (isSolutionTerminal(rec.status)) continue;
+      const threshold = opts.thresholdsHours[rec.status];
+      if (threshold === undefined) continue;
+      const ageHours = (nowMs - rec.statusSince.getTime()) / 3_600_000;
+      if (ageHours >= threshold) {
+        out.push({
+          solution: cloneSolution(rec),
+          ageHoursInState: ageHours,
+          thresholdHours: threshold,
+          nextExpectedState: deriveNextExpected(rec.status),
+        });
+      }
+    }
+    return out.sort(
+      (a, b) =>
+        b.ageHoursInState - b.thresholdHours - (a.ageHoursInState - a.thresholdHours),
+    );
+  }
+
+  async subscribe(
+    channel: string,
+    handler: (payload: string) => void,
+  ): Promise<() => Promise<void>> {
+    let set = this.listeners.get(channel);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(channel, set);
+    }
+    set.add(handler);
+    return async () => {
+      const s = this.listeners.get(channel);
+      if (s) {
+        s.delete(handler);
+        if (s.size === 0) this.listeners.delete(channel);
+      }
+    };
+  }
+
+  private fireNotify(channel: string, event: Record<string, unknown>): void {
+    const set = this.listeners.get(channel);
+    if (!set) return;
+    const payload = JSON.stringify(event);
+    for (const h of [...set]) {
+      try {
+        h(payload);
+      } catch {
+        /* swallow listener errors */
+      }
+    }
+  }
+}
+
+function cloneSolution(rec: SolutionRow): SolutionRow {
+  return {
+    ...rec,
+    currentPayload: { ...rec.currentPayload },
+    lastAttestation: { ...rec.lastAttestation },
+  };
+}
+
+function cloneHistory(rec: SolutionHistoryRow): SolutionHistoryRow {
+  return {
+    ...rec,
+    payload: { ...rec.payload },
+    attestation: { ...rec.attestation },
+    evidence: { ...rec.evidence },
+  };
+}
+
+function defaultSolutionId(now: Date): string {
+  // canonical caia-YYYY-MM-DD-<random6> shape
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(now.getUTCDate()).padStart(2, '0');
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `caia-${yyyy}-${mm}-${dd}-${rand}`;
+}
+
+/** Compute the conductor's expected next forward state. Uses the first
+ * non-failure, non-rolled-back edge from the transition table — which by
+ * construction (see `solution-transitions.ts`) is the next forward
+ * state in `SOLUTION_FORWARD_STATES`. */
+function deriveNextExpected(current: SolutionState): SolutionState | null {
+  const edges = availableSolutionTransitions(current);
+  // First edge added by `buildTransitionTable` for forward states is the
+  // next forward state — preserve that contract via lookup.
+  const matrix = VALID_SOLUTION_TRANSITIONS[current];
+  if (matrix.length === 0) return null;
+  for (const candidate of edges) {
+    if (
+      candidate !== 'paused' &&
+      candidate !== 'abandoned' &&
+      !candidate.endsWith('-failed') &&
+      !candidate.endsWith('-rolled-back')
+    ) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/packages/state-machine/src/entities/pg-solution-store.ts
+++ b/packages/state-machine/src/entities/pg-solution-store.ts
@@ -1,0 +1,586 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { Client as PgClientCtor, Pool, PoolConfig } from 'pg';
+
+import { DuplicateSolutionIdError } from './solution-errors.js';
+import {
+  ALL_SOLUTION_STATES,
+  isSolutionState,
+  isSolutionTerminal,
+  SOLUTION_INITIAL_STATE,
+  type SolutionState,
+} from './solution-states.js';
+import {
+  availableSolutionTransitions,
+  VALID_SOLUTION_TRANSITIONS,
+} from './solution-transitions.js';
+import type {
+  SolutionAdvanceAtomicInput,
+  SolutionAdvanceAtomicResult,
+  SolutionStore,
+  ListStuckOpts,
+} from './solution-store.js';
+import type {
+  ApprovedPlanInput,
+  SolutionActorKind,
+  SolutionHistoryRow,
+  SolutionRow,
+  StuckSolution,
+} from './solution-types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function loadSolutionMigrationSql(): Promise<string> {
+  const candidates = [
+    join(__dirname, '..', '..', 'migrations', '0002_solution_lifecycle.sql'),
+    join(__dirname, '..', '..', '..', 'migrations', '0002_solution_lifecycle.sql'),
+    join(process.cwd(), 'migrations', '0002_solution_lifecycle.sql'),
+  ];
+  for (const path of candidates) {
+    try {
+      return await readFile(path, 'utf8');
+    } catch {
+      // try next
+    }
+  }
+  throw new Error(
+    'cannot locate 0002_solution_lifecycle.sql — checked: ' + candidates.join(', '),
+  );
+}
+
+export interface PgSolutionStoreOptions {
+  /** Schema for the meta tables. Defaults to caia_meta. */
+  schema?: string;
+  /** Skip the bundled migration on init() — caller manages it elsewhere. */
+  skipInit?: boolean;
+}
+
+/** Postgres-backed `SolutionStore`. Mirrors the project FSM's
+ * `PgStateStore` — same advisory-lock / optimistic-version protocol
+ * plus a LISTEN client for realtime. */
+export class PgSolutionStore implements SolutionStore {
+  private readonly pool: Pool;
+  private readonly schema: string;
+  private readonly skipInit: boolean;
+  private listenClient: InstanceType<typeof PgClientCtor> | null = null;
+  private listenHandlers = new Map<string, Set<(payload: string) => void>>();
+  private listenStarting: Promise<void> | null = null;
+
+  constructor(pool: Pool, opts: PgSolutionStoreOptions = {}) {
+    this.pool = pool;
+    this.schema = opts.schema ?? 'caia_meta';
+    this.skipInit = opts.skipInit ?? false;
+  }
+
+  async init(): Promise<void> {
+    if (this.skipInit) return;
+    const sql = await loadSolutionMigrationSql();
+    const final =
+      this.schema === 'caia_meta'
+        ? sql
+        : sql.replace(/caia_meta\./g, `${this.schema}.`);
+    await this.pool.query(final);
+  }
+
+  async reset(): Promise<void> {
+    await this.pool.query(`
+      TRUNCATE TABLE ${this.schema}.solution_history,
+                     ${this.schema}.solution_lifecycle
+        RESTART IDENTITY CASCADE
+    `);
+  }
+
+  async registerSolution(input: ApprovedPlanInput, now: Date): Promise<SolutionRow> {
+    const solutionId = input.solutionId ?? defaultSolutionId(now);
+    const initialState = input.initialState ?? SOLUTION_INITIAL_STATE;
+    const approvedAt = input.approvedAt ? new Date(input.approvedAt) : now;
+    try {
+      const r = await this.pool.query(
+        `INSERT INTO ${this.schema}.solution_lifecycle
+           (solution_id, title, plan_path, approved_by_adr, approved_at,
+            status, status_since, current_payload, manifest_pointer)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, '{}'::jsonb), $9)
+         RETURNING *`,
+        [
+          solutionId,
+          input.title,
+          input.planPath ?? null,
+          input.approvedByAdr ?? null,
+          approvedAt.toISOString(),
+          initialState,
+          now.toISOString(),
+          input.initialPayload ? JSON.stringify(input.initialPayload) : null,
+          input.manifestPointer ?? null,
+        ],
+      );
+      return rowToSolution(r.rows[0]);
+    } catch (err) {
+      if (isUniqueViolation(err)) {
+        throw new DuplicateSolutionIdError(solutionId);
+      }
+      throw err;
+    }
+  }
+
+  async getSolution(solutionId: string): Promise<SolutionRow | null> {
+    const r = await this.pool.query(
+      `SELECT * FROM ${this.schema}.solution_lifecycle WHERE solution_id = $1`,
+      [solutionId],
+    );
+    if (r.rows.length === 0) return null;
+    return rowToSolution(r.rows[0]);
+  }
+
+  async listActiveSolutions(): Promise<SolutionRow[]> {
+    const r = await this.pool.query(
+      `SELECT * FROM ${this.schema}.solution_lifecycle
+        WHERE abandoned_at IS NULL AND done_at IS NULL`,
+    );
+    return r.rows.map(rowToSolution);
+  }
+
+  async setPaused(
+    solutionId: string,
+    by: string,
+    now: Date,
+  ): Promise<SolutionRow | null> {
+    const r = await this.pool.query(
+      `UPDATE ${this.schema}.solution_lifecycle
+          SET paused = true,
+              paused_at = $2,
+              paused_by = $3,
+              prior_state = CASE WHEN paused THEN prior_state ELSE status END,
+              status = 'paused',
+              status_since = $2,
+              version = version + 1
+        WHERE solution_id = $1
+          AND done_at IS NULL
+          AND abandoned_at IS NULL
+        RETURNING *`,
+      [solutionId, now.toISOString(), by],
+    );
+    if (r.rows.length === 0) return null;
+    return rowToSolution(r.rows[0]);
+  }
+
+  async setResumed(solutionId: string, now: Date): Promise<SolutionRow | null> {
+    const r = await this.pool.query(
+      `UPDATE ${this.schema}.solution_lifecycle
+          SET paused = false,
+              paused_at = NULL,
+              paused_by = NULL,
+              status = COALESCE(prior_state, status),
+              status_since = $2,
+              prior_state = NULL,
+              version = version + 1
+        WHERE solution_id = $1
+          AND paused = true
+        RETURNING *`,
+      [solutionId, now.toISOString()],
+    );
+    if (r.rows.length === 0) return null;
+    return rowToSolution(r.rows[0]);
+  }
+
+  async advanceAtomic(
+    input: SolutionAdvanceAtomicInput,
+  ): Promise<SolutionAdvanceAtomicResult> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const lockKey = `solution:${input.solutionId}`;
+      const lockHash = hashToInt32(lockKey);
+      const lockRes = await client.query(
+        'SELECT pg_try_advisory_xact_lock($1) AS ok',
+        [lockHash],
+      );
+      if (!lockRes.rows[0]?.ok) {
+        await client.query('ROLLBACK');
+        return { applied: false, newVersion: 0, historyId: null, idempotentReplay: false };
+      }
+
+      const dup = await client.query(
+        `SELECT id FROM ${this.schema}.solution_history
+          WHERE solution_id = $1 AND to_state = $2 AND payload_hash = $3
+          LIMIT 1`,
+        [input.solutionId, input.toState, input.payloadHash],
+      );
+      if (dup.rowCount && dup.rowCount > 0) {
+        const cur = await client.query(
+          `SELECT version FROM ${this.schema}.solution_lifecycle WHERE solution_id = $1`,
+          [input.solutionId],
+        );
+        await client.query('COMMIT');
+        return {
+          applied: false,
+          newVersion: cur.rows[0]?.version ?? 0,
+          historyId: dup.rows[0].id,
+          idempotentReplay: true,
+        };
+      }
+
+      if (input.idempotencyWindowMs > 0) {
+        const winSec = input.idempotencyWindowMs / 1000;
+        const winDup = await client.query(
+          `SELECT id FROM ${this.schema}.solution_history
+            WHERE solution_id = $1
+              AND to_state = $2
+              AND payload_hash = $4
+              AND at > now() - ($3 || ' seconds')::interval
+            LIMIT 1`,
+          [input.solutionId, input.toState, String(winSec), input.payloadHash],
+        );
+        if (winDup.rowCount && winDup.rowCount > 0) {
+          const cur = await client.query(
+            `SELECT version FROM ${this.schema}.solution_lifecycle WHERE solution_id = $1`,
+            [input.solutionId],
+          );
+          await client.query('COMMIT');
+          return {
+            applied: false,
+            newVersion: cur.rows[0]?.version ?? 0,
+            historyId: winDup.rows[0].id,
+            idempotentReplay: true,
+          };
+        }
+      }
+
+      const upd = await client.query(
+        `UPDATE ${this.schema}.solution_lifecycle
+            SET status = $2,
+                status_since = $7::timestamptz,
+                current_payload = $3,
+                last_attestation = $4,
+                version = version + 1,
+                abandoned_at = CASE WHEN $2 = 'abandoned' THEN $7::timestamptz ELSE abandoned_at END,
+                done_at      = CASE WHEN $2 = 'done'      THEN $7::timestamptz ELSE done_at END
+          WHERE solution_id = $1
+            AND version = $5
+            AND status = $6
+          RETURNING version`,
+        [
+          input.solutionId,
+          input.toState,
+          JSON.stringify(input.payload),
+          JSON.stringify(input.attestation),
+          input.expectedVersion,
+          input.expectedStatus,
+          input.now.toISOString(),
+        ],
+      );
+
+      if (upd.rowCount === 0) {
+        await client.query('ROLLBACK');
+        return { applied: false, newVersion: 0, historyId: null, idempotentReplay: false };
+      }
+
+      const newVersion = upd.rows[0].version as number;
+
+      const ins = await client.query(
+        `INSERT INTO ${this.schema}.solution_history
+           (solution_id, from_state, to_state, reason, actor_kind, actor_id,
+            attestation, evidence, payload, payload_hash)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         ON CONFLICT (solution_id, to_state, payload_hash) DO NOTHING
+         RETURNING id`,
+        [
+          input.solutionId,
+          input.expectedStatus,
+          input.toState,
+          input.reason,
+          input.actorKind,
+          input.actorId,
+          JSON.stringify(input.attestation),
+          JSON.stringify(input.evidence),
+          JSON.stringify(input.payload),
+          input.payloadHash,
+        ],
+      );
+
+      await client.query('COMMIT');
+      return {
+        applied: true,
+        newVersion,
+        historyId: ins.rows[0]?.id ?? null,
+        idempotentReplay: false,
+      };
+    } catch (err) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        /* ignore */
+      }
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listHistory(
+    solutionId: string,
+    opts: { limit?: number; afterId?: number; toState?: SolutionState } = {},
+  ): Promise<SolutionHistoryRow[]> {
+    const conds: string[] = ['solution_id = $1'];
+    const params: unknown[] = [solutionId];
+    if (opts.afterId !== undefined) {
+      params.push(opts.afterId);
+      conds.push(`id > $${params.length}`);
+    }
+    if (opts.toState) {
+      params.push(opts.toState);
+      conds.push(`to_state = $${params.length}`);
+    }
+    let sql = `SELECT * FROM ${this.schema}.solution_history WHERE ${conds.join(' AND ')} ORDER BY id ASC`;
+    if (opts.limit !== undefined) {
+      params.push(opts.limit);
+      sql += ` LIMIT $${params.length}`;
+    }
+    const r = await this.pool.query(sql, params);
+    return r.rows.map(rowToHistory);
+  }
+
+  async listStuck(opts: ListStuckOpts): Promise<StuckSolution[]> {
+    // Build a one-shot SQL using the in-memory thresholds. We compute the
+    // age in SQL but compare against the per-state threshold via a CASE
+    // expression so the query stays a single round-trip.
+    const states = Object.keys(opts.thresholdsHours).filter((s) =>
+      isSolutionState(s),
+    ) as SolutionState[];
+    if (states.length === 0) return [];
+
+    // Defensive: only include non-terminal states (defaults already do this,
+    // but operator may override).
+    const validStates = states.filter((s) => !isSolutionTerminal(s));
+    if (validStates.length === 0) return [];
+
+    const cases = validStates
+      .map((s, i) => `WHEN status = $${i + 1} THEN ${Number(opts.thresholdsHours[s])}`)
+      .join('\n          ');
+    const params: unknown[] = [...validStates, opts.now.toISOString()];
+
+    const sql = `
+      WITH thresholds AS (
+        SELECT solution_id, status, status_since, paused, abandoned_at, done_at,
+               (
+                 CASE
+                   ${cases}
+                   ELSE NULL
+                 END
+               )::numeric AS threshold_hours,
+               EXTRACT(EPOCH FROM ($${params.length}::timestamptz - status_since)) / 3600.0 AS age_hours
+          FROM ${this.schema}.solution_lifecycle
+         WHERE paused = false
+           AND abandoned_at IS NULL
+           AND done_at IS NULL
+      )
+      SELECT sl.*
+        FROM ${this.schema}.solution_lifecycle sl
+        JOIN thresholds t USING (solution_id)
+       WHERE t.threshold_hours IS NOT NULL
+         AND t.age_hours >= t.threshold_hours
+       ORDER BY (t.age_hours - t.threshold_hours) DESC
+    `;
+    const r = await this.pool.query(sql, params);
+    const nowMs = opts.now.getTime();
+    return r.rows.map((row) => {
+      const solution = rowToSolution(row);
+      const threshold = opts.thresholdsHours[solution.status] ?? 0;
+      const ageHours = (nowMs - solution.statusSince.getTime()) / 3_600_000;
+      return {
+        solution,
+        ageHoursInState: ageHours,
+        thresholdHours: threshold,
+        nextExpectedState: deriveNextExpected(solution.status),
+      };
+    });
+  }
+
+  async subscribe(
+    channel: string,
+    handler: (payload: string) => void,
+  ): Promise<() => Promise<void>> {
+    let set = this.listenHandlers.get(channel);
+    if (!set) {
+      set = new Set();
+      this.listenHandlers.set(channel, set);
+    }
+    set.add(handler);
+    await this.ensureListening(channel);
+    return async () => {
+      const s = this.listenHandlers.get(channel);
+      if (s) {
+        s.delete(handler);
+        if (s.size === 0) {
+          this.listenHandlers.delete(channel);
+          if (this.listenClient) {
+            try {
+              await this.listenClient.query(`UNLISTEN ${escapeIdent(channel)}`);
+            } catch {
+              /* ignore */
+            }
+          }
+        }
+      }
+    };
+  }
+
+  async closeListenClient(): Promise<void> {
+    const client = this.listenClient;
+    if (!client) return;
+    this.listenClient = null;
+    try {
+      await client.end();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private async ensureListening(channel: string): Promise<void> {
+    if (this.listenStarting) {
+      await this.listenStarting;
+    }
+    if (!this.listenClient) {
+      this.listenStarting = this.startListenClient();
+      await this.listenStarting;
+      this.listenStarting = null;
+    }
+    if (!this.listenClient) throw new Error('solution listen client failed to start');
+    await this.listenClient.query(`LISTEN ${escapeIdent(channel)}`);
+  }
+
+  private async startListenClient(): Promise<void> {
+    const poolOpts = ((this.pool as unknown as { options?: PoolConfig }).options ?? {}) as PoolConfig;
+    const { Client: PgClient } = await import('pg');
+    const client = new PgClient(poolOpts);
+    client.on('notification', (msg: import('pg').Notification) => {
+      const ch = msg.channel;
+      const set = this.listenHandlers.get(ch);
+      if (!set) return;
+      for (const h of [...set]) {
+        try {
+          h(msg.payload ?? '');
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+    client.on('error', () => {
+      this.listenClient = null;
+    });
+    await client.connect();
+    this.listenClient = client;
+  }
+}
+
+function rowToSolution(row: Record<string, unknown>): SolutionRow {
+  const status = String(row.status);
+  if (!isSolutionState(status)) {
+    throw new Error(`bad solution status from db: ${status}`);
+  }
+  const prior = row.prior_state == null ? null : String(row.prior_state);
+  if (prior !== null && !isSolutionState(prior)) {
+    throw new Error(`bad solution prior_state from db: ${prior}`);
+  }
+  return {
+    id: String(row.id),
+    solutionId: String(row.solution_id),
+    title: String(row.title),
+    planPath: row.plan_path == null ? null : String(row.plan_path),
+    approvedByAdr: row.approved_by_adr == null ? null : String(row.approved_by_adr),
+    approvedAt: toDate(row.approved_at),
+    status,
+    statusSince: toDate(row.status_since),
+    paused: Boolean(row.paused),
+    pausedAt: row.paused_at == null ? null : toDate(row.paused_at),
+    pausedBy: row.paused_by == null ? null : String(row.paused_by),
+    priorState: prior as SolutionState | null,
+    currentPayload: (row.current_payload as Record<string, unknown>) ?? {},
+    lastAttestation: (row.last_attestation as Record<string, unknown>) ?? {},
+    manifestPointer: row.manifest_pointer == null ? null : String(row.manifest_pointer),
+    abandonedAt: row.abandoned_at == null ? null : toDate(row.abandoned_at),
+    doneAt: row.done_at == null ? null : toDate(row.done_at),
+    version: Number(row.version),
+    createdAt: toDate(row.created_at),
+  };
+}
+
+function rowToHistory(row: Record<string, unknown>): SolutionHistoryRow {
+  const toState = String(row.to_state);
+  if (!isSolutionState(toState)) throw new Error(`bad to_state from db: ${toState}`);
+  const fromStateRaw = row.from_state == null ? null : String(row.from_state);
+  if (fromStateRaw !== null && !isSolutionState(fromStateRaw)) {
+    throw new Error(`bad from_state from db: ${fromStateRaw}`);
+  }
+  const actorKind = String(row.actor_kind);
+  if (
+    actorKind !== 'system' &&
+    actorKind !== 'operator' &&
+    actorKind !== 'agent' &&
+    actorKind !== 'steward'
+  ) {
+    throw new Error(`bad actor_kind from db: ${actorKind}`);
+  }
+  return {
+    id: Number(row.id),
+    solutionId: String(row.solution_id),
+    fromState: fromStateRaw as SolutionState | null,
+    toState,
+    reason: String(row.reason),
+    actorKind: actorKind as SolutionActorKind,
+    actorId: String(row.actor_id),
+    attestation: (row.attestation as Record<string, unknown>) ?? {},
+    evidence: (row.evidence as Record<string, unknown>) ?? {},
+    payload: (row.payload as Record<string, unknown>) ?? {},
+    payloadHash: String(row.payload_hash),
+    at: toDate(row.at),
+  };
+}
+
+function toDate(v: unknown): Date {
+  if (v instanceof Date) return v;
+  return new Date(String(v));
+}
+
+function escapeIdent(name: string): string {
+  return '"' + name.replace(/"/g, '""') + '"';
+}
+
+function hashToInt32(s: string): number {
+  const h = createHash('sha256').update(s).digest();
+  return h.readInt32BE(0);
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  if (err === null || typeof err !== 'object') return false;
+  const e = err as { code?: unknown };
+  return typeof e.code === 'string' && e.code === '23505';
+}
+
+function defaultSolutionId(now: Date): string {
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(now.getUTCDate()).padStart(2, '0');
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `caia-${yyyy}-${mm}-${dd}-${rand}`;
+}
+
+function deriveNextExpected(current: SolutionState): SolutionState | null {
+  const edges = availableSolutionTransitions(current);
+  // unused vars elimination via reference (silences future lints if we add them)
+  void ALL_SOLUTION_STATES;
+  void VALID_SOLUTION_TRANSITIONS;
+  for (const candidate of edges) {
+    if (
+      candidate !== 'paused' &&
+      candidate !== 'abandoned' &&
+      !candidate.endsWith('-failed') &&
+      !candidate.endsWith('-rolled-back')
+    ) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/packages/state-machine/src/entities/solution-errors.ts
+++ b/packages/state-machine/src/entities/solution-errors.ts
@@ -1,0 +1,70 @@
+import type { SolutionState } from './solution-states.js';
+
+export class InvalidSolutionTransitionError extends Error {
+  readonly code = 'INVALID_SOLUTION_TRANSITION';
+  readonly fromState: SolutionState;
+  readonly toState: SolutionState;
+  readonly causeReason: string;
+
+  constructor(
+    fromState: SolutionState,
+    toState: SolutionState,
+    cause: string,
+  ) {
+    super(
+      `invalid solution transition: ${fromState} -> ${toState} (${cause})`,
+    );
+    this.name = 'InvalidSolutionTransitionError';
+    this.fromState = fromState;
+    this.toState = toState;
+    this.causeReason = cause;
+  }
+}
+
+export class SolutionNotFoundError extends Error {
+  readonly code = 'SOLUTION_NOT_FOUND';
+  readonly solutionId: string;
+  constructor(solutionId: string) {
+    super(`solution not found: ${solutionId}`);
+    this.name = 'SolutionNotFoundError';
+    this.solutionId = solutionId;
+  }
+}
+
+export class StaleSolutionVersionError extends Error {
+  readonly code = 'STALE_SOLUTION_VERSION';
+  readonly solutionId: string;
+  readonly expectedVersion: number;
+  constructor(solutionId: string, expectedVersion: number) {
+    super(
+      `stale solution version for ${solutionId}: caller expected ${expectedVersion}`,
+    );
+    this.name = 'StaleSolutionVersionError';
+    this.solutionId = solutionId;
+    this.expectedVersion = expectedVersion;
+  }
+}
+
+export class SolutionTransitionRetryExhaustedError extends Error {
+  readonly code = 'SOLUTION_TRANSITION_RETRY_EXHAUSTED';
+  readonly solutionId: string;
+  readonly attempts: number;
+  constructor(solutionId: string, attempts: number) {
+    super(
+      `solution transition for ${solutionId} retry budget exhausted after ${attempts} attempts`,
+    );
+    this.name = 'SolutionTransitionRetryExhaustedError';
+    this.solutionId = solutionId;
+    this.attempts = attempts;
+  }
+}
+
+export class DuplicateSolutionIdError extends Error {
+  readonly code = 'DUPLICATE_SOLUTION_ID';
+  readonly solutionId: string;
+  constructor(solutionId: string) {
+    super(`solution already registered: ${solutionId}`);
+    this.name = 'DuplicateSolutionIdError';
+    this.solutionId = solutionId;
+  }
+}

--- a/packages/state-machine/src/entities/solution-states.ts
+++ b/packages/state-machine/src/entities/solution-states.ts
@@ -1,0 +1,238 @@
+/**
+ * Solution-lifecycle states for the Real Definition-of-Done state machine.
+ *
+ * Sourced from:
+ *   - operator prompt (state-machine-solution-lifecycle 2026-05-24)
+ *   - `agent-memory/feedback_real_definition_of_done.md` (the canonical
+ *     vocabulary that the operator typed)
+ *   - `research/real_definition_of_done_enforcement_2026.md` §6.1 (the
+ *     longer-form canonical lifecycle; we use the operator vocabulary on
+ *     the wire but document the canonical synonyms here so cross-package
+ *     readers can join the two).
+ *
+ * Operator vocabulary  ↔ canonical-doc vocabulary
+ * ────────────────────────────────────────────────────────────────
+ * approved             ↔ plan-approved
+ * implemented          ↔ code-written
+ * merged               ↔ pr-merged          (pr-opened is folded in,
+ *                                            since the existing project
+ *                                            FSM tracks PR-opened already)
+ * deployed             ↔ deployed
+ * imported             ↔ built-into-active-app + imported (collapsed)
+ * called-in-test       ↔ called-in-test
+ * called-in-prod       ↔ called-in-prod
+ * producing-metrics    ↔ producing-metrics  (terminal-success in the
+ *                                            canonical doc; here it is
+ *                                            a holdover state — see
+ *                                            `done` below)
+ * done                 ↔ producing-metrics held for ≥24h consecutive
+ *                       (per canonical §6.3)
+ *
+ * Failure-side vocabulary follows the existing `@caia/state-machine`
+ * `*-failed` pattern (every "doing" state has a `*-failed` variant) plus
+ * `*-rolled-back` for post-deployment regressions. This matches the
+ * operator prompt exactly. The canonical doc's `degraded` ≈ currently
+ * in a `*-rolled-back` state; `abandoned` is preserved verbatim;
+ * `sunset` is operator-driven and reuses `abandoned` with a documented
+ * `reason: 'sunset'`.
+ */
+
+/** Forward path (9 states). DONE is reached only when the lifecycle has
+ * spent ≥24 consecutive hours in `producing-metrics` (per canonical §6.3). */
+export const SOLUTION_FORWARD_STATES = [
+  'approved',
+  'implemented',
+  'merged',
+  'deployed',
+  'imported',
+  'called-in-test',
+  'called-in-prod',
+  'producing-metrics',
+  'done',
+] as const;
+
+/** Failure variants — one per non-initial forward state.
+ *
+ * `<state>-failed` means the *transition into* `<state>` was attempted
+ * and failed, OR `<state>` was reached and its attestation later went
+ * red within the per-state freshness window. Recovery: re-attempt by
+ * advancing to the corresponding forward state, OR abandon.
+ */
+export const SOLUTION_FAILED_STATES = [
+  'implemented-failed',
+  'merged-failed',
+  'deployed-failed',
+  'imported-failed',
+  'called-in-test-failed',
+  'called-in-prod-failed',
+  'producing-metrics-failed',
+] as const;
+
+/** Post-deployment regression variants. Reached when a previously-green
+ * post-deploy attestation goes red (drift). Recovery: re-enter the
+ * forward state once the steward re-greens it, OR abandon. */
+export const SOLUTION_ROLLED_BACK_STATES = [
+  'deployed-rolled-back',
+  'imported-rolled-back',
+  'called-in-test-rolled-back',
+  'called-in-prod-rolled-back',
+  'producing-metrics-rolled-back',
+] as const;
+
+/** Control / terminal states. */
+export const SOLUTION_CONTROL_STATES = [
+  /** Orthogonal: reachable from any non-terminal state. `resumeSolution`
+   * restores `prior_state`. */
+  'paused',
+  /** Terminal-failure. Operator-driven. */
+  'abandoned',
+] as const;
+
+export const ALL_SOLUTION_STATES = [
+  ...SOLUTION_FORWARD_STATES,
+  ...SOLUTION_FAILED_STATES,
+  ...SOLUTION_ROLLED_BACK_STATES,
+  ...SOLUTION_CONTROL_STATES,
+] as const;
+
+export type SolutionForwardState = (typeof SOLUTION_FORWARD_STATES)[number];
+export type SolutionFailedState = (typeof SOLUTION_FAILED_STATES)[number];
+export type SolutionRolledBackState = (typeof SOLUTION_ROLLED_BACK_STATES)[number];
+export type SolutionControlState = (typeof SOLUTION_CONTROL_STATES)[number];
+export type SolutionState =
+  | SolutionForwardState
+  | SolutionFailedState
+  | SolutionRolledBackState
+  | SolutionControlState;
+
+const FORWARD_SET = new Set<string>(SOLUTION_FORWARD_STATES);
+const FAILED_SET = new Set<string>(SOLUTION_FAILED_STATES);
+const ROLLED_BACK_SET = new Set<string>(SOLUTION_ROLLED_BACK_STATES);
+const CONTROL_SET = new Set<string>(SOLUTION_CONTROL_STATES);
+const ALL_SET = new Set<string>(ALL_SOLUTION_STATES);
+
+export function isSolutionState(value: unknown): value is SolutionState {
+  return typeof value === 'string' && ALL_SET.has(value);
+}
+
+export function isSolutionForwardState(
+  state: SolutionState,
+): state is SolutionForwardState {
+  return FORWARD_SET.has(state);
+}
+
+export function isSolutionFailedState(
+  state: SolutionState,
+): state is SolutionFailedState {
+  return FAILED_SET.has(state);
+}
+
+export function isSolutionRolledBackState(
+  state: SolutionState,
+): state is SolutionRolledBackState {
+  return ROLLED_BACK_SET.has(state);
+}
+
+export function isSolutionControlState(
+  state: SolutionState,
+): state is SolutionControlState {
+  return CONTROL_SET.has(state);
+}
+
+/** Terminal states have no outbound transitions.
+ *
+ * - `done` is the happy terminal (Definition-of-Done achieved).
+ * - `abandoned` is the operator-abandoned / sunset terminal. */
+export const SOLUTION_TERMINAL_STATES: readonly SolutionState[] = [
+  'done',
+  'abandoned',
+] as const;
+
+export function isSolutionTerminal(state: SolutionState): boolean {
+  return SOLUTION_TERMINAL_STATES.includes(state);
+}
+
+/** The state a fresh registerSolution() lands in. */
+export const SOLUTION_INITIAL_STATE: SolutionState = 'approved';
+
+/** Map each forward state (except `approved`) to its `<state>-failed`
+ * sibling. Used for symmetric transition-table generation. */
+export const FAILED_OF: Readonly<
+  Partial<Record<SolutionForwardState, SolutionFailedState>>
+> = {
+  implemented: 'implemented-failed',
+  merged: 'merged-failed',
+  deployed: 'deployed-failed',
+  imported: 'imported-failed',
+  'called-in-test': 'called-in-test-failed',
+  'called-in-prod': 'called-in-prod-failed',
+  'producing-metrics': 'producing-metrics-failed',
+};
+
+/** Map each post-deployment forward state to its `<state>-rolled-back`
+ * sibling. */
+export const ROLLED_BACK_OF: Readonly<
+  Partial<Record<SolutionForwardState, SolutionRolledBackState>>
+> = {
+  deployed: 'deployed-rolled-back',
+  imported: 'imported-rolled-back',
+  'called-in-test': 'called-in-test-rolled-back',
+  'called-in-prod': 'called-in-prod-rolled-back',
+  'producing-metrics': 'producing-metrics-rolled-back',
+};
+
+/** Map each `*-failed` back to the forward state it failed to reach. */
+export const FORWARD_OF_FAILED: Readonly<Record<SolutionFailedState, SolutionForwardState>> = {
+  'implemented-failed': 'implemented',
+  'merged-failed': 'merged',
+  'deployed-failed': 'deployed',
+  'imported-failed': 'imported',
+  'called-in-test-failed': 'called-in-test',
+  'called-in-prod-failed': 'called-in-prod',
+  'producing-metrics-failed': 'producing-metrics',
+};
+
+/** Map each `*-rolled-back` back to the forward state it regressed from. */
+export const FORWARD_OF_ROLLED_BACK: Readonly<
+  Record<SolutionRolledBackState, SolutionForwardState>
+> = {
+  'deployed-rolled-back': 'deployed',
+  'imported-rolled-back': 'imported',
+  'called-in-test-rolled-back': 'called-in-test',
+  'called-in-prod-rolled-back': 'called-in-prod',
+  'producing-metrics-rolled-back': 'producing-metrics',
+};
+
+/** Canonical-doc synonyms exposed as a constant so cross-package readers
+ * (e.g. `@chiefaia/events-taxonomy-internal`) can register both
+ * vocabularies in the event registry. */
+export const SOLUTION_STATE_CANONICAL_SYNONYM: Readonly<
+  Partial<Record<SolutionState, string>>
+> = {
+  approved: 'plan-approved',
+  implemented: 'code-written',
+  merged: 'pr-merged',
+  imported: 'built-into-active-app',
+};
+
+/** Default per-state thresholds (in hours) for the "stuck" heuristic.
+ *
+ * Numbers come from `real_definition_of_done_enforcement_2026.md` §5
+ * (the per-solution manifest's `verifier_freshness_thresholds`) and
+ * §6.3 (the 24h holdover in `producing-metrics` before DONE).
+ *
+ * The threshold is interpreted as "if the solution has been in this
+ * state for longer than N hours, it is stuck and a `solution.stuck`
+ * event should be emitted". Terminal states are not stuck-able. */
+export const DEFAULT_STUCK_THRESHOLDS_HOURS: Readonly<
+  Partial<Record<SolutionState, number>>
+> = {
+  approved: 24, // EA-approved but no code yet — should start within a day
+  implemented: 24, // code written but not yet PR-merged
+  merged: 2, // canonical: deploy_steward_max_age_hours = 2
+  deployed: 4, // canonical: usage_steward_max_age_hours = 4
+  imported: 6, // canonical: activation_steward_max_age_hours = 6 (test phase)
+  'called-in-test': 24, // generous: prod activation may take a release cycle
+  'called-in-prod': 24, // canonical: outcome_steward_max_age_hours = 24
+  'producing-metrics': 24, // canonical §6.3: ≥24h before DONE
+};

--- a/packages/state-machine/src/entities/solution-store.ts
+++ b/packages/state-machine/src/entities/solution-store.ts
@@ -1,0 +1,96 @@
+/**
+ * `SolutionStore` is the backend-agnostic storage contract for the
+ * Solution lifecycle FSM. Two implementations ship in this package:
+ *
+ *   - `InMemorySolutionStore` — fast, deterministic, used in tests.
+ *   - `PgSolutionStore` — wraps a `pg.Pool` against `caia_meta.solution_lifecycle`.
+ *
+ * Same atomicity contract as the project FSM's `StateStore`: a single
+ * `advanceAtomic()` call MUST read current state + apply transition +
+ * write history in one durable step. Per-solution advisory locks +
+ * optimistic-`version` checks guard against the multi-steward race.
+ */
+
+import type { SolutionState } from './solution-states.js';
+import type {
+  ApprovedPlanInput,
+  SolutionActorKind,
+  SolutionHistoryRow,
+  SolutionRow,
+  StuckSolution,
+} from './solution-types.js';
+
+export interface SolutionAdvanceAtomicInput {
+  solutionId: string;
+  expectedVersion: number;
+  expectedStatus: SolutionState;
+  toState: SolutionState;
+  reason: string;
+  actorKind: SolutionActorKind;
+  actorId: string;
+  agentRunId: string | null;
+  attestation: Record<string, unknown>;
+  evidence: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  payloadHash: string;
+  idempotencyWindowMs: number;
+  /** Clock for the transition timestamp — passed by the machine so mocked clocks in tests match the snapshot ageHoursInState math. */
+  now: Date;
+}
+
+export interface SolutionAdvanceAtomicResult {
+  applied: boolean;
+  newVersion: number;
+  historyId: number | null;
+  /** True iff the call collided with an existing history row by hash
+   * (the canonical "idempotent replay" success-shape). */
+  idempotentReplay: boolean;
+}
+
+export interface ListStuckOpts {
+  /** Per-state thresholds in hours. Required (the machine passes the
+   * resolved-after-defaults map). */
+  thresholdsHours: Partial<Record<SolutionState, number>>;
+  /** Clock — caller passes a Date so the store does not need its own. */
+  now: Date;
+}
+
+export interface SolutionStore {
+  /** Apply migrations (idempotent). */
+  init(): Promise<void>;
+
+  /** Test/admin helper — wipes all state. */
+  reset?(): Promise<void>;
+
+  /** Insert the solution row. Throws DuplicateSolutionIdError on
+   * UNIQUE(solution_id) collision. */
+  registerSolution(input: ApprovedPlanInput, now: Date): Promise<SolutionRow>;
+
+  getSolution(solutionId: string): Promise<SolutionRow | null>;
+
+  listActiveSolutions(): Promise<SolutionRow[]>;
+
+  /** Sets paused=true and preserves `prior_state`. */
+  setPaused(solutionId: string, by: string, now: Date): Promise<SolutionRow | null>;
+
+  /** Sets paused=false, returns the saved `prior_state` (caller advances
+   * back via advanceAtomic). */
+  setResumed(solutionId: string, now: Date): Promise<SolutionRow | null>;
+
+  advanceAtomic(input: SolutionAdvanceAtomicInput): Promise<SolutionAdvanceAtomicResult>;
+
+  listHistory(
+    solutionId: string,
+    opts?: { limit?: number; afterId?: number; toState?: SolutionState },
+  ): Promise<SolutionHistoryRow[]>;
+
+  /** Solutions whose `statusSince` is older than the per-state threshold.
+   * Terminal solutions and paused solutions are excluded. */
+  listStuck(opts: ListStuckOpts): Promise<StuckSolution[]>;
+
+  /** Realtime LISTEN/NOTIFY subscription on a per-solution channel. */
+  subscribe(
+    channel: string,
+    handler: (payload: string) => void,
+  ): Promise<() => Promise<void>>;
+}

--- a/packages/state-machine/src/entities/solution-test-support.ts
+++ b/packages/state-machine/src/entities/solution-test-support.ts
@@ -1,0 +1,42 @@
+import { InMemorySolutionStore } from './in-memory-solution-store.js';
+import { SolutionLifecycleMachine } from './solution.js';
+import {
+  SOLUTION_FORWARD_STATES,
+  type SolutionState,
+} from './solution-states.js';
+import type { SolutionMachineOptions } from './solution-types.js';
+
+/** Build a fresh in-memory SolutionLifecycleMachine for tests. */
+export function buildInMemorySolutionMachine(opts: SolutionMachineOptions = {}): {
+  machine: SolutionLifecycleMachine;
+  store: InMemorySolutionStore;
+} {
+  const store = new InMemorySolutionStore();
+  const machine = new SolutionLifecycleMachine(store, opts);
+  return { machine, store };
+}
+
+/** Canonical happy-path walk through every forward state.
+ * `approved` is the initial state, so the walk starts at the first
+ * transition. */
+export const SOLUTION_HAPPY_PATH: ReadonlyArray<[SolutionState, SolutionState]> = (() => {
+  const out: [SolutionState, SolutionState][] = [];
+  for (let i = 0; i < SOLUTION_FORWARD_STATES.length - 1; i++) {
+    const from = SOLUTION_FORWARD_STATES[i];
+    const to = SOLUTION_FORWARD_STATES[i + 1];
+    if (from !== undefined && to !== undefined) {
+      out.push([from, to]);
+    }
+  }
+  return out;
+})();
+
+/** Convenience: a fake steward-id -> the canonical green attestation shape. */
+export function fakeAttestation(steward: string, idSuffix: string) {
+  return {
+    steward,
+    id: `${steward.slice(0, 2)}-${idSuffix}`,
+    status: 'green' as const,
+    at: new Date().toISOString(),
+  };
+}

--- a/packages/state-machine/src/entities/solution-transitions.ts
+++ b/packages/state-machine/src/entities/solution-transitions.ts
@@ -1,0 +1,173 @@
+/**
+ * Solution-lifecycle valid transitions.
+ *
+ * The transition table is derived programmatically from the state lists
+ * in `./solution-states.ts` so that adding/removing a state automatically
+ * extends/contracts the matrix in lock-step. The shape mirrors the
+ * existing project FSM's `transitions.ts`:
+ *
+ *   from -> readonly [to1, to2, ...]
+ *
+ * Rules (encoded below):
+ *   1. Forward path: each forward state F_i -> F_{i+1} ∪ {F_i-failed?, F_i-rolled-back?, paused, abandoned}
+ *      Initial state `approved` has no `*-failed` (you can't fail to approve), but it
+ *      does have `implemented-failed` as a reachable next state (the implementation
+ *      attempt failed before reaching `implemented`).
+ *   2. `*-failed` -> {forward-state-they-failed-to-reach, abandoned}
+ *      A failed solution can be retried by re-attempting the same forward state.
+ *   3. `*-rolled-back` -> {forward-state-they-regressed-from, abandoned}
+ *      A rolled-back solution can re-green and re-enter the forward state.
+ *   4. `paused` -> any non-`paused`, non-`done`, non-`abandoned` state
+ *      (resume restores prior_state via the API; the matrix is permissive to allow
+ *      operator-fork patterns).
+ *   5. `done`, `abandoned` -> ∅ (terminal).
+ */
+
+import {
+  ALL_SOLUTION_STATES,
+  FAILED_OF,
+  FORWARD_OF_FAILED,
+  FORWARD_OF_ROLLED_BACK,
+  ROLLED_BACK_OF,
+  SOLUTION_FORWARD_STATES,
+  isSolutionTerminal,
+  type SolutionState,
+} from './solution-states.js';
+
+/** Build the raw transition table from the state declarations. */
+function buildTransitionTable(): Readonly<Record<SolutionState, readonly SolutionState[]>> {
+  const table: Record<SolutionState, SolutionState[]> = {} as Record<
+    SolutionState,
+    SolutionState[]
+  >;
+  // Initialise every state with an empty list.
+  for (const state of ALL_SOLUTION_STATES) {
+    table[state] = [];
+  }
+
+  // -- Forward transitions ------------------------------------------------
+  for (let i = 0; i < SOLUTION_FORWARD_STATES.length; i++) {
+    const from = SOLUTION_FORWARD_STATES[i] as SolutionState;
+    if (isSolutionTerminal(from)) continue; // skip `done`
+    const next = SOLUTION_FORWARD_STATES[i + 1];
+    if (next !== undefined) table[from].push(next);
+
+    // The "tried to advance and failed" edge: from F_i, you can land in
+    // the next state's `*-failed` variant (the transition attempt itself
+    // failed). E.g. approved -> implemented-failed (couldn't write code).
+    if (next !== undefined && next !== 'done') {
+      const failedNext = FAILED_OF[next as keyof typeof FAILED_OF];
+      if (failedNext !== undefined) table[from].push(failedNext);
+    }
+
+    // The "currently in this state and a re-attestation went red" edge:
+    // from F_i, you can also land in F_i's own `*-rolled-back` (drift).
+    const rolledBack = ROLLED_BACK_OF[from as keyof typeof ROLLED_BACK_OF];
+    if (rolledBack !== undefined) table[from].push(rolledBack);
+
+    // Control + abandon are reachable from every forward non-terminal.
+    table[from].push('paused', 'abandoned');
+  }
+
+  // -- `*-failed` -> recovery target or abandon --------------------------
+  for (const failed of Object.keys(FORWARD_OF_FAILED) as Array<
+    keyof typeof FORWARD_OF_FAILED
+  >) {
+    const forward = FORWARD_OF_FAILED[failed];
+    table[failed].push(forward, 'paused', 'abandoned');
+  }
+
+  // -- `*-rolled-back` -> re-enter forward or abandon --------------------
+  for (const rb of Object.keys(FORWARD_OF_ROLLED_BACK) as Array<
+    keyof typeof FORWARD_OF_ROLLED_BACK
+  >) {
+    const forward = FORWARD_OF_ROLLED_BACK[rb];
+    table[rb].push(forward, 'paused', 'abandoned');
+  }
+
+  // -- paused -> any non-paused, non-terminal -----------------------------
+  // (resume restores prior_state via the API, but the matrix is permissive
+  //  so operator-driven fork patterns are allowed.)
+  for (const state of ALL_SOLUTION_STATES) {
+    if (state === 'paused') continue;
+    if (isSolutionTerminal(state)) continue;
+    table.paused.push(state);
+  }
+  // Plus 'abandoned' itself is allowed from paused (operator can abandon
+  // a paused solution outright).
+  table.paused.push('abandoned');
+
+  // Terminal: empty.
+  // table.done and table.abandoned remain [].
+
+  // Freeze.
+  const frozen: Record<SolutionState, readonly SolutionState[]> = {} as Record<
+    SolutionState,
+    readonly SolutionState[]
+  >;
+  for (const key of Object.keys(table) as SolutionState[]) {
+    frozen[key] = Object.freeze([...table[key]]);
+  }
+  return Object.freeze(frozen);
+}
+
+export const VALID_SOLUTION_TRANSITIONS: Readonly<
+  Record<SolutionState, readonly SolutionState[]>
+> = buildTransitionTable();
+
+export interface SolutionTransitionCheck {
+  ok: boolean;
+  reason?: string;
+}
+
+export function canSolutionTransition(
+  from: SolutionState,
+  to: SolutionState,
+): boolean {
+  if (from === to) return false;
+  if (isSolutionTerminal(from)) return false;
+  return VALID_SOLUTION_TRANSITIONS[from].includes(to);
+}
+
+export function checkSolutionTransition(
+  from: SolutionState,
+  to: SolutionState,
+): SolutionTransitionCheck {
+  if (from === to) {
+    return { ok: false, reason: 'self-transition is a no-op' };
+  }
+  if (isSolutionTerminal(from)) {
+    return { ok: false, reason: `${from} is a terminal state` };
+  }
+  const allowed = VALID_SOLUTION_TRANSITIONS[from];
+  if (!allowed.includes(to)) {
+    return {
+      ok: false,
+      reason: `${from} -> ${to} is not in the solution-lifecycle transition table`,
+    };
+  }
+  return { ok: true };
+}
+
+export function availableSolutionTransitions(
+  from: SolutionState,
+): readonly SolutionState[] {
+  return VALID_SOLUTION_TRANSITIONS[from];
+}
+
+export function validNextSolutionStates(
+  from: SolutionState,
+): readonly SolutionState[] {
+  return VALID_SOLUTION_TRANSITIONS[from];
+}
+
+/** Every (from,to) edge in the FSM. Used by tests + static analysis. */
+export function allSolutionEdges(): { from: SolutionState; to: SolutionState }[] {
+  const out: { from: SolutionState; to: SolutionState }[] = [];
+  for (const from of ALL_SOLUTION_STATES) {
+    for (const to of VALID_SOLUTION_TRANSITIONS[from]) {
+      out.push({ from, to });
+    }
+  }
+  return out;
+}

--- a/packages/state-machine/src/entities/solution-types.ts
+++ b/packages/state-machine/src/entities/solution-types.ts
@@ -1,0 +1,192 @@
+import type { ActorKind } from '../types.js';
+import type { SolutionState } from './solution-states.js';
+
+/** Distinguishes who/what advanced the solution.
+ *
+ * `steward` is added beyond the project FSM's `system|operator|agent`
+ * because Solutions are predominantly driven by the four stewards
+ * (deploy / usage / activation / outcome) and the lifecycle-conductor.
+ * Keeping `steward` as its own kind makes audit + dashboards readable. */
+export type SolutionActorKind = ActorKind | 'steward';
+
+export interface SolutionTriggeredBy {
+  kind: SolutionActorKind;
+  /** Steward id (e.g. 'deploy-steward'), agent id, or operator user id. */
+  id: string;
+  /** Optional pointer to an agent_runs / steward_runs row. */
+  agentRunId?: string;
+}
+
+/** Per-steward attestation envelope. Shape matches the canonical doc's
+ * §A.8 event envelope (per-steward attestation block). */
+export interface StewardAttestation {
+  /** Steward id, e.g. 'deploy-steward'. */
+  steward: string;
+  /** Stable id for THIS attestation run (e.g. 'ds-1f0c'). */
+  id: string;
+  /** Status — typically 'green' on a forward transition. */
+  status: 'green' | 'amber' | 'red';
+  /** ISO timestamp the attestation was produced. */
+  at: string;
+  /** Optional metric, span count, etc. */
+  evidence?: Record<string, unknown>;
+}
+
+/** Input to `registerSolution`. */
+export interface ApprovedPlanInput {
+  /** Canonical id, format `caia-YYYY-MM-DD-short-slug`. If omitted, a
+   * UUID is generated and the caller is expected to record the mapping
+   * separately. */
+  solutionId?: string;
+  /** Human-readable title. */
+  title: string;
+  /** Path to the approving plan markdown (e.g. research/foo.md). */
+  planPath?: string;
+  /** ADR id that captured the approval (e.g. 'ADR-068'). */
+  approvedByAdr?: string;
+  /** Pointer into the per-solution manifest yaml. */
+  manifestPointer?: string;
+  /** Free-form payload persisted on the solution row. */
+  initialPayload?: Record<string, unknown>;
+  /** Override the initial state. Defaults to 'approved'. Mostly for tests. */
+  initialState?: SolutionState;
+  /** ISO timestamp; defaults to now(). */
+  approvedAt?: string;
+}
+
+export interface RegisteredSolution {
+  solutionId: string;
+  currentState: SolutionState;
+  version: number;
+  createdAt: Date;
+}
+
+export interface SolutionRow {
+  /** UUID PK (separate from solution_id which is the human/cross-system join key). */
+  id: string;
+  /** Canonical caia-YYYY-MM-DD-slug. */
+  solutionId: string;
+  title: string;
+  planPath: string | null;
+  approvedByAdr: string | null;
+  approvedAt: Date;
+  status: SolutionState;
+  /** When the current `status` was entered. Used by `getStuckSolutions`. */
+  statusSince: Date;
+  paused: boolean;
+  pausedAt: Date | null;
+  pausedBy: string | null;
+  /** Saved on pause so `resumeSolution` can restore. */
+  priorState: SolutionState | null;
+  currentPayload: Record<string, unknown>;
+  /** Most-recent attestation block (mirror of the last solution_history row). */
+  lastAttestation: Record<string, unknown>;
+  manifestPointer: string | null;
+  abandonedAt: Date | null;
+  doneAt: Date | null;
+  version: number;
+  createdAt: Date;
+}
+
+export interface SolutionTransitionOpts {
+  reason: string;
+  triggeredBy: SolutionTriggeredBy;
+  /** Per-steward attestation envelope. Persisted on solution_history.attestation. */
+  attestation?: StewardAttestation;
+  /** Free-form supporting evidence (logs, screenshots, etc.). */
+  evidence?: Record<string, unknown>;
+  /** Free-form payload (also used for payload-hash idempotency). */
+  payload?: Record<string, unknown>;
+  /** When set, the transition is only applied if version matches. */
+  expectedVersion?: number;
+  /** Override per-call retry budget. Defaults to the machine's defaultRetries. */
+  retries?: number;
+}
+
+export interface SolutionTransitionResult {
+  /** True if this call actually moved state; false on idempotent no-op. */
+  applied: boolean;
+  solutionId: string;
+  fromState: SolutionState;
+  toState: SolutionState;
+  newVersion: number;
+  historyId: number | null;
+  payloadHash: string;
+  /** Number of optimistic-lock retries before the call resolved. */
+  retries: number;
+}
+
+export interface SolutionHistoryRow {
+  id: number;
+  solutionId: string;
+  fromState: SolutionState | null;
+  toState: SolutionState;
+  reason: string;
+  actorKind: SolutionActorKind;
+  actorId: string;
+  attestation: Record<string, unknown>;
+  evidence: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  payloadHash: string;
+  at: Date;
+}
+
+export interface SolutionLifecycleSnapshot {
+  solution: SolutionRow;
+  /** Full audit trail, oldest-first. */
+  history: SolutionHistoryRow[];
+  /** Hours the solution has been in `current_state`. */
+  ageHoursInState: number;
+}
+
+export interface StuckSolution {
+  solution: SolutionRow;
+  /** Hours over the threshold for the current state. */
+  ageHoursInState: number;
+  thresholdHours: number;
+  /** What the conductor expects to come next, derived from the
+   * transition matrix (first non-failure forward edge). */
+  nextExpectedState: SolutionState | null;
+}
+
+export interface SolutionMachineOptions {
+  /** Clock for tests. */
+  now?: () => Date;
+  /** Idempotency window — same as project FSM. Defaults to 1000ms. */
+  idempotencyWindowMs?: number;
+  /** Default retry budget for `advanceSolution`. Defaults to 3. */
+  defaultRetries?: number;
+  /** Per-state stuck thresholds in hours. Defaults baked into
+   * `DEFAULT_STUCK_THRESHOLDS_HOURS`. */
+  stuckThresholdsHours?: Partial<Record<SolutionState, number>>;
+}
+
+/** Event envelope emitted on every solution transition. Mirrors the
+ * canonical-doc §A.8 envelope, with our three event types
+ * (`solution.advanced` | `solution.stuck` | `solution.completed`). */
+export interface SolutionEvent {
+  type: 'solution.advanced' | 'solution.stuck' | 'solution.completed';
+  /** Canonical-doc alias for cross-package consumers. */
+  canonicalType?: 'solution.state-transitioned' | 'solution.stuck' | 'solution.done';
+  namespace: 'solution-lifecycle';
+  envelopeVersion: 1;
+  at: string;
+  payload: {
+    solutionId: string;
+    fromState: SolutionState | null;
+    toState: SolutionState;
+    historyId: number | null;
+    trigger: string;
+    actor: { kind: SolutionActorKind; id: string };
+    attestation?: StewardAttestation;
+    evidence?: Record<string, unknown>;
+    /** Populated on `solution.stuck`. */
+    stuck?: {
+      currentState: SolutionState;
+      since: string;
+      ageHoursInState: number;
+      thresholdHours: number;
+      nextExpectedState: SolutionState | null;
+    };
+  };
+}

--- a/packages/state-machine/src/entities/solution.ts
+++ b/packages/state-machine/src/entities/solution.ts
@@ -1,0 +1,558 @@
+/**
+ * `SolutionLifecycleMachine` — the public API for the Real
+ * Definition-of-Done state machine, exposed at the same level of
+ * `@caia/state-machine` as the existing `StateMachine`.
+ *
+ * Methods named per the operator prompt:
+ *   - registerSolution(plan)          — invoked by EA Agent on plan approval
+ *   - advanceSolution(id, to, opts)   — invoked by each steward on green attestation
+ *   - getSolutionLifecycle(id)        — snapshot + history
+ *   - getStuckSolutions(thresholds?)  — for the lifecycle-conductor's cron
+ *   - pauseSolution / resumeSolution  — operator controls
+ *   - abandonSolution                 — operator-driven terminal-failure
+ *   - subscribeToSolution             — LISTEN/NOTIFY for realtime
+ *
+ * Concurrency contract: every `advanceSolution` call runs under a
+ * per-solution advisory lock + optimistic-version check. If two
+ * stewards race to advance the same solution, exactly one wins; the
+ * other sees `InvalidSolutionTransitionError` because the prerequisite
+ * forward state was not yet reached.
+ */
+
+import { hashPayload } from '../hash.js';
+import {
+  DuplicateSolutionIdError,
+  InvalidSolutionTransitionError,
+  SolutionNotFoundError,
+  SolutionTransitionRetryExhaustedError,
+  StaleSolutionVersionError,
+} from './solution-errors.js';
+import {
+  ALL_SOLUTION_STATES,
+  DEFAULT_STUCK_THRESHOLDS_HOURS,
+  isSolutionState,
+  isSolutionTerminal,
+  type SolutionState,
+} from './solution-states.js';
+import type { SolutionStore } from './solution-store.js';
+import {
+  availableSolutionTransitions,
+  checkSolutionTransition,
+  canSolutionTransition,
+  validNextSolutionStates,
+} from './solution-transitions.js';
+import type {
+  ApprovedPlanInput,
+  RegisteredSolution,
+  SolutionEvent,
+  SolutionHistoryRow,
+  SolutionLifecycleSnapshot,
+  SolutionMachineOptions,
+  SolutionRow,
+  SolutionTransitionOpts,
+  SolutionTransitionResult,
+  StewardAttestation,
+  StuckSolution,
+} from './solution-types.js';
+
+/** Local handler signature for the in-process event bus mirror that
+ * `subscribeToSolutionEvents` exposes. (DB-level LISTEN/NOTIFY is also
+ * available via `subscribeToSolution`; the in-process one is for
+ * same-runtime consumers like the pipeline-conductor when colocated.) */
+export type SolutionEventHandler = (event: SolutionEvent) => void | Promise<void>;
+
+export class SolutionLifecycleMachine {
+  private readonly nowFn: () => Date;
+  private readonly idempotencyWindowMs: number;
+  private readonly defaultRetries: number;
+  private readonly stuckThresholds: Partial<Record<SolutionState, number>>;
+  private readonly eventHandlers = new Set<SolutionEventHandler>();
+  /** Per-type subscription map, populated lazily. */
+  private readonly typedHandlers = new Map<SolutionEvent['type'], Set<SolutionEventHandler>>();
+
+  constructor(
+    private readonly store: SolutionStore,
+    opts: SolutionMachineOptions = {},
+  ) {
+    this.nowFn = opts.now ?? ((): Date => new Date());
+    this.idempotencyWindowMs = opts.idempotencyWindowMs ?? 1_000;
+    this.defaultRetries = opts.defaultRetries ?? 3;
+    this.stuckThresholds = {
+      ...DEFAULT_STUCK_THRESHOLDS_HOURS,
+      ...(opts.stuckThresholdsHours ?? {}),
+    };
+  }
+
+  async init(): Promise<void> {
+    await this.store.init();
+  }
+
+  /**
+   * Register an approved plan as a new Solution. Returns the freshly
+   * created `{ solutionId, currentState: 'approved' }`.
+   *
+   * Invoked by the EA Architect Agent on `ea-review-approved` (or
+   * `ea-review-conditional-approval`).
+   */
+  async registerSolution(plan: ApprovedPlanInput): Promise<RegisteredSolution> {
+    if (
+      plan.initialState !== undefined &&
+      !isSolutionState(plan.initialState)
+    ) {
+      throw new InvalidSolutionTransitionError(
+        'approved',
+        plan.initialState as SolutionState,
+        'unknown initial state',
+      );
+    }
+    const now = this.nowFn();
+    const row = await this.store.registerSolution(plan, now);
+    // Emit a synthetic solution.advanced{from:null,to:'approved'} so the
+    // event-feed history matches the persistent history. The DB tracks
+    // history rows on every transition; the "register" step has no
+    // history row, so this is purely an in-process notification.
+    this.emit({
+      type: 'solution.advanced',
+      canonicalType: 'solution.state-transitioned',
+      namespace: 'solution-lifecycle',
+      envelopeVersion: 1,
+      at: now.toISOString(),
+      payload: {
+        solutionId: row.solutionId,
+        fromState: null,
+        toState: row.status,
+        historyId: null,
+        trigger: 'registerSolution',
+        actor: { kind: 'agent', id: 'ea-architect-agent' },
+      },
+    });
+    return {
+      solutionId: row.solutionId,
+      currentState: row.status,
+      version: row.version,
+      createdAt: row.createdAt,
+    };
+  }
+
+  async getSolution(solutionId: string): Promise<SolutionRow | null> {
+    return this.store.getSolution(solutionId);
+  }
+
+  async listActiveSolutions(): Promise<SolutionRow[]> {
+    return this.store.listActiveSolutions();
+  }
+
+  /**
+   * Advance a solution to a new state. Idempotent under the
+   * payload-hash unique index; concurrent callers retry up to the
+   * `defaultRetries` budget. Throws:
+   *  - `SolutionNotFoundError` if `solutionId` doesn't exist
+   *  - `InvalidSolutionTransitionError` if the (from, to) edge is not in the matrix
+   *    (this is the case the two-steward race hits — the loser sees this)
+   *  - `StaleSolutionVersionError` if `expectedVersion` is set + mismatched
+   *  - `SolutionTransitionRetryExhaustedError` if optimistic-lock retries
+   *    cannot reach a stable read
+   */
+  async advanceSolution(
+    solutionId: string,
+    toState: SolutionState,
+    opts: SolutionTransitionOpts,
+  ): Promise<SolutionTransitionResult> {
+    if (!isSolutionState(toState)) {
+      throw new InvalidSolutionTransitionError(
+        'approved',
+        toState,
+        'unknown to-state',
+      );
+    }
+
+    const payload = opts.payload ?? {};
+    const payloadHash = hashPayload(payload);
+    const maxRetries = opts.retries ?? this.defaultRetries;
+    const attestation = opts.attestation
+      ? attestationToJson(opts.attestation)
+      : {};
+    const evidence = opts.evidence ?? {};
+
+    let attempt = 0;
+    let lastReadVersion = -1;
+
+    while (attempt <= maxRetries) {
+      const sol = await this.store.getSolution(solutionId);
+      if (!sol) throw new SolutionNotFoundError(solutionId);
+
+      // Idempotent self-call: status already at toState + same payload hash.
+      if (sol.status === toState) {
+        const recent = await this.store.listHistory(solutionId, {
+          toState,
+          limit: 50,
+        });
+        const dup = recent.find((h) => h.payloadHash === payloadHash);
+        if (dup) {
+          return {
+            applied: false,
+            solutionId,
+            fromState: sol.status,
+            toState,
+            newVersion: sol.version,
+            historyId: dup.id,
+            payloadHash,
+            retries: attempt,
+          };
+        }
+        throw new InvalidSolutionTransitionError(
+          sol.status,
+          toState,
+          'self-transition is a no-op',
+        );
+      }
+
+      const check = checkSolutionTransition(sol.status, toState);
+      if (!check.ok) {
+        throw new InvalidSolutionTransitionError(
+          sol.status,
+          toState,
+          check.reason ?? 'illegal transition',
+        );
+      }
+
+      if (
+        opts.expectedVersion !== undefined &&
+        opts.expectedVersion !== sol.version
+      ) {
+        throw new StaleSolutionVersionError(solutionId, opts.expectedVersion);
+      }
+
+      if (lastReadVersion === sol.version && attempt > 0) {
+        lastReadVersion = -1;
+      }
+      lastReadVersion = sol.version;
+
+      const result = await this.store.advanceAtomic({
+        solutionId,
+        expectedVersion: sol.version,
+        expectedStatus: sol.status,
+        toState,
+        reason: opts.reason,
+        actorKind: opts.triggeredBy.kind,
+        actorId: opts.triggeredBy.id,
+        agentRunId: opts.triggeredBy.agentRunId ?? null,
+        attestation,
+        evidence,
+        payload,
+        payloadHash,
+        idempotencyWindowMs: this.idempotencyWindowMs,
+        now: this.nowFn(),
+      });
+
+      if (result.applied) {
+        const now = this.nowFn();
+        this.emit({
+          type: 'solution.advanced',
+          canonicalType: 'solution.state-transitioned',
+          namespace: 'solution-lifecycle',
+          envelopeVersion: 1,
+          at: now.toISOString(),
+          payload: {
+            solutionId,
+            fromState: sol.status,
+            toState,
+            historyId: result.historyId,
+            trigger: opts.reason,
+            actor: { kind: opts.triggeredBy.kind, id: opts.triggeredBy.id },
+            ...(opts.attestation !== undefined ? { attestation: opts.attestation } : {}),
+            ...(Object.keys(evidence).length > 0 ? { evidence } : {}),
+          },
+        });
+        if (toState === 'done') {
+          this.emit({
+            type: 'solution.completed',
+            canonicalType: 'solution.done',
+            namespace: 'solution-lifecycle',
+            envelopeVersion: 1,
+            at: now.toISOString(),
+            payload: {
+              solutionId,
+              fromState: sol.status,
+              toState: 'done',
+              historyId: result.historyId,
+              trigger: opts.reason,
+              actor: { kind: opts.triggeredBy.kind, id: opts.triggeredBy.id },
+              ...(opts.attestation !== undefined ? { attestation: opts.attestation } : {}),
+            },
+          });
+        }
+        return {
+          applied: true,
+          solutionId,
+          fromState: sol.status,
+          toState,
+          newVersion: result.newVersion,
+          historyId: result.historyId,
+          payloadHash,
+          retries: attempt,
+        };
+      }
+
+      if (result.idempotentReplay && result.historyId !== null) {
+        return {
+          applied: false,
+          solutionId,
+          fromState: sol.status,
+          toState,
+          newVersion: result.newVersion,
+          historyId: result.historyId,
+          payloadHash,
+          retries: attempt,
+        };
+      }
+
+      // Optimistic-conflict — retry.
+      attempt += 1;
+      if (attempt > maxRetries) {
+        throw new SolutionTransitionRetryExhaustedError(solutionId, attempt);
+      }
+      await new Promise((resolve) => setTimeout(resolve, Math.min(10, attempt * 2)));
+    }
+
+    throw new SolutionTransitionRetryExhaustedError(solutionId, attempt);
+  }
+
+  /** Snapshot + full history + age-in-state. */
+  async getSolutionLifecycle(
+    solutionId: string,
+  ): Promise<SolutionLifecycleSnapshot> {
+    const sol = await this.store.getSolution(solutionId);
+    if (!sol) throw new SolutionNotFoundError(solutionId);
+    const history = await this.store.listHistory(solutionId);
+    const ageHoursInState =
+      (this.nowFn().getTime() - sol.statusSince.getTime()) / 3_600_000;
+    return { solution: sol, history, ageHoursInState };
+  }
+
+  /**
+   * Solutions stuck in a non-terminal state past the threshold.
+   *
+   * `thresholds` may be:
+   *  - omitted: use machine defaults
+   *  - a number: use as a uniform threshold for every non-terminal state
+   *  - an object: per-state override; missing entries fall back to defaults
+   *
+   * Side effect: emits `solution.stuck` for every result on this call.
+   * This is the wire the lifecycle-conductor + pipeline-conductor
+   * subscribe to in order to surface INBOX entries.
+   */
+  async getStuckSolutions(
+    thresholdsHours?: number | Partial<Record<SolutionState, number>>,
+  ): Promise<StuckSolution[]> {
+    const resolved = this.resolveThresholds(thresholdsHours);
+    const now = this.nowFn();
+    const stuck = await this.store.listStuck({
+      thresholdsHours: resolved,
+      now,
+    });
+    for (const item of stuck) {
+      this.emit({
+        type: 'solution.stuck',
+        canonicalType: 'solution.stuck',
+        namespace: 'solution-lifecycle',
+        envelopeVersion: 1,
+        at: now.toISOString(),
+        payload: {
+          solutionId: item.solution.solutionId,
+          fromState: item.solution.status,
+          toState: item.solution.status, // stays in place; "stuck" is not a transition
+          historyId: null,
+          trigger: 'getStuckSolutions',
+          actor: { kind: 'system', id: 'solution-lifecycle-machine' },
+          stuck: {
+            currentState: item.solution.status,
+            since: item.solution.statusSince.toISOString(),
+            ageHoursInState: item.ageHoursInState,
+            thresholdHours: item.thresholdHours,
+            nextExpectedState: item.nextExpectedState,
+          },
+        },
+      });
+    }
+    return stuck;
+  }
+
+  async pauseSolution(solutionId: string, by: string): Promise<void> {
+    const before = await this.store.getSolution(solutionId);
+    if (!before) throw new SolutionNotFoundError(solutionId);
+    if (isSolutionTerminal(before.status)) {
+      throw new InvalidSolutionTransitionError(
+        before.status,
+        'paused',
+        `${before.status} is a terminal state`,
+      );
+    }
+    const updated = await this.store.setPaused(solutionId, by, this.nowFn());
+    if (!updated) throw new SolutionNotFoundError(solutionId);
+  }
+
+  async resumeSolution(solutionId: string): Promise<void> {
+    const before = await this.store.getSolution(solutionId);
+    if (!before) throw new SolutionNotFoundError(solutionId);
+    const updated = await this.store.setResumed(solutionId, this.nowFn());
+    if (!updated) throw new SolutionNotFoundError(solutionId);
+  }
+
+  /** Operator-driven terminal-failure transition. Records a history row. */
+  async abandonSolution(
+    solutionId: string,
+    by: string,
+    reason = 'operator-abandoned',
+    triggeredBy: { kind: 'operator' | 'agent'; id: string } = {
+      kind: 'operator',
+      id: by,
+    },
+  ): Promise<SolutionTransitionResult> {
+    return this.advanceSolution(solutionId, 'abandoned', {
+      reason,
+      triggeredBy,
+    });
+  }
+
+  // -- Pure helpers (re-exported for callers / dashboards) ---------------
+
+  availableTransitions(from: SolutionState): readonly SolutionState[] {
+    return availableSolutionTransitions(from);
+  }
+
+  validNextStates(from: SolutionState): readonly SolutionState[] {
+    return validNextSolutionStates(from);
+  }
+
+  canTransition(from: SolutionState, to: SolutionState): boolean {
+    return canSolutionTransition(from, to);
+  }
+
+  // -- Realtime ----------------------------------------------------------
+
+  /** In-process subscription to ALL solution events (or a specific type). */
+  on(handler: SolutionEventHandler): () => void;
+  on(type: SolutionEvent['type'], handler: SolutionEventHandler): () => void;
+  on(
+    typeOrHandler: SolutionEvent['type'] | SolutionEventHandler,
+    maybeHandler?: SolutionEventHandler,
+  ): () => void {
+    if (typeof typeOrHandler === 'function') {
+      this.eventHandlers.add(typeOrHandler);
+      return () => {
+        this.eventHandlers.delete(typeOrHandler);
+      };
+    }
+    if (maybeHandler === undefined) {
+      throw new TypeError('on(type, handler) requires both arguments');
+    }
+    const handler = maybeHandler;
+    const type = typeOrHandler;
+    let set = this.typedHandlers.get(type);
+    if (!set) {
+      set = new Set();
+      this.typedHandlers.set(type, set);
+    }
+    set.add(handler);
+    return () => {
+      const s = this.typedHandlers.get(type);
+      if (s) s.delete(handler);
+    };
+  }
+
+  /** DB-level (LISTEN/NOTIFY for PgSolutionStore; in-process for memory store). */
+  async subscribeToSolution(
+    solutionId: string,
+    handler: (event: SolutionAdvancedNotifyPayload) => void,
+  ): Promise<() => Promise<void>> {
+    return this.store.subscribe('caia_solution_' + solutionId, (payload) => {
+      try {
+        const parsed = JSON.parse(payload) as SolutionAdvancedNotifyPayload;
+        handler(parsed);
+      } catch {
+        /* ignore malformed payload */
+      }
+    });
+  }
+
+  // -- Internals ---------------------------------------------------------
+
+  private resolveThresholds(
+    thresholds?: number | Partial<Record<SolutionState, number>>,
+  ): Partial<Record<SolutionState, number>> {
+    if (thresholds === undefined) {
+      return this.stuckThresholds;
+    }
+    if (typeof thresholds === 'number') {
+      const out: Partial<Record<SolutionState, number>> = {};
+      for (const state of ALL_SOLUTION_STATES) {
+        if (isSolutionTerminal(state)) continue;
+        if (state === 'paused') continue;
+        out[state] = thresholds;
+      }
+      return out;
+    }
+    // Object override merged on top of defaults.
+    return { ...this.stuckThresholds, ...thresholds };
+  }
+
+  private emit(event: SolutionEvent): void {
+    // Fire-and-forget. Errors in one handler must not break others.
+    for (const h of [...this.eventHandlers]) {
+      try {
+        const result = h(event);
+        if (result && typeof (result as Promise<void>).catch === 'function') {
+          (result as Promise<void>).catch(() => {
+            /* swallow */
+          });
+        }
+      } catch {
+        /* swallow */
+      }
+    }
+    const typed = this.typedHandlers.get(event.type);
+    if (typed) {
+      for (const h of [...typed]) {
+        try {
+          const result = h(event);
+          if (result && typeof (result as Promise<void>).catch === 'function') {
+            (result as Promise<void>).catch(() => {
+              /* swallow */
+            });
+          }
+        } catch {
+          /* swallow */
+        }
+      }
+    }
+  }
+}
+
+/** Shape of the LISTEN/NOTIFY payload emitted by the Pg trigger. */
+export interface SolutionAdvancedNotifyPayload {
+  kind: 'solution-advanced';
+  history_id: number;
+  from_state: SolutionState | null;
+  to_state: SolutionState;
+  reason: string;
+  actor_kind: string;
+  actor_id: string;
+  at: string;
+}
+
+function attestationToJson(att: StewardAttestation): Record<string, unknown> {
+  // Persist as a plain object so the store's JSON serialization is
+  // stable (Date/undefined would round-trip differently).
+  return {
+    steward: att.steward,
+    id: att.id,
+    status: att.status,
+    at: att.at,
+    ...(att.evidence !== undefined ? { evidence: att.evidence } : {}),
+  };
+}
+
+// Re-export DuplicateSolutionIdError so callers can catch it without
+// reaching into the errors module.
+export { DuplicateSolutionIdError };

--- a/packages/state-machine/src/index.ts
+++ b/packages/state-machine/src/index.ts
@@ -3,9 +3,10 @@
  *
  * Public surface. Everything else stays internal.
  *
- * The package now hosts TWO entity FSMs:
+ * The package now hosts THREE entity FSMs:
  *   1. `StateMachine` (the original project FSM, project-state-centric)
- *   2. `SolutionLifecycleMachine` (the Real Definition-of-Done FSM
+ *   2. EA Review Entity (per research/ea_agent_operational_framework_2026.md §7)
+ *   3. `SolutionLifecycleMachine` (the Real Definition-of-Done FSM
  *      for the solution-lifecycle described in
  *      `research/real_definition_of_done_enforcement_2026.md`).
  */
@@ -102,3 +103,84 @@ export {
 } from './ea-review-entity.js';
 export type { EaReviewState } from './ea-review-entity.js';
 
+// -- Solution-lifecycle (Real Definition-of-Done) ----------------------
+
+export {
+  ALL_SOLUTION_STATES,
+  SOLUTION_FORWARD_STATES,
+  SOLUTION_FAILED_STATES,
+  SOLUTION_ROLLED_BACK_STATES,
+  SOLUTION_CONTROL_STATES,
+  SOLUTION_TERMINAL_STATES,
+  SOLUTION_INITIAL_STATE,
+  SOLUTION_STATE_CANONICAL_SYNONYM,
+  DEFAULT_STUCK_THRESHOLDS_HOURS,
+  FAILED_OF,
+  ROLLED_BACK_OF,
+  FORWARD_OF_FAILED,
+  FORWARD_OF_ROLLED_BACK,
+  isSolutionState,
+  isSolutionForwardState,
+  isSolutionFailedState,
+  isSolutionRolledBackState,
+  isSolutionControlState,
+  isSolutionTerminal,
+} from './entities/solution-states.js';
+export type {
+  SolutionState,
+  SolutionForwardState,
+  SolutionFailedState,
+  SolutionRolledBackState,
+  SolutionControlState,
+} from './entities/solution-states.js';
+
+export {
+  VALID_SOLUTION_TRANSITIONS,
+  canSolutionTransition,
+  checkSolutionTransition,
+  availableSolutionTransitions,
+  validNextSolutionStates,
+  allSolutionEdges,
+} from './entities/solution-transitions.js';
+export type { SolutionTransitionCheck } from './entities/solution-transitions.js';
+
+export {
+  DuplicateSolutionIdError,
+  InvalidSolutionTransitionError,
+  SolutionNotFoundError,
+  StaleSolutionVersionError,
+  SolutionTransitionRetryExhaustedError,
+} from './entities/solution-errors.js';
+
+export { SolutionLifecycleMachine } from './entities/solution.js';
+export type {
+  SolutionEventHandler,
+  SolutionAdvancedNotifyPayload,
+} from './entities/solution.js';
+
+export { InMemorySolutionStore } from './entities/in-memory-solution-store.js';
+export { PgSolutionStore } from './entities/pg-solution-store.js';
+export type { PgSolutionStoreOptions } from './entities/pg-solution-store.js';
+
+export type {
+  SolutionStore,
+  SolutionAdvanceAtomicInput,
+  SolutionAdvanceAtomicResult,
+  ListStuckOpts,
+} from './entities/solution-store.js';
+
+export type {
+  ApprovedPlanInput,
+  RegisteredSolution,
+  SolutionRow,
+  SolutionTransitionOpts,
+  SolutionTransitionResult,
+  SolutionHistoryRow,
+  SolutionLifecycleSnapshot,
+  StuckSolution,
+  SolutionMachineOptions,
+  SolutionEvent,
+  SolutionActorKind,
+  SolutionTriggeredBy,
+  StewardAttestation,
+} from './entities/solution-types.js';

--- a/packages/state-machine/src/test-support.ts
+++ b/packages/state-machine/src/test-support.ts
@@ -37,3 +37,10 @@ export const HAPPY_PATH: ReadonlyArray<[ProjectState, ProjectState]> = [
   ['deployed', 'verified'],
   ['verified', 'done'],
 ];
+
+// Re-export the solution-side test helpers so callers can `import { ... } from '@caia/state-machine/test-support'`.
+export {
+  buildInMemorySolutionMachine,
+  SOLUTION_HAPPY_PATH,
+  fakeAttestation,
+} from './entities/solution-test-support.js';

--- a/packages/state-machine/tests/solution-integration.test.ts
+++ b/packages/state-machine/tests/solution-integration.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  InvalidSolutionTransitionError,
+} from '../src/entities/solution-errors.js';
+import { InMemorySolutionStore } from '../src/entities/in-memory-solution-store.js';
+import {
+  buildInMemorySolutionMachine,
+  fakeAttestation,
+  SOLUTION_HAPPY_PATH,
+} from '../src/entities/solution-test-support.js';
+import { SolutionLifecycleMachine } from '../src/entities/solution.js';
+import type {
+  SolutionEvent,
+  SolutionTransitionOpts,
+} from '../src/entities/solution-types.js';
+
+/**
+ * End-to-end: register a fake solution, walk it through all 9 forward
+ * states via simulated steward attestations, verify each transition
+ * emits the correct event + persists the history row with the right
+ * actor + attestation.
+ */
+describe('integration: full solution-lifecycle walkthrough', () => {
+  it('walks approved → done with one steward attestation per transition', async () => {
+    const { machine, store } = buildInMemorySolutionMachine({ idempotencyWindowMs: 0 });
+    await machine.init();
+
+    const seen: SolutionEvent[] = [];
+    machine.on((e) => seen.push(e));
+
+    const reg = await machine.registerSolution({
+      solutionId: 'caia-2026-05-24-ea-coordinator',
+      title: 'EA Coordinator framework build',
+      planPath: 'research/ea_coordinator_2026.md',
+      approvedByAdr: 'ADR-068',
+    });
+    expect(reg.currentState).toBe('approved');
+    expect(seen[0]?.type).toBe('solution.advanced');
+    expect(seen[0]?.payload.fromState).toBeNull();
+
+    // Each forward step is driven by a different steward to mirror the
+    // canonical 4-steward + lifecycle-conductor architecture.
+    const stewardByTo: Record<string, string> = {
+      implemented: 'coding-worker',
+      merged: 'pr-merger',
+      deployed: 'deploy-steward',
+      imported: 'usage-steward',
+      'called-in-test': 'activation-steward',
+      'called-in-prod': 'activation-steward',
+      'producing-metrics': 'outcome-steward',
+      done: 'lifecycle-conductor',
+    };
+
+    for (const [, to] of SOLUTION_HAPPY_PATH) {
+      const stewardId = stewardByTo[to] ?? 'system';
+      const opts: SolutionTransitionOpts = {
+        reason: `${stewardId}-green-first-attestation`,
+        triggeredBy: { kind: 'steward', id: stewardId },
+        attestation: fakeAttestation(stewardId, `${to}-1`),
+        evidence: { stepTo: to },
+      };
+      const result = await machine.advanceSolution('caia-2026-05-24-ea-coordinator', to, opts);
+      expect(result.applied).toBe(true);
+      expect(result.toState).toBe(to);
+    }
+
+    const snap = await machine.getSolutionLifecycle('caia-2026-05-24-ea-coordinator');
+    expect(snap.solution.status).toBe('done');
+    expect(snap.solution.doneAt).not.toBeNull();
+    // History has 8 forward transitions (approved is the initial state — no row).
+    expect(snap.history.length).toBe(SOLUTION_HAPPY_PATH.length);
+    expect(snap.history[0]!.fromState).toBe('approved');
+    expect(snap.history[0]!.toState).toBe('implemented');
+    expect(snap.history[snap.history.length - 1]!.toState).toBe('done');
+    // Steward attestations are persisted.
+    expect(snap.history[2]!.attestation['steward']).toBe('deploy-steward');
+
+    // Event log: 1 synthetic register + 8 advances + 1 completed.
+    const advanceEvents = seen.filter((e) => e.type === 'solution.advanced');
+    const completedEvents = seen.filter((e) => e.type === 'solution.completed');
+    expect(advanceEvents.length).toBe(1 + SOLUTION_HAPPY_PATH.length);
+    expect(completedEvents.length).toBe(1);
+
+    // The pg-store and in-memory store agree on the active set: this
+    // one's done so listActiveSolutions excludes it.
+    const active = await store.listActiveSolutions();
+    expect(active.find((s) => s.solutionId === 'caia-2026-05-24-ea-coordinator')).toBeUndefined();
+  });
+
+  it('walkthrough also exercises a recovery edge (deployed-failed → deployed)', async () => {
+    const { machine } = buildInMemorySolutionMachine({ idempotencyWindowMs: 0 });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'rec', title: 'rec' });
+    await machine.advanceSolution('rec', 'implemented', {
+      reason: 'r',
+      triggeredBy: { kind: 'system', id: 't' },
+    });
+    await machine.advanceSolution('rec', 'merged', {
+      reason: 'r',
+      triggeredBy: { kind: 'system', id: 't' },
+    });
+    // The deploy went red.
+    await machine.advanceSolution('rec', 'deployed-failed', {
+      reason: 'deploy-steward-red',
+      triggeredBy: { kind: 'steward', id: 'deploy-steward' },
+    });
+    expect((await machine.getSolution('rec'))!.status).toBe('deployed-failed');
+    // Re-deployed and green this time.
+    await machine.advanceSolution('rec', 'deployed', {
+      reason: 'deploy-steward-green-retry',
+      triggeredBy: { kind: 'steward', id: 'deploy-steward' },
+    });
+    expect((await machine.getSolution('rec'))!.status).toBe('deployed');
+  });
+
+  it('walkthrough also exercises a regression edge (called-in-prod → called-in-prod-rolled-back → called-in-prod)', async () => {
+    const { machine } = buildInMemorySolutionMachine({ idempotencyWindowMs: 0 });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'reg', title: 'reg' });
+    for (const to of [
+      'implemented',
+      'merged',
+      'deployed',
+      'imported',
+      'called-in-test',
+      'called-in-prod',
+    ] as const) {
+      await machine.advanceSolution('reg', to, {
+        reason: 'walk',
+        triggeredBy: { kind: 'system', id: 't' },
+      });
+    }
+    expect((await machine.getSolution('reg'))!.status).toBe('called-in-prod');
+    // Activation-steward goes red — drift.
+    await machine.advanceSolution('reg', 'called-in-prod-rolled-back', {
+      reason: 'activation-red',
+      triggeredBy: { kind: 'steward', id: 'activation-steward' },
+    });
+    expect((await machine.getSolution('reg'))!.status).toBe('called-in-prod-rolled-back');
+    // Steward re-greens. Use a distinct payload to avoid colliding with the
+    // ORIGINAL called-in-prod transition's payload-hash (the idempotency index
+    // is keyed on (solution_id, to_state, payload_hash) and would otherwise
+    // collapse this to a no-op replay).
+    const r = await machine.advanceSolution('reg', 'called-in-prod', {
+      reason: 'activation-green-recovered',
+      triggeredBy: { kind: 'steward', id: 'activation-steward' },
+      payload: { greenId: 'as-prod-recover-1' },
+    });
+    expect(r.applied).toBe(true);
+    expect((await machine.getSolution('reg'))!.status).toBe('called-in-prod');
+  });
+});
+
+/**
+ * Concurrency: two stewards race to advance the same solution; only
+ * the steward whose transition matches the current state wins. The
+ * other gets InvalidSolutionTransitionError because the prerequisite
+ * forward state was not yet reached.
+ *
+ * Specifically: while the solution is in `merged`, the deploy-steward
+ * advances `merged → deployed` (legal). At the same time the
+ * usage-steward tries to advance `merged → imported` (illegal — the
+ * forward path requires deploy first). The usage-steward must lose
+ * with InvalidSolutionTransitionError.
+ */
+describe('integration: two stewards racing — usage-steward cannot skip ahead', () => {
+  it('usage-steward cannot advance merged → imported until deploy-steward has advanced to deployed', async () => {
+    const { machine } = buildInMemorySolutionMachine({ idempotencyWindowMs: 0 });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'race', title: 'race' });
+    // Walk to merged.
+    await machine.advanceSolution('race', 'implemented', {
+      reason: 'r',
+      triggeredBy: { kind: 'system', id: 't' },
+    });
+    await machine.advanceSolution('race', 'merged', {
+      reason: 'r',
+      triggeredBy: { kind: 'system', id: 't' },
+    });
+
+    // Race: both stewards fire concurrent advances.
+    const deployPromise = machine.advanceSolution('race', 'deployed', {
+      reason: 'deploy-green',
+      triggeredBy: { kind: 'steward', id: 'deploy-steward' },
+      attestation: fakeAttestation('deploy-steward', 'race-1'),
+    });
+    const usagePromise = machine.advanceSolution('race', 'imported', {
+      reason: 'usage-green',
+      triggeredBy: { kind: 'steward', id: 'usage-steward' },
+      attestation: fakeAttestation('usage-steward', 'race-1'),
+    });
+
+    const [deployResult, usageResult] = await Promise.allSettled([
+      deployPromise,
+      usagePromise,
+    ]);
+
+    expect(deployResult.status).toBe('fulfilled');
+    if (deployResult.status === 'fulfilled') {
+      expect(deployResult.value.applied).toBe(true);
+      expect(deployResult.value.toState).toBe('deployed');
+    }
+
+    expect(usageResult.status).toBe('rejected');
+    if (usageResult.status === 'rejected') {
+      const err = usageResult.reason;
+      expect(err).toBeInstanceOf(InvalidSolutionTransitionError);
+      const e = err as InvalidSolutionTransitionError;
+      expect(e.fromState).toBe('merged');
+      expect(e.toState).toBe('imported');
+    }
+
+    // After the deploy-steward wins, the usage-steward CAN advance.
+    const usageRetry = await machine.advanceSolution('race', 'imported', {
+      reason: 'usage-green-retry',
+      triggeredBy: { kind: 'steward', id: 'usage-steward' },
+      attestation: fakeAttestation('usage-steward', 'race-2'),
+    });
+    expect(usageRetry.applied).toBe(true);
+    expect(usageRetry.toState).toBe('imported');
+  });
+
+  it('two stewards racing to advance the SAME legal transition: exactly one applies, the other is idempotent', async () => {
+    const { machine } = buildInMemorySolutionMachine({ idempotencyWindowMs: 0 });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'tie', title: 'tie' });
+    await machine.advanceSolution('tie', 'implemented', {
+      reason: 'r',
+      triggeredBy: { kind: 'system', id: 't' },
+    });
+    await machine.advanceSolution('tie', 'merged', {
+      reason: 'r',
+      triggeredBy: { kind: 'system', id: 't' },
+    });
+
+    const sharedPayload = { commit: 'abc-shared' };
+    const a = machine.advanceSolution('tie', 'deployed', {
+      reason: 'race-a',
+      triggeredBy: { kind: 'steward', id: 'deploy-steward-a' },
+      payload: sharedPayload,
+    });
+    const b = machine.advanceSolution('tie', 'deployed', {
+      reason: 'race-b',
+      triggeredBy: { kind: 'steward', id: 'deploy-steward-b' },
+      payload: sharedPayload,
+    });
+    const [ra, rb] = await Promise.all([a, b]);
+    // Exactly one applied = true; the other matched the idempotency hash
+    // (it ran second and saw the existing history row).
+    const applied = [ra.applied, rb.applied].filter(Boolean).length;
+    expect(applied).toBe(1);
+    // Both return the SAME historyId (idempotent replay collapse).
+    expect(ra.historyId).toBe(rb.historyId);
+    expect((await machine.getSolution('tie'))!.status).toBe('deployed');
+  });
+
+  it('optimistic-lock retries surface in the result', async () => {
+    // Use a low retry budget to verify exhaustion path.
+    const { machine } = buildInMemorySolutionMachine({
+      idempotencyWindowMs: 0,
+      defaultRetries: 0,
+    });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'opt', title: 'opt' });
+    const r = await machine.advanceSolution('opt', 'implemented', {
+      reason: 'first',
+      triggeredBy: { kind: 'system', id: 't' },
+    });
+    // retries=0 on first try, applied=true
+    expect(r.retries).toBe(0);
+    expect(r.applied).toBe(true);
+  });
+
+  it('SolutionLifecycleMachine can be constructed with a freshly-built store', async () => {
+    // Smoke: API still works without the test-support helper.
+    const store = new InMemorySolutionStore();
+    const machine = new SolutionLifecycleMachine(store, { idempotencyWindowMs: 0 });
+    await machine.init();
+    const reg = await machine.registerSolution({ solutionId: 's', title: 's' });
+    expect(reg.currentState).toBe('approved');
+  });
+});

--- a/packages/state-machine/tests/solution-lifecycle.test.ts
+++ b/packages/state-machine/tests/solution-lifecycle.test.ts
@@ -1,0 +1,511 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DuplicateSolutionIdError,
+  InvalidSolutionTransitionError,
+  SolutionNotFoundError,
+  StaleSolutionVersionError,
+} from '../src/entities/solution-errors.js';
+import {
+  buildInMemorySolutionMachine,
+  fakeAttestation,
+  SOLUTION_HAPPY_PATH,
+} from '../src/entities/solution-test-support.js';
+import type {
+  SolutionEvent,
+  SolutionTransitionOpts,
+} from '../src/entities/solution-types.js';
+
+const SYSTEM: SolutionTransitionOpts['triggeredBy'] = { kind: 'system', id: 'test' };
+
+const deployStewardOpts = (reason: string): SolutionTransitionOpts => ({
+  reason,
+  triggeredBy: { kind: 'steward', id: 'deploy-steward' },
+  attestation: fakeAttestation('deploy-steward', 'first'),
+});
+
+describe('SolutionLifecycleMachine — register + read', () => {
+  it('registers a fresh solution at state=approved', async () => {
+    const { machine } = buildInMemorySolutionMachine({ idempotencyWindowMs: 0 });
+    await machine.init();
+    const reg = await machine.registerSolution({
+      solutionId: 'caia-2026-05-24-x',
+      title: 'X',
+    });
+    expect(reg.solutionId).toBe('caia-2026-05-24-x');
+    expect(reg.currentState).toBe('approved');
+    expect(reg.version).toBe(1);
+  });
+
+  it('generates a default solution_id if none provided', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    const reg = await machine.registerSolution({ title: 'no-id' });
+    expect(reg.solutionId).toMatch(/^caia-\d{4}-\d{2}-\d{2}-/);
+  });
+
+  it('throws DuplicateSolutionIdError on UNIQUE collision', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'dup', title: 'A' });
+    await expect(
+      machine.registerSolution({ solutionId: 'dup', title: 'B' }),
+    ).rejects.toBeInstanceOf(DuplicateSolutionIdError);
+  });
+
+  it('persists optional fields (plan_path, approved_by_adr, manifest_pointer)', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await machine.registerSolution({
+      solutionId: 'x',
+      title: 'X',
+      planPath: 'research/x.md',
+      approvedByAdr: 'ADR-068',
+      manifestPointer: 'agent-memory/solutions_manifest.yaml#/solutions/0',
+    });
+    const sol = await machine.getSolution('x');
+    expect(sol).not.toBeNull();
+    expect(sol!.planPath).toBe('research/x.md');
+    expect(sol!.approvedByAdr).toBe('ADR-068');
+    expect(sol!.manifestPointer).toBe('agent-memory/solutions_manifest.yaml#/solutions/0');
+  });
+
+  it('getSolution returns null for unknown id', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    expect(await machine.getSolution('nope')).toBeNull();
+  });
+});
+
+describe('SolutionLifecycleMachine — advance', () => {
+  let machine: ReturnType<typeof buildInMemorySolutionMachine>['machine'];
+
+  beforeEach(async () => {
+    ({ machine } = buildInMemorySolutionMachine({ idempotencyWindowMs: 0 }));
+    await machine.init();
+    await machine.registerSolution({ solutionId: 's1', title: 'S1' });
+  });
+
+  it('advances approved -> implemented (legal forward hop)', async () => {
+    const r = await machine.advanceSolution('s1', 'implemented', {
+      reason: 'code-written',
+      triggeredBy: SYSTEM,
+      payload: { commit: 'abc' },
+    });
+    expect(r.applied).toBe(true);
+    expect(r.fromState).toBe('approved');
+    expect(r.toState).toBe('implemented');
+    expect(r.newVersion).toBe(2);
+    expect(r.historyId).not.toBeNull();
+  });
+
+  it('rejects illegal forward skip (approved -> deployed) with InvalidSolutionTransitionError', async () => {
+    await expect(
+      machine.advanceSolution('s1', 'deployed', {
+        reason: 'skip',
+        triggeredBy: SYSTEM,
+      }),
+    ).rejects.toBeInstanceOf(InvalidSolutionTransitionError);
+  });
+
+  it('throws SolutionNotFoundError for unknown id', async () => {
+    await expect(
+      machine.advanceSolution('nope', 'implemented', {
+        reason: 'r',
+        triggeredBy: SYSTEM,
+      }),
+    ).rejects.toBeInstanceOf(SolutionNotFoundError);
+  });
+
+  it('rejects self-transition with InvalidSolutionTransitionError', async () => {
+    await expect(
+      machine.advanceSolution('s1', 'approved', {
+        reason: 'self',
+        triggeredBy: SYSTEM,
+        payload: { distinctive: true },
+      }),
+    ).rejects.toBeInstanceOf(InvalidSolutionTransitionError);
+  });
+
+  it('expectedVersion mismatch raises StaleSolutionVersionError', async () => {
+    await expect(
+      machine.advanceSolution('s1', 'implemented', {
+        reason: 'r',
+        triggeredBy: SYSTEM,
+        expectedVersion: 99,
+      }),
+    ).rejects.toBeInstanceOf(StaleSolutionVersionError);
+  });
+
+  it('idempotent replay: same to-state + payload hash returns applied=false', async () => {
+    const a = await machine.advanceSolution('s1', 'implemented', {
+      reason: 'first',
+      triggeredBy: SYSTEM,
+      payload: { commit: 'abc' },
+    });
+    const b = await machine.advanceSolution('s1', 'implemented', {
+      reason: 'replay',
+      triggeredBy: SYSTEM,
+      payload: { commit: 'abc' },
+    });
+    expect(a.applied).toBe(true);
+    expect(b.applied).toBe(false);
+    expect(b.historyId).toBe(a.historyId);
+  });
+
+  it('TransitionResult carries retries (0 on first attempt)', async () => {
+    const r = await machine.advanceSolution('s1', 'implemented', {
+      reason: 'r',
+      triggeredBy: SYSTEM,
+    });
+    expect(r.retries).toBe(0);
+  });
+
+  it('records actor kind=steward on history rows for steward-driven advances', async () => {
+    await machine.advanceSolution('s1', 'implemented', {
+      reason: 'code-written',
+      triggeredBy: SYSTEM,
+    });
+    await machine.advanceSolution('s1', 'merged', {
+      reason: 'pr-merged',
+      triggeredBy: SYSTEM,
+    });
+    await machine.advanceSolution('s1', 'deployed', deployStewardOpts('deploy-green'));
+    const snap = await machine.getSolutionLifecycle('s1');
+    const last = snap.history[snap.history.length - 1];
+    expect(last).toBeDefined();
+    expect(last!.actorKind).toBe('steward');
+    expect(last!.actorId).toBe('deploy-steward');
+  });
+});
+
+describe('SolutionLifecycleMachine — pause + resume + abandon', () => {
+  it('pauseSolution saves prior_state and resumeSolution restores it', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'p', title: 'P' });
+    await machine.advanceSolution('p', 'implemented', {
+      reason: 'code',
+      triggeredBy: SYSTEM,
+    });
+    await machine.pauseSolution('p', 'operator-jane');
+    const paused = await machine.getSolution('p');
+    expect(paused!.paused).toBe(true);
+    expect(paused!.status).toBe('paused');
+    expect(paused!.priorState).toBe('implemented');
+    expect(paused!.pausedBy).toBe('operator-jane');
+    await machine.resumeSolution('p');
+    const resumed = await machine.getSolution('p');
+    expect(resumed!.paused).toBe(false);
+    expect(resumed!.status).toBe('implemented');
+    expect(resumed!.priorState).toBeNull();
+  });
+
+  it('pauseSolution throws InvalidSolutionTransitionError for terminal solution', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'a', title: 'A' });
+    await machine.abandonSolution('a', 'operator-jane');
+    await expect(machine.pauseSolution('a', 'operator-jane'))
+      .rejects.toBeInstanceOf(InvalidSolutionTransitionError);
+  });
+
+  it('pauseSolution throws SolutionNotFoundError for unknown', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await expect(machine.pauseSolution('nope', 'op')).rejects.toBeInstanceOf(
+      SolutionNotFoundError,
+    );
+  });
+
+  it('resumeSolution is idempotent on a non-paused solution', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'r', title: 'R' });
+    await machine.resumeSolution('r'); // no-op, no throw
+    const sol = await machine.getSolution('r');
+    expect(sol!.paused).toBe(false);
+  });
+
+  it('abandonSolution transitions to abandoned from any non-terminal state', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'ab', title: 'AB' });
+    const r = await machine.abandonSolution('ab', 'op', 'no-longer-needed');
+    expect(r.applied).toBe(true);
+    expect(r.toState).toBe('abandoned');
+    const sol = await machine.getSolution('ab');
+    expect(sol!.abandonedAt).not.toBeNull();
+  });
+
+  it('abandonSolution rejects further transitions (terminal)', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'ab2', title: 'AB2' });
+    await machine.abandonSolution('ab2', 'op');
+    await expect(
+      machine.advanceSolution('ab2', 'approved', {
+        reason: 'reopen',
+        triggeredBy: SYSTEM,
+      }),
+    ).rejects.toBeInstanceOf(InvalidSolutionTransitionError);
+  });
+});
+
+describe('SolutionLifecycleMachine — getSolutionLifecycle snapshot', () => {
+  it('returns the current solution + full history + ageHoursInState', async () => {
+    const baseNow = new Date('2026-05-24T00:00:00Z');
+    let clock = baseNow.getTime();
+    const { machine } = buildInMemorySolutionMachine({
+      now: () => new Date(clock),
+      idempotencyWindowMs: 0,
+    });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 's', title: 'S' });
+    clock += 30 * 60_000;
+    await machine.advanceSolution('s', 'implemented', {
+      reason: 'r',
+      triggeredBy: SYSTEM,
+    });
+    clock += 30 * 60_000;
+    const snap = await machine.getSolutionLifecycle('s');
+    expect(snap.solution.status).toBe('implemented');
+    expect(snap.history.length).toBe(1);
+    expect(snap.history[0]!.fromState).toBe('approved');
+    expect(snap.history[0]!.toState).toBe('implemented');
+    expect(snap.ageHoursInState).toBeCloseTo(0.5, 1);
+  });
+
+  it('throws SolutionNotFoundError for unknown id', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await expect(machine.getSolutionLifecycle('nope')).rejects.toBeInstanceOf(
+      SolutionNotFoundError,
+    );
+  });
+});
+
+describe('SolutionLifecycleMachine — getStuckSolutions', () => {
+  it('returns [] when no solutions exceed thresholds', async () => {
+    const baseNow = new Date('2026-05-24T00:00:00Z');
+    let clock = baseNow.getTime();
+    const { machine } = buildInMemorySolutionMachine({
+      now: () => new Date(clock),
+    });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'fresh', title: 'F' });
+    clock += 60_000; // 1 minute later
+    const stuck = await machine.getStuckSolutions();
+    expect(stuck).toEqual([]);
+  });
+
+  it('flags solutions that have exceeded their per-state threshold', async () => {
+    const baseNow = new Date('2026-05-24T00:00:00Z');
+    let clock = baseNow.getTime();
+    const { machine } = buildInMemorySolutionMachine({
+      now: () => new Date(clock),
+    });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'old', title: 'OLD' });
+    // Default threshold for 'approved' is 24h; jump 36h.
+    clock += 36 * 3_600_000;
+    const stuck = await machine.getStuckSolutions();
+    expect(stuck.length).toBe(1);
+    expect(stuck[0]!.solution.solutionId).toBe('old');
+    expect(stuck[0]!.ageHoursInState).toBeCloseTo(36, 0);
+    expect(stuck[0]!.thresholdHours).toBe(24);
+    expect(stuck[0]!.nextExpectedState).toBe('implemented');
+  });
+
+  it('accepts a uniform numeric threshold override', async () => {
+    const baseNow = new Date('2026-05-24T00:00:00Z');
+    let clock = baseNow.getTime();
+    const { machine } = buildInMemorySolutionMachine({
+      now: () => new Date(clock),
+    });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'a', title: 'A' });
+    clock += 2 * 3_600_000;
+    // Default 24h would not flag, but 1h threshold does.
+    expect((await machine.getStuckSolutions()).length).toBe(0);
+    expect((await machine.getStuckSolutions(1)).length).toBe(1);
+  });
+
+  it('accepts a per-state threshold override object', async () => {
+    const baseNow = new Date('2026-05-24T00:00:00Z');
+    let clock = baseNow.getTime();
+    const { machine } = buildInMemorySolutionMachine({
+      now: () => new Date(clock),
+    });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'a', title: 'A' });
+    clock += 5 * 3_600_000;
+    expect((await machine.getStuckSolutions({ approved: 1 })).length).toBe(1);
+  });
+
+  it('paused solutions are never flagged as stuck', async () => {
+    const baseNow = new Date('2026-05-24T00:00:00Z');
+    let clock = baseNow.getTime();
+    const { machine } = buildInMemorySolutionMachine({
+      now: () => new Date(clock),
+    });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'p', title: 'P' });
+    await machine.pauseSolution('p', 'op');
+    clock += 100 * 3_600_000;
+    expect(await machine.getStuckSolutions()).toEqual([]);
+  });
+
+  it('terminal solutions (done / abandoned) are never flagged as stuck', async () => {
+    const baseNow = new Date('2026-05-24T00:00:00Z');
+    let clock = baseNow.getTime();
+    const { machine } = buildInMemorySolutionMachine({
+      now: () => new Date(clock),
+    });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'a', title: 'A' });
+    await machine.abandonSolution('a', 'op');
+    clock += 100 * 3_600_000;
+    expect(await machine.getStuckSolutions()).toEqual([]);
+  });
+
+  it('emits a solution.stuck event for every stuck result on the call', async () => {
+    const baseNow = new Date('2026-05-24T00:00:00Z');
+    let clock = baseNow.getTime();
+    const { machine } = buildInMemorySolutionMachine({
+      now: () => new Date(clock),
+    });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'a', title: 'A' });
+    await machine.registerSolution({ solutionId: 'b', title: 'B' });
+    clock += 36 * 3_600_000;
+    const stuckEvents: SolutionEvent[] = [];
+    machine.on('solution.stuck', (e) => {
+      stuckEvents.push(e);
+    });
+    const stuck = await machine.getStuckSolutions();
+    expect(stuck.length).toBe(2);
+    expect(stuckEvents.length).toBe(2);
+    expect(stuckEvents[0]!.payload.stuck?.thresholdHours).toBe(24);
+    expect(stuckEvents[0]!.payload.stuck?.nextExpectedState).toBe('implemented');
+  });
+});
+
+describe('SolutionLifecycleMachine — event emission', () => {
+  it('emits solution.advanced on registerSolution (synthetic from-null)', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    const seen: SolutionEvent[] = [];
+    machine.on((e) => seen.push(e));
+    await machine.registerSolution({ solutionId: 'x', title: 'X' });
+    expect(seen.length).toBe(1);
+    expect(seen[0]!.type).toBe('solution.advanced');
+    expect(seen[0]!.payload.fromState).toBeNull();
+    expect(seen[0]!.payload.toState).toBe('approved');
+  });
+
+  it('emits solution.advanced on each transition with the steward attestation', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'y', title: 'Y' });
+    const seen: SolutionEvent[] = [];
+    machine.on('solution.advanced', (e) => seen.push(e));
+    await machine.advanceSolution('y', 'implemented', {
+      reason: 'r',
+      triggeredBy: { kind: 'steward', id: 'cw' },
+      attestation: fakeAttestation('cw', '1'),
+    });
+    // First handler call is the synthetic register event? No — `on('type', ...)` is
+    // registered AFTER register. So only one event here.
+    expect(seen.length).toBe(1);
+    expect(seen[0]!.type).toBe('solution.advanced');
+    expect(seen[0]!.canonicalType).toBe('solution.state-transitioned');
+    expect(seen[0]!.payload.attestation?.steward).toBe('cw');
+  });
+
+  it('emits solution.completed when reaching done (alongside solution.advanced)', async () => {
+    const { machine } = buildInMemorySolutionMachine({ idempotencyWindowMs: 0 });
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'd', title: 'D' });
+    for (const [, to] of SOLUTION_HAPPY_PATH) {
+      await machine.advanceSolution('d', to, {
+        reason: 'walk',
+        triggeredBy: SYSTEM,
+        payload: { to },
+      });
+    }
+    const completed: SolutionEvent[] = [];
+    machine.on('solution.completed', (e) => completed.push(e));
+    // The done transition has already happened above; we'll send the "done" event
+    // by replaying through a fresh machine.
+    const { machine: m2 } = buildInMemorySolutionMachine({ idempotencyWindowMs: 0 });
+    await m2.init();
+    await m2.registerSolution({ solutionId: 'd2', title: 'D2' });
+    const done2: SolutionEvent[] = [];
+    m2.on('solution.completed', (e) => done2.push(e));
+    for (const [, to] of SOLUTION_HAPPY_PATH) {
+      await m2.advanceSolution('d2', to, {
+        reason: 'walk',
+        triggeredBy: SYSTEM,
+        payload: { to },
+      });
+    }
+    expect(done2.length).toBe(1);
+    expect(done2[0]!.type).toBe('solution.completed');
+    expect(done2[0]!.canonicalType).toBe('solution.done');
+    expect(done2[0]!.payload.toState).toBe('done');
+  });
+
+  it('handler unsubscribe via returned function works', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    const seen: SolutionEvent[] = [];
+    const unsub = machine.on((e) => seen.push(e));
+    await machine.registerSolution({ solutionId: 'u1', title: 'U1' });
+    unsub();
+    await machine.registerSolution({ solutionId: 'u2', title: 'U2' });
+    expect(seen.length).toBe(1);
+  });
+
+  it('subscribeToSolution receives Pg-style notify payloads in memory', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    await machine.registerSolution({ solutionId: 'n', title: 'N' });
+    const events: Array<{ to_state: string }> = [];
+    const unsub = await machine.subscribeToSolution('n', (evt) => {
+      events.push({ to_state: evt.to_state });
+    });
+    await machine.advanceSolution('n', 'implemented', {
+      reason: 'r',
+      triggeredBy: SYSTEM,
+    });
+    await unsub();
+    expect(events.map((e) => e.to_state)).toEqual(['implemented']);
+  });
+});
+
+describe('SolutionLifecycleMachine — availableTransitions helpers', () => {
+  it('availableTransitions matches the matrix for a known state', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    const t = machine.availableTransitions('approved');
+    expect(t).toContain('implemented');
+    expect(t).toContain('abandoned');
+    expect(t).toContain('paused');
+  });
+
+  it('canTransition returns boolean', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    expect(machine.canTransition('approved', 'implemented')).toBe(true);
+    expect(machine.canTransition('approved', 'deployed')).toBe(false);
+  });
+
+  it('validNextStates is an alias for availableTransitions', async () => {
+    const { machine } = buildInMemorySolutionMachine();
+    await machine.init();
+    expect(machine.validNextStates('approved')).toEqual(
+      machine.availableTransitions('approved'),
+    );
+  });
+});

--- a/packages/state-machine/tests/solution-states.test.ts
+++ b/packages/state-machine/tests/solution-states.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALL_SOLUTION_STATES,
+  DEFAULT_STUCK_THRESHOLDS_HOURS,
+  FAILED_OF,
+  FORWARD_OF_FAILED,
+  FORWARD_OF_ROLLED_BACK,
+  isSolutionControlState,
+  isSolutionFailedState,
+  isSolutionForwardState,
+  isSolutionRolledBackState,
+  isSolutionState,
+  isSolutionTerminal,
+  ROLLED_BACK_OF,
+  SOLUTION_CONTROL_STATES,
+  SOLUTION_FAILED_STATES,
+  SOLUTION_FORWARD_STATES,
+  SOLUTION_INITIAL_STATE,
+  SOLUTION_ROLLED_BACK_STATES,
+  SOLUTION_STATE_CANONICAL_SYNONYM,
+  SOLUTION_TERMINAL_STATES,
+} from '../src/entities/solution-states.js';
+
+describe('solution-states', () => {
+  it('declares 9 forward states', () => {
+    expect(SOLUTION_FORWARD_STATES).toHaveLength(9);
+    expect(SOLUTION_FORWARD_STATES[0]).toBe('approved');
+    expect(SOLUTION_FORWARD_STATES[SOLUTION_FORWARD_STATES.length - 1]).toBe('done');
+  });
+
+  it('declares 7 failed-state variants (one per non-initial forward state)', () => {
+    expect(SOLUTION_FAILED_STATES).toHaveLength(7);
+    for (const failed of SOLUTION_FAILED_STATES) {
+      expect(failed.endsWith('-failed')).toBe(true);
+    }
+  });
+
+  it('declares 5 rolled-back variants (post-deployment forward states)', () => {
+    expect(SOLUTION_ROLLED_BACK_STATES).toHaveLength(5);
+    for (const rb of SOLUTION_ROLLED_BACK_STATES) {
+      expect(rb.endsWith('-rolled-back')).toBe(true);
+    }
+  });
+
+  it('declares 2 control states: paused + abandoned', () => {
+    expect(SOLUTION_CONTROL_STATES).toEqual(['paused', 'abandoned']);
+  });
+
+  it('ALL_SOLUTION_STATES is the union of the four buckets, with no duplicates', () => {
+    expect(ALL_SOLUTION_STATES).toHaveLength(9 + 7 + 5 + 2);
+    const set = new Set<string>(ALL_SOLUTION_STATES);
+    expect(set.size).toBe(ALL_SOLUTION_STATES.length);
+  });
+
+  it('isSolutionState narrows correctly', () => {
+    expect(isSolutionState('approved')).toBe(true);
+    expect(isSolutionState('producing-metrics')).toBe(true);
+    expect(isSolutionState('producing-metrics-rolled-back')).toBe(true);
+    expect(isSolutionState('not-a-state')).toBe(false);
+    expect(isSolutionState(42)).toBe(false);
+    expect(isSolutionState(null)).toBe(false);
+  });
+
+  it('bucket-narrowing predicates are mutually exclusive', () => {
+    for (const state of ALL_SOLUTION_STATES) {
+      const f = isSolutionForwardState(state) ? 1 : 0;
+      const ff = isSolutionFailedState(state) ? 1 : 0;
+      const rb = isSolutionRolledBackState(state) ? 1 : 0;
+      const c = isSolutionControlState(state) ? 1 : 0;
+      expect(f + ff + rb + c).toBe(1);
+    }
+  });
+
+  it('initial state is "approved"', () => {
+    expect(SOLUTION_INITIAL_STATE).toBe('approved');
+    expect(isSolutionForwardState(SOLUTION_INITIAL_STATE)).toBe(true);
+  });
+
+  it('terminal states are exactly {done, abandoned}', () => {
+    expect(SOLUTION_TERMINAL_STATES).toEqual(['done', 'abandoned']);
+    expect(isSolutionTerminal('done')).toBe(true);
+    expect(isSolutionTerminal('abandoned')).toBe(true);
+    expect(isSolutionTerminal('approved')).toBe(false);
+    expect(isSolutionTerminal('paused')).toBe(false);
+  });
+
+  it('FAILED_OF maps every non-initial forward state to its `*-failed` variant', () => {
+    for (const fwd of SOLUTION_FORWARD_STATES) {
+      if (fwd === 'approved') continue; // no implemented-failed precursor
+      if (fwd === 'done') continue; // done has no -failed sibling; it's terminal
+      const failed = FAILED_OF[fwd as keyof typeof FAILED_OF];
+      expect(failed).toBe(`${fwd}-failed`);
+      expect(isSolutionFailedState(failed!)).toBe(true);
+    }
+  });
+
+  it('FORWARD_OF_FAILED is the inverse of FAILED_OF', () => {
+    for (const failed of SOLUTION_FAILED_STATES) {
+      const fwd = FORWARD_OF_FAILED[failed];
+      expect(fwd).toBe(failed.replace('-failed', ''));
+    }
+  });
+
+  it('ROLLED_BACK_OF covers post-deployment forward states only', () => {
+    expect(Object.keys(ROLLED_BACK_OF)).toEqual([
+      'deployed',
+      'imported',
+      'called-in-test',
+      'called-in-prod',
+      'producing-metrics',
+    ]);
+  });
+
+  it('FORWARD_OF_ROLLED_BACK is the inverse of ROLLED_BACK_OF', () => {
+    for (const rb of SOLUTION_ROLLED_BACK_STATES) {
+      const fwd = FORWARD_OF_ROLLED_BACK[rb];
+      expect(fwd).toBe(rb.replace('-rolled-back', ''));
+    }
+  });
+
+  it('canonical synonyms cover the four states that have a different canonical-doc name', () => {
+    expect(SOLUTION_STATE_CANONICAL_SYNONYM['approved']).toBe('plan-approved');
+    expect(SOLUTION_STATE_CANONICAL_SYNONYM['implemented']).toBe('code-written');
+    expect(SOLUTION_STATE_CANONICAL_SYNONYM['merged']).toBe('pr-merged');
+    expect(SOLUTION_STATE_CANONICAL_SYNONYM['imported']).toBe('built-into-active-app');
+  });
+
+  it('DEFAULT_STUCK_THRESHOLDS_HOURS covers every non-terminal forward state', () => {
+    for (const fwd of SOLUTION_FORWARD_STATES) {
+      if (fwd === 'done') continue;
+      expect(DEFAULT_STUCK_THRESHOLDS_HOURS[fwd]).toBeGreaterThan(0);
+    }
+  });
+
+  it('default thresholds match the canonical manifest numbers', () => {
+    // merged → deployed must be ≤2h (canonical deploy_steward_max_age)
+    expect(DEFAULT_STUCK_THRESHOLDS_HOURS['merged']).toBe(2);
+    // deployed → imported must be ≤4h (canonical usage_steward_max_age)
+    expect(DEFAULT_STUCK_THRESHOLDS_HOURS['deployed']).toBe(4);
+    // imported → called-in-test must be ≤6h (canonical activation_steward_max_age)
+    expect(DEFAULT_STUCK_THRESHOLDS_HOURS['imported']).toBe(6);
+    // called-in-prod → producing-metrics must be ≤24h (canonical outcome_steward_max_age)
+    expect(DEFAULT_STUCK_THRESHOLDS_HOURS['called-in-prod']).toBe(24);
+    // producing-metrics → done must be ≤24h (canonical §6.3 holdover)
+    expect(DEFAULT_STUCK_THRESHOLDS_HOURS['producing-metrics']).toBe(24);
+  });
+});

--- a/packages/state-machine/tests/solution-transitions.test.ts
+++ b/packages/state-machine/tests/solution-transitions.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALL_SOLUTION_STATES,
+  isSolutionTerminal,
+  SOLUTION_FAILED_STATES,
+  SOLUTION_FORWARD_STATES,
+  SOLUTION_ROLLED_BACK_STATES,
+  type SolutionState,
+} from '../src/entities/solution-states.js';
+import {
+  allSolutionEdges,
+  availableSolutionTransitions,
+  canSolutionTransition,
+  checkSolutionTransition,
+  VALID_SOLUTION_TRANSITIONS,
+} from '../src/entities/solution-transitions.js';
+
+describe('solution-transitions', () => {
+  it('every state appears as a key in the transition matrix', () => {
+    for (const state of ALL_SOLUTION_STATES) {
+      expect(VALID_SOLUTION_TRANSITIONS[state]).toBeDefined();
+    }
+  });
+
+  it('terminal states have zero outbound edges', () => {
+    expect(VALID_SOLUTION_TRANSITIONS['done']).toEqual([]);
+    expect(VALID_SOLUTION_TRANSITIONS['abandoned']).toEqual([]);
+  });
+
+  it('forward path is wired left-to-right', () => {
+    for (let i = 0; i < SOLUTION_FORWARD_STATES.length - 1; i++) {
+      const from = SOLUTION_FORWARD_STATES[i] as SolutionState;
+      const to = SOLUTION_FORWARD_STATES[i + 1] as SolutionState;
+      expect(canSolutionTransition(from, to)).toBe(true);
+    }
+  });
+
+  it('skipping forward states is rejected (e.g. approved → merged)', () => {
+    expect(canSolutionTransition('approved', 'merged')).toBe(false);
+    expect(canSolutionTransition('approved', 'deployed')).toBe(false);
+    expect(canSolutionTransition('deployed', 'producing-metrics')).toBe(false);
+  });
+
+  it('self-transitions are rejected', () => {
+    for (const state of SOLUTION_FORWARD_STATES) {
+      expect(canSolutionTransition(state, state)).toBe(false);
+    }
+  });
+
+  it('backward forward transitions are rejected (e.g. deployed → merged)', () => {
+    expect(canSolutionTransition('deployed', 'merged')).toBe(false);
+    expect(canSolutionTransition('producing-metrics', 'called-in-prod')).toBe(false);
+  });
+
+  it('each forward state (except approved + done) has a reachable `*-failed` edge', () => {
+    // From state F_i you can go to F_{i+1}-failed (next state failed).
+    // E.g. approved -> implemented-failed (we tried to implement but failed).
+    for (let i = 0; i < SOLUTION_FORWARD_STATES.length - 1; i++) {
+      const from = SOLUTION_FORWARD_STATES[i] as SolutionState;
+      const nextFailed = `${SOLUTION_FORWARD_STATES[i + 1]}-failed` as SolutionState;
+      if (SOLUTION_FAILED_STATES.includes(nextFailed as never)) {
+        expect(canSolutionTransition(from, nextFailed)).toBe(true);
+      }
+    }
+  });
+
+  it('each `*-failed` state can recover by retrying the forward state', () => {
+    for (const failed of SOLUTION_FAILED_STATES) {
+      const forward = failed.replace('-failed', '') as SolutionState;
+      expect(canSolutionTransition(failed, forward)).toBe(true);
+    }
+  });
+
+  it('each `*-failed` state can also be abandoned', () => {
+    for (const failed of SOLUTION_FAILED_STATES) {
+      expect(canSolutionTransition(failed, 'abandoned')).toBe(true);
+    }
+  });
+
+  it('each `*-rolled-back` state re-enters the forward state OR abandons', () => {
+    for (const rb of SOLUTION_ROLLED_BACK_STATES) {
+      const forward = rb.replace('-rolled-back', '') as SolutionState;
+      expect(canSolutionTransition(rb, forward)).toBe(true);
+      expect(canSolutionTransition(rb, 'abandoned')).toBe(true);
+      // ...but cannot jump elsewhere.
+      expect(canSolutionTransition(rb, 'done')).toBe(false);
+    }
+  });
+
+  it('post-deploy forward states can also regress into their `*-rolled-back` sibling', () => {
+    expect(canSolutionTransition('deployed', 'deployed-rolled-back')).toBe(true);
+    expect(canSolutionTransition('imported', 'imported-rolled-back')).toBe(true);
+    expect(canSolutionTransition('producing-metrics', 'producing-metrics-rolled-back')).toBe(true);
+  });
+
+  it('every non-terminal state can be paused', () => {
+    for (const state of ALL_SOLUTION_STATES) {
+      if (isSolutionTerminal(state)) continue;
+      if (state === 'paused') continue;
+      expect(canSolutionTransition(state, 'paused')).toBe(true);
+    }
+  });
+
+  it('paused can resume into any non-paused, non-terminal forward state', () => {
+    expect(canSolutionTransition('paused', 'approved')).toBe(true);
+    expect(canSolutionTransition('paused', 'merged')).toBe(true);
+    expect(canSolutionTransition('paused', 'abandoned')).toBe(true);
+    // paused cannot exit to itself
+    expect(canSolutionTransition('paused', 'paused')).toBe(false);
+    // paused cannot directly mark done (resume first; done is reached via producing-metrics)
+    expect(canSolutionTransition('paused', 'done')).toBe(false);
+  });
+
+  it('every non-terminal state can be abandoned', () => {
+    for (const state of ALL_SOLUTION_STATES) {
+      if (isSolutionTerminal(state)) continue;
+      expect(canSolutionTransition(state, 'abandoned')).toBe(true);
+    }
+  });
+
+  it('checkSolutionTransition returns structured rejection reason', () => {
+    const r1 = checkSolutionTransition('approved', 'deployed');
+    expect(r1.ok).toBe(false);
+    expect(r1.reason).toContain('not in the solution-lifecycle transition table');
+
+    const r2 = checkSolutionTransition('done', 'approved');
+    expect(r2.ok).toBe(false);
+    expect(r2.reason).toContain('terminal state');
+
+    const r3 = checkSolutionTransition('approved', 'approved');
+    expect(r3.ok).toBe(false);
+    expect(r3.reason).toContain('self-transition');
+
+    const r4 = checkSolutionTransition('approved', 'implemented');
+    expect(r4.ok).toBe(true);
+    expect(r4.reason).toBeUndefined();
+  });
+
+  it('availableSolutionTransitions returns the edges for a given state', () => {
+    const fromApproved = availableSolutionTransitions('approved');
+    expect(fromApproved).toContain('implemented');
+    expect(fromApproved).toContain('paused');
+    expect(fromApproved).toContain('abandoned');
+    expect(fromApproved).toContain('implemented-failed');
+  });
+
+  it('allSolutionEdges enumerates the full FSM (≥40 edges)', () => {
+    const edges = allSolutionEdges();
+    expect(edges.length).toBeGreaterThanOrEqual(40);
+    // No edge from terminal.
+    for (const e of edges) {
+      expect(isSolutionTerminal(e.from)).toBe(false);
+    }
+  });
+
+  it('terminal-state attempts return ok:false with the correct reason', () => {
+    const r1 = checkSolutionTransition('done', 'paused');
+    expect(r1.ok).toBe(false);
+    expect(r1.reason).toContain('done is a terminal state');
+    const r2 = checkSolutionTransition('abandoned', 'approved');
+    expect(r2.ok).toBe(false);
+    expect(r2.reason).toContain('abandoned is a terminal state');
+  });
+});


### PR DESCRIPTION
# `@caia/state-machine` v0.2.0 — Solution lifecycle FSM (Real Definition-of-Done)

Closes the operator's recurring "merged code that's not actively used = not done" feedback (`agent-memory/feedback_real_definition_of_done.md`) by adding a second entity, `Solution`, to `@caia/state-machine`. **Definition-of-Done is `producing-metrics` held + a `done` transition driven by the lifecycle-conductor — not `merged`.**

## States (23 total)

**Forward (9):** `approved → implemented → merged → deployed → imported → called-in-test → called-in-prod → producing-metrics → done`

**Failed (7):** `<stage>-failed` for each non-initial forward state. Recovery → retry forward OR abandon.

**Rolled-back (5):** post-deployment drift variants. `deployed-rolled-back` … `producing-metrics-rolled-back`. Recovery → re-enter forward OR abandon.

**Control (2):** `paused` (orthogonal, restores prior_state on resume), `abandoned` (terminal-failure, operator-driven).

Operator vocabulary is mapped to the canonical research-doc vocabulary via `SOLUTION_STATE_CANONICAL_SYNONYM` (`approved ↔ plan-approved`, `implemented ↔ code-written`, `merged ↔ pr-merged`, `imported ↔ built-into-active-app`). Both names are exported.

## API surface (per operator prompt)

```ts
machine.registerSolution(plan)              // EA Agent on approval
machine.advanceSolution(id, to, opts)       // each steward on green attestation
machine.getSolutionLifecycle(id)            // snapshot + history + ageHoursInState
machine.getStuckSolutions(thresholds?)      // emits solution.stuck per result
machine.pauseSolution / resumeSolution / abandonSolution
machine.subscribeToSolution(id, handler)    // DB LISTEN/NOTIFY
machine.on('solution.advanced'|'solution.stuck'|'solution.completed', handler)
```

## Concurrency contract (the "two stewards racing" case)

`advanceSolution` runs under a per-solution advisory lock + optimistic-`version` check, mirroring the project FSM's `transitionAtomic`. **Exactly one steward wins; the loser sees `InvalidSolutionTransitionError` because the prerequisite forward state was not reached** — e.g. `usage-steward` cannot advance `merged → imported` until `deploy-steward` has reached `deployed`. Covered by an integration test (`solution-integration.test.ts > usage-steward cannot advance merged → imported …`).

## Storage

- `caia_meta.solution_lifecycle` (one row per solution; optimistic-`version` + advisory lock)
- `caia_meta.solution_history` (append-only; unique on `(solution_id, to_state, payload_hash)` for idempotent replay)
- LISTEN/NOTIFY trigger fires on every history insert
- Migration: `packages/state-machine/migrations/0002_solution_lifecycle.sql` (idempotent; applied by `PgSolutionStore.init()`)

## Events (per ADR-011 / ADR-029)

Namespace: `solution-lifecycle`. Types:

| Operator vocabulary | Canonical-doc alias | Emitted when |
|---|---|---|
| `solution.advanced` | `solution.state-transitioned` | every transition |
| `solution.stuck` | `solution.stuck` | `getStuckSolutions()` finds a result |
| `solution.completed` | `solution.done` | transition to `done` |

Default per-state stuck thresholds (hours) come from `research/real_definition_of_done_enforcement_2026.md` §5 manifest: deploy 2h / usage 4h / activation 6h / outcome 24h / producing-metrics→done 24h.

## Tests + typecheck

**183 tests pass, 0 failures.** 77 new solution-lifecycle tests (≥50 bar met):

| File | Tests | Coverage |
|---|---|---|
| `solution-states.test.ts` | 16 | state declaration + bucket-narrowing predicates + canonical synonyms + default thresholds |
| `solution-transitions.test.ts` | 18 | every legal forward + recovery + regression edge; all common illegals rejected; terminal exit set; `paused` reachable from every non-terminal incl. failed + rolled-back |
| `solution-lifecycle.test.ts` | 36 | register/advance/get/pause/resume/abandon + optimistic concurrency + idempotency + event emission + stuck detection (default + numeric + per-state overrides) + paused/terminal exclusion + event subscription |
| `solution-integration.test.ts` | 7 | full 9-state walkthrough with one steward attestation per transition; `deployed-failed → deployed` recovery; `called-in-prod → -rolled-back → called-in-prod` regression; **two-steward race (usage cannot skip ahead of deploy)**; same-transition tie collapse to idempotent replay; optimistic-lock retry count surfaces; standalone constructor smoke |

`tsc --noEmit` clean under `strict` + `exactOptionalPropertyTypes` + `noUncheckedIndexedAccess` + `noImplicitOverride`.

## EA Agent review

Plan markdown at `research/plan_state_machine_solution_lifecycle_2026.md`. Two `submitPlan` attempts via `@caia/ea-architect` resulted in claude-spawner infrastructure errors (90s timeout, then `exit 1` with no stderr — upstream LLM availability, not a content rejection). Re-submission script: `packages/state-machine/scripts/submit-plan.mjs`.

## Dogfood

`packages/state-machine/scripts/dogfood-register-ea-coordinator.mjs` registers the EA Coordinator framework build as the first `Solution` in production. Run with `PG_DSN=postgresql://… node scripts/dogfood-register-ea-coordinator.mjs` once the migration has been applied to live `caia_meta`.

## Downstream wiring (sibling tasks, NOT in this PR)

- `@caia/pipeline-conductor` → subscribes to `solution.stuck` → INBOX
- `@caia/deploy-steward` → `advanceSolution(merged → deployed)`
- `@caia/usage-steward` → `advanceSolution(deployed → imported)`
- `@caia/activation-steward` → `advanceSolution(imported → called-in-test/-in-prod)`
- `@caia/outcome-steward` → `advanceSolution(called-in-prod → producing-metrics)`
- `@caia/lifecycle-conductor` → drives `producing-metrics → done` after ≥24h holdover

## True-Zero on caia — admin-merge

Per operator policy, this PR auto-admin-merges once green.
