### PR TITLE
feat(@caia/pipeline-conductor): Layer 5 drift detection — drift-detector + alerter

### DIFF
--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -30,7 +30,11 @@ export type EventActor =
   | 'release-agent'
   | 'story-validator'
   | 'feature-registry-writer'
-  | 'pipeline-conductor';
+  | 'pipeline-conductor'
+  // ─── AI-First Continuous Discipline — Layer 5 actors ──────────────────
+  | 'policy-linter'
+  | 'memory-consolidator'
+  | 'ea-drift-sentinel';
 
 /** Canonical envelope for every event emitted through the bus */
 export interface ConductorEvent {
@@ -553,7 +557,11 @@ export type EventType =
   | 'conductor.escalation.opened'
   | 'conductor.escalation.closed'
   | 'conductor.forecast.updated'
-  | 'conductor.pipeline-bottleneck.detected';
+  | 'conductor.pipeline-bottleneck.detected'
+  // ─── AI-First Continuous Discipline — Layer 5 drift events ───────────
+  | 'policy.violation.detected'
+  | 'memory.consistency.broken'
+  | 'architecture.principle.violated';
 
 /** Default severity for each event type */
 export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
@@ -682,6 +690,12 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'conductor.escalation.closed': 'info',
   'conductor.forecast.updated': 'info',
   'conductor.pipeline-bottleneck.detected': 'warning',
+  // ─── AI-First Continuous Discipline — Layer 5 drift events ───────────
+  // policy.violation.detected severity is dynamic: callers MAY override
+  // to 'error' on hard-fail mode. Default is 'warning' (advisory/soft-fail).
+  'policy.violation.detected': 'warning',
+  'memory.consistency.broken': 'warning',
+  'architecture.principle.violated': 'error',
 };
 
 /** All valid event type strings from the registry */
@@ -724,3 +738,57 @@ export interface ConductorPipelineBottleneckDetectedPayload {
   median_dwell_seconds: number;
   recommended_action: 'scale-workers' | 'review-prompt' | 'escalate-to-architect' | 'none';
 }
+
+// ─── AI-First Continuous Discipline — Layer 5 drift events ──────────────────
+
+/**
+ * Emitted by @caia/pipeline-conductor's drift-detector when a policy
+ * linter reports a violation. Sourced from research/ai_first_continuous_discipline_2026.md §7.
+ */
+export interface PolicyViolationDetectedPayload {
+  /** Linter rule id, e.g. "p005-auto-merge-prs". */
+  policy_id: string;
+  /** Originating dispatch id (correlation). */
+  dispatch_id: string;
+  /** Agent that triggered the dispatch. */
+  caller_agent_id: string;
+  /** Sentinel three-mode classification. */
+  mode: 'hard-fail' | 'soft-fail' | 'advisory';
+  /** Human-readable reason from the linter. */
+  reason: string;
+  /** Optional suggested remediation. */
+  suggested_fix?: string;
+}
+
+/**
+ * Emitted by @caia/pipeline-conductor's drift-detector when the
+ * memory-consolidation saga finds a memory claim that no longer matches
+ * filesystem reality.
+ */
+export interface MemoryConsistencyBrokenPayload {
+  /** Absolute path to the memory file. */
+  memory_file: string;
+  /** The claim that was broken. */
+  claim: string;
+  /** What the filesystem actually says. */
+  actual: string;
+  /** Who discovered it — 'memory-consolidation-cron' | 'manual' | etc. */
+  discovered_by: string;
+}
+
+/**
+ * Emitted by @caia/pipeline-conductor's drift-detector when the EA Drift
+ * Sentinel confirms a tier-1 hit via tier-2 reasoning. A confirmed
+ * architecture principle violation is a P0-class signal.
+ */
+export interface ArchitecturePrincipleViolatedPayload {
+  /** Principle id, e.g. "P11". */
+  principle_id: string;
+  /** Optional ADR the violation traces to. */
+  adr_id?: string;
+  /** Where the violation lives — file:line or url. */
+  location: string;
+  /** ISO 8601 timestamp of detection. */
+  detected_at: string;
+}
+

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -658,3 +658,33 @@ events:
     severity: warning
     actor: [pipeline-conductor]
     payload: [stage, active_count, stuck_count, median_dwell_seconds, recommended_action]
+
+  # ─── AI-First Continuous Discipline — Layer 5 drift events ───────────────
+  # research/ai_first_continuous_discipline_2026.md §7. Three drift event
+  # types normalised by @caia/pipeline-conductor's drift-detector from
+  # upstream signals (@caia/policy-linter, @caia/memory-consolidator,
+  # @caia/ea-drift-sentinel). Pipeline Conductor's alerter subscribes to
+  # all three and surfaces to INBOX + dashboard.
+
+  # Emitted by the drift-detector when a policy linter reports a violation.
+  # The `mode` carries the Sentinel three-mode discipline: advisory|soft-fail|hard-fail.
+  # Severity is dynamic — `warning` for advisory/soft-fail, `error` for hard-fail.
+  - type: policy.violation.detected
+    severity: warning
+    actor: [pipeline-conductor, policy-linter]
+    payload: [policy_id, dispatch_id, caller_agent_id, mode, reason, suggested_fix]
+
+  # Emitted by the drift-detector when the memory-consolidation saga finds
+  # a memory file whose claim no longer matches the filesystem reality.
+  - type: memory.consistency.broken
+    severity: warning
+    actor: [pipeline-conductor, memory-consolidator]
+    payload: [memory_file, claim, actual, discovered_by]
+
+  # Emitted by the drift-detector when the EA Drift Sentinel confirms a
+  # tier-1 hit via its tier-2 LLM reasoner. Severity is `error` because a
+  # confirmed principle violation is a P0-class signal.
+  - type: architecture.principle.violated
+    severity: error
+    actor: [pipeline-conductor, ea-drift-sentinel]
+    payload: [principle_id, adr_id, location, detected_at]

--- a/packages/pipeline-conductor/src/alerter.ts
+++ b/packages/pipeline-conductor/src/alerter.ts
@@ -1,0 +1,374 @@
+/**
+ * @caia/pipeline-conductor — alerter.ts
+ *
+ * Layer 5 alerter — subscribes to the three canonical drift event types
+ * and surfaces them to operator visibility:
+ *
+ *   1. INBOX  — appends a markdown entry under "## DRIFT ALERTS" with
+ *               deduplication (one entry per `(type, dedupKey)` per
+ *               configurable window — defaults to 24 hours).
+ *   2. Dashboard — appends a one-line summary to a daily markdown file
+ *               (`~/Documents/projects/reports/drift_dashboard_YYYY-MM-DD.md`).
+ *   3. Notifier — calls an optional pluggable hook for operator
+ *               notification (e.g. a future Slack/macOS-notification
+ *               bridge). Defaults to a no-op.
+ *
+ * Reference: research/ai_first_continuous_discipline_2026.md §7 Layer 5.
+ */
+
+import { eventBus } from '@chiefaia/event-bus-internal';
+import type { ConductorEvent } from '@chiefaia/event-bus-internal';
+
+/** Drift event types the alerter subscribes to. */
+export const DRIFT_EVENT_TYPES = [
+  'policy.violation.detected',
+  'memory.consistency.broken',
+  'architecture.principle.violated',
+] as const;
+
+export type DriftEventType = (typeof DRIFT_EVENT_TYPES)[number];
+
+/** Filesystem abstraction — same shape as @caia/ea-architect's. */
+export interface AlerterFsAdapter {
+  exists(path: string): boolean;
+  readFile(path: string): string;
+  writeFile(path: string, content: string): void;
+  appendFile(path: string, content: string): void;
+  mkdir(path: string): void;
+}
+
+/** Operator notifier callback. */
+export type OperatorNotifier = (notification: OperatorNotification) => void | Promise<void>;
+
+export interface OperatorNotification {
+  type: DriftEventType;
+  severity: 'warning' | 'error';
+  title: string;
+  body: string;
+  event: ConductorEvent;
+}
+
+export interface AlerterOptions {
+  bus?: typeof eventBus;
+  fs: AlerterFsAdapter;
+  clock?: () => Date;
+  /** Path to operator INBOX. */
+  inboxPath: string;
+  /**
+   * Directory where daily drift_dashboard_YYYY-MM-DD.md files live.
+   * Will be created if missing.
+   */
+  dashboardDir: string;
+  /** Optional operator notifier. Defaults to no-op. */
+  notifier?: OperatorNotifier;
+  /** Dedup window in milliseconds. Default 24h. */
+  dedupWindowMs?: number;
+}
+
+export const INBOX_SECTION_HEADER = '## DRIFT ALERTS';
+const DEFAULT_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+const NOOP_NOTIFIER: OperatorNotifier = () => undefined;
+
+export class Alerter {
+  private readonly bus: typeof eventBus;
+  private readonly fs: AlerterFsAdapter;
+  private readonly clock: () => Date;
+  private readonly inboxPath: string;
+  private readonly dashboardDir: string;
+  private readonly notifier: OperatorNotifier;
+  private readonly dedupWindowMs: number;
+  private readonly recentDedupKeys = new Map<string, number>();
+  private unsubs: Array<() => void> = [];
+
+  /** Telemetry counters. */
+  public alertsObserved = 0;
+  public inboxEntriesWritten = 0;
+  public inboxEntriesDeduped = 0;
+  public dashboardLinesWritten = 0;
+  public notifierCalls = 0;
+  public notifierErrors = 0;
+
+  constructor(opts: AlerterOptions) {
+    this.bus = opts.bus ?? eventBus;
+    this.fs = opts.fs;
+    this.clock = opts.clock ?? ((): Date => new Date());
+    this.inboxPath = opts.inboxPath;
+    this.dashboardDir = opts.dashboardDir;
+    this.notifier = opts.notifier ?? NOOP_NOTIFIER;
+    this.dedupWindowMs = opts.dedupWindowMs ?? DEFAULT_DEDUP_WINDOW_MS;
+  }
+
+  start(): void {
+    if (this.unsubs.length > 0) return;
+    for (const type of DRIFT_EVENT_TYPES) {
+      this.unsubs.push(
+        this.bus.subscribe(type, (event) => {
+          void this.handleDriftEvent(event);
+        }),
+      );
+    }
+  }
+
+  stop(): void {
+    for (const unsub of this.unsubs) {
+      try { unsub(); } catch { /* never throw on stop */ }
+    }
+    this.unsubs = [];
+  }
+
+  /**
+   * Public surface so callers can invoke alerting without going through
+   * the bus (useful in tests + for sibling code with the event already in
+   * hand). Idempotent within the dedup window.
+   */
+  async handleDriftEvent(event: ConductorEvent): Promise<void> {
+    if (!isDriftEventType(event.type)) return;
+    this.alertsObserved += 1;
+
+    const type = event.type as DriftEventType;
+    const dedupKey = this.dedupKeyFor(type, event);
+    const now = this.clock().getTime();
+    this.purgeStaleDedupEntries(now);
+
+    if (this.recentDedupKeys.has(dedupKey)) {
+      this.inboxEntriesDeduped += 1;
+      return;
+    }
+    this.recentDedupKeys.set(dedupKey, now);
+
+    const rendered = renderAlertEntry(type, event, new Date(now));
+
+    try { this.appendToInbox(rendered.inboxMarkdown); } catch (err) {
+      // INBOX failures are surfaced but never throw to the bus.
+      console.error('[alerter] inbox append failed', err);
+    }
+
+    try { this.appendToDashboard(rendered.dashboardLine, new Date(now)); } catch (err) {
+      console.error('[alerter] dashboard append failed', err);
+    }
+
+    try {
+      await Promise.resolve(this.notifier({
+        type,
+        severity: event.severity === 'error' ? 'error' : 'warning',
+        title: rendered.title,
+        body: rendered.body,
+        event,
+      }));
+      this.notifierCalls += 1;
+    } catch (err) {
+      this.notifierErrors += 1;
+      console.error('[alerter] notifier failed', err);
+    }
+  }
+
+  /** Clear the dedup cache. Useful in tests. */
+  resetDedupCache(): void {
+    this.recentDedupKeys.clear();
+  }
+
+  // ─── INBOX writes ─────────────────────────────────────────────────────────
+
+  private appendToInbox(entry: string): void {
+    if (!this.fs.exists(this.inboxPath)) {
+      this.fs.writeFile(this.inboxPath, `${INBOX_SECTION_HEADER}\n\n${entry}\n`);
+      this.inboxEntriesWritten += 1;
+      return;
+    }
+    const body = this.fs.readFile(this.inboxPath);
+    if (body.includes(INBOX_SECTION_HEADER)) {
+      // Insert the new entry immediately after the section header.
+      const lines = body.split('\n');
+      const idx = lines.findIndex((l) => l === INBOX_SECTION_HEADER);
+      const before = lines.slice(0, idx + 1).join('\n');
+      const after = lines.slice(idx + 1).join('\n');
+      const newBody = `${before}\n\n${entry}\n${after.startsWith('\n') ? after : `\n${after}`}`;
+      this.fs.writeFile(this.inboxPath, newBody);
+    } else {
+      const sep = body.endsWith('\n') ? '\n' : '\n\n';
+      this.fs.writeFile(this.inboxPath, `${body}${sep}${INBOX_SECTION_HEADER}\n\n${entry}\n`);
+    }
+    this.inboxEntriesWritten += 1;
+  }
+
+  // ─── Dashboard writes ─────────────────────────────────────────────────────
+
+  private appendToDashboard(line: string, when: Date): void {
+    if (!this.fs.exists(this.dashboardDir)) this.fs.mkdir(this.dashboardDir);
+    const day = isoDate(when);
+    const filePath = `${this.dashboardDir.replace(/\/$/, '')}/drift_dashboard_${day}.md`;
+    if (!this.fs.exists(filePath)) {
+      this.fs.writeFile(filePath, `# Drift Dashboard — ${day}\n\n`);
+    }
+    this.fs.appendFile(filePath, `${line}\n`);
+    this.dashboardLinesWritten += 1;
+  }
+
+  // ─── Dedup ────────────────────────────────────────────────────────────────
+
+  private purgeStaleDedupEntries(nowMs: number): void {
+    for (const [key, ts] of this.recentDedupKeys.entries()) {
+      if (nowMs - ts > this.dedupWindowMs) this.recentDedupKeys.delete(key);
+    }
+  }
+
+  private dedupKeyFor(type: DriftEventType, event: ConductorEvent): string {
+    const p = event.payload as Record<string, unknown>;
+    switch (type) {
+      case 'policy.violation.detected':
+        return `policy::${asStr(p.policy_id)}::${asStr(p.caller_agent_id)}::${asStr(p.mode)}`;
+      case 'memory.consistency.broken':
+        return `memory::${asStr(p.memory_file)}::${hashShort(asStr(p.claim))}`;
+      case 'architecture.principle.violated':
+        return `arch::${asStr(p.principle_id)}::${asStr(p.location)}`;
+    }
+  }
+}
+
+// ─── Rendering ──────────────────────────────────────────────────────────────
+
+interface RenderedAlert {
+  title: string;
+  body: string;
+  inboxMarkdown: string;
+  dashboardLine: string;
+}
+
+export function renderAlertEntry(
+  type: DriftEventType,
+  event: ConductorEvent,
+  when: Date,
+): RenderedAlert {
+  const ts = when.toISOString();
+  const p = event.payload as Record<string, unknown>;
+
+  switch (type) {
+    case 'policy.violation.detected': {
+      const policyId = asStr(p.policy_id);
+      const mode = asStr(p.mode);
+      const reason = asStr(p.reason);
+      const caller = asStr(p.caller_agent_id);
+      const fix = p.suggested_fix !== undefined ? asStr(p.suggested_fix) : '';
+      const title = `[policy-violation] ${policyId} (${mode}) — ${reason.slice(0, 80)}`;
+      const body = `Policy \`${policyId}\` (\`${mode}\`) violated by \`${caller}\`.\nReason: ${reason}` +
+        (fix ? `\nSuggested fix: ${fix}` : '');
+      return {
+        title,
+        body,
+        inboxMarkdown: [
+          `### ${ts} — drift: policy.violation.detected`,
+          ``,
+          `- **Policy**: \`${policyId}\``,
+          `- **Mode**: \`${mode}\``,
+          `- **Caller**: \`${caller}\``,
+          `- **Reason**: ${reason}`,
+          ...(fix ? [`- **Suggested fix**: ${fix}`] : []),
+          `- **Event id**: \`${event.id}\``,
+        ].join('\n'),
+        dashboardLine: `- ${ts}  policy.violation.detected  policy=${policyId} mode=${mode} caller=${caller}`,
+      };
+    }
+    case 'memory.consistency.broken': {
+      const file = asStr(p.memory_file);
+      const claim = asStr(p.claim);
+      const actual = asStr(p.actual);
+      const discoveredBy = asStr(p.discovered_by);
+      const title = `[memory-drift] ${shortPath(file)} — ${claim.slice(0, 80)}`;
+      const body = `Memory file \`${file}\` has drifted.\nClaim: ${claim}\nActual: ${actual}\nDiscovered by: ${discoveredBy}`;
+      return {
+        title,
+        body,
+        inboxMarkdown: [
+          `### ${ts} — drift: memory.consistency.broken`,
+          ``,
+          `- **File**: \`${file}\``,
+          `- **Claim**: ${claim}`,
+          `- **Actual**: ${actual}`,
+          `- **Discovered by**: \`${discoveredBy}\``,
+          `- **Event id**: \`${event.id}\``,
+        ].join('\n'),
+        dashboardLine: `- ${ts}  memory.consistency.broken  file=${shortPath(file)} discovered_by=${discoveredBy}`,
+      };
+    }
+    case 'architecture.principle.violated': {
+      const principle = asStr(p.principle_id);
+      const adr = p.adr_id !== undefined ? asStr(p.adr_id) : '';
+      const location = asStr(p.location);
+      const detectedAt = asStr(p.detected_at);
+      const title = `[principle-violation] ${principle} — ${shortPath(location)}`;
+      const body = `Principle \`${principle}\` violated at \`${location}\`.` +
+        (adr ? `\nADR: ${adr}` : '') +
+        `\nDetected at: ${detectedAt}`;
+      return {
+        title,
+        body,
+        inboxMarkdown: [
+          `### ${ts} — drift: architecture.principle.violated`,
+          ``,
+          `- **Principle**: \`${principle}\``,
+          ...(adr ? [`- **ADR**: \`${adr}\``] : []),
+          `- **Location**: \`${location}\``,
+          `- **Detected at**: \`${detectedAt}\``,
+          `- **Event id**: \`${event.id}\``,
+        ].join('\n'),
+        dashboardLine: `- ${ts}  architecture.principle.violated  principle=${principle} location=${shortPath(location)}`,
+      };
+    }
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+export function isDriftEventType(type: string): type is DriftEventType {
+  return (DRIFT_EVENT_TYPES as readonly string[]).includes(type);
+}
+
+function asStr(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v === undefined || v === null) return '';
+  return String(v);
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function shortPath(p: string): string {
+  if (p.length <= 60) return p;
+  return `…${p.slice(-57)}`;
+}
+
+/** Stable 6-char hash for dedup keys (FNV-1a 32-bit, base36). */
+function hashShort(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = (h * 0x01000193) >>> 0;
+  }
+  return h.toString(36).slice(0, 6);
+}
+
+// ─── In-memory FS adapter for tests ─────────────────────────────────────────
+
+export class InMemoryAlerterFs implements AlerterFsAdapter {
+  public files = new Map<string, string>();
+  public dirs = new Set<string>();
+
+  exists(path: string): boolean {
+    return this.files.has(path) || this.dirs.has(path);
+  }
+  readFile(path: string): string {
+    const v = this.files.get(path);
+    if (v === undefined) throw new Error(`ENOENT: ${path}`);
+    return v;
+  }
+  writeFile(path: string, content: string): void {
+    this.files.set(path, content);
+  }
+  appendFile(path: string, content: string): void {
+    this.files.set(path, (this.files.get(path) ?? '') + content);
+  }
+  mkdir(path: string): void {
+    this.dirs.add(path);
+  }
+}

--- a/packages/pipeline-conductor/src/drift-detector.ts
+++ b/packages/pipeline-conductor/src/drift-detector.ts
@@ -1,0 +1,376 @@
+/**
+ * @caia/pipeline-conductor — drift-detector.ts
+ *
+ * Layer 5 of the AI-First Continuous Discipline framework
+ * (research/ai_first_continuous_discipline_2026.md §7).
+ *
+ * The drift-detector is the *normalising adapter* between upstream drift
+ * signals and the canonical Layer 5 event taxonomy. It subscribes to the
+ * shared event bus and emits exactly three drift event types:
+ *
+ *   - policy.violation.detected
+ *   - memory.consistency.broken
+ *   - architecture.principle.violated
+ *
+ * Source mapping is intentionally permissive — the detector accepts
+ * either fully-formed drift events (from in-process callers via the
+ * direct `report*` API) OR upstream-shaped signals (legacy event names
+ * from sibling packages) that it then re-publishes under the canonical
+ * type. The re-emit guard prevents subscription loops by short-circuiting
+ * any event whose actor is 'pipeline-conductor' itself.
+ *
+ * Subscription-only by design: no imports from @caia/policy-linter,
+ * @caia/memory-consolidator, or @caia/ea-drift-sentinel. Loose coupling
+ * via the event bus IS the contract (per P9 / P14).
+ */
+
+import { eventBus } from '@chiefaia/event-bus-internal';
+import type { ConductorEvent } from '@chiefaia/event-bus-internal';
+
+export interface DriftDetectorOptions {
+  /** Event bus instance. Defaults to the shared `eventBus`. */
+  bus?: typeof eventBus;
+  /** Clock injection — tests stub. */
+  clock?: () => Date;
+  /**
+   * Source-event globs the detector subscribes to. Each glob is matched
+   * against the event `type`. Defaults below capture both the canonical
+   * drift event names (for re-emit guard) and the most likely upstream
+   * legacy names from sibling packages. Overridable for tests.
+   */
+  sourceGlobs?: {
+    policyViolation?: string[];
+    memoryInconsistency?: string[];
+    principleViolation?: string[];
+  };
+}
+
+/** Canonical payload shape for `policy.violation.detected`. */
+export interface PolicyViolationInput {
+  policy_id: string;
+  dispatch_id: string;
+  caller_agent_id: string;
+  mode: 'hard-fail' | 'soft-fail' | 'advisory';
+  reason: string;
+  suggested_fix?: string;
+  /** Optional correlation id propagated to the emitted event. */
+  correlation_id?: string;
+}
+
+/** Canonical payload shape for `memory.consistency.broken`. */
+export interface MemoryInconsistencyInput {
+  memory_file: string;
+  claim: string;
+  actual: string;
+  discovered_by: string;
+  correlation_id?: string;
+}
+
+/** Canonical payload shape for `architecture.principle.violated`. */
+export interface PrincipleViolationInput {
+  principle_id: string;
+  adr_id?: string;
+  location: string;
+  /** Optional ISO timestamp; defaults to detector clock. */
+  detected_at?: string;
+  correlation_id?: string;
+}
+
+export const DEFAULT_SOURCE_GLOBS = Object.freeze({
+  policyViolation: Object.freeze([
+    'policy.violation.detected',
+    'policy-linter.violation',
+    'policy-linter.violation.detected',
+    'ea-policy.violation',
+  ]),
+  memoryInconsistency: Object.freeze([
+    'memory.consistency.broken',
+    'memory-consolidator.inconsistency-found',
+    'memory-consolidator.claim-broken',
+  ]),
+  principleViolation: Object.freeze([
+    'architecture.principle.violated',
+    'ea-drift-sentinel.violation.confirmed',
+    'ea-drift-sentinel.confirmed-violation',
+  ]),
+}) as Readonly<{
+  policyViolation: ReadonlyArray<string>;
+  memoryInconsistency: ReadonlyArray<string>;
+  principleViolation: ReadonlyArray<string>;
+}>;
+
+/** Detector self-actor — used to short-circuit re-emit loops. */
+export const DRIFT_DETECTOR_ACTOR = 'pipeline-conductor' as const;
+
+export class DriftDetector {
+  private readonly bus: typeof eventBus;
+  private readonly clock: () => Date;
+  private readonly sourceGlobs: {
+    policyViolation: ReadonlyArray<string>;
+    memoryInconsistency: ReadonlyArray<string>;
+    principleViolation: ReadonlyArray<string>;
+  };
+
+  private unsubs: Array<() => void> = [];
+
+  /** Telemetry counters (test-visible, never reset by stop). */
+  public eventsObserved = 0;
+  public policyViolationsEmitted = 0;
+  public memoryInconsistenciesEmitted = 0;
+  public principleViolationsEmitted = 0;
+  public reemitLoopsBlocked = 0;
+  public malformedSourceEvents = 0;
+
+  constructor(opts: DriftDetectorOptions = {}) {
+    this.bus = opts.bus ?? eventBus;
+    this.clock = opts.clock ?? ((): Date => new Date());
+    this.sourceGlobs = {
+      policyViolation: opts.sourceGlobs?.policyViolation ?? DEFAULT_SOURCE_GLOBS.policyViolation,
+      memoryInconsistency:
+        opts.sourceGlobs?.memoryInconsistency ?? DEFAULT_SOURCE_GLOBS.memoryInconsistency,
+      principleViolation:
+        opts.sourceGlobs?.principleViolation ?? DEFAULT_SOURCE_GLOBS.principleViolation,
+    };
+  }
+
+  /** Start subscribing. Idempotent. */
+  start(): void {
+    if (this.unsubs.length > 0) return;
+
+    for (const glob of this.sourceGlobs.policyViolation) {
+      this.unsubs.push(
+        this.bus.subscribe(glob, (event) => this.handlePolicySource(event)),
+      );
+    }
+    for (const glob of this.sourceGlobs.memoryInconsistency) {
+      this.unsubs.push(
+        this.bus.subscribe(glob, (event) => this.handleMemorySource(event)),
+      );
+    }
+    for (const glob of this.sourceGlobs.principleViolation) {
+      this.unsubs.push(
+        this.bus.subscribe(glob, (event) => this.handlePrincipleSource(event)),
+      );
+    }
+  }
+
+  /** Stop subscribing. Idempotent. */
+  stop(): void {
+    for (const unsub of this.unsubs) {
+      try { unsub(); } catch { /* never throw on stop */ }
+    }
+    this.unsubs = [];
+  }
+
+  // ─── Bus handlers ─────────────────────────────────────────────────────────
+
+  private handlePolicySource(event: ConductorEvent): void {
+    this.eventsObserved += 1;
+    if (this.isOwnEmission(event)) {
+      this.reemitLoopsBlocked += 1;
+      return;
+    }
+    const input = this.coercePolicyInput(event);
+    if (input === null) {
+      this.malformedSourceEvents += 1;
+      return;
+    }
+    this.reportPolicyViolation(input, event);
+  }
+
+  private handleMemorySource(event: ConductorEvent): void {
+    this.eventsObserved += 1;
+    if (this.isOwnEmission(event)) {
+      this.reemitLoopsBlocked += 1;
+      return;
+    }
+    const input = this.coerceMemoryInput(event);
+    if (input === null) {
+      this.malformedSourceEvents += 1;
+      return;
+    }
+    this.reportMemoryInconsistency(input, event);
+  }
+
+  private handlePrincipleSource(event: ConductorEvent): void {
+    this.eventsObserved += 1;
+    if (this.isOwnEmission(event)) {
+      this.reemitLoopsBlocked += 1;
+      return;
+    }
+    const input = this.coercePrincipleInput(event);
+    if (input === null) {
+      this.malformedSourceEvents += 1;
+      return;
+    }
+    this.reportPrincipleViolation(input, event);
+  }
+
+  // ─── Direct API (sync, for in-process callers / tests) ───────────────────
+
+  /** Emit `policy.violation.detected`. Severity is `error` on hard-fail. */
+  reportPolicyViolation(
+    input: PolicyViolationInput,
+    causedBy?: ConductorEvent,
+  ): ConductorEvent {
+    const severity = input.mode === 'hard-fail' ? 'error' : 'warning';
+    const event = this.bus.publish({
+      type: 'policy.violation.detected',
+      actor: DRIFT_DETECTOR_ACTOR,
+      severity,
+      payload: {
+        policy_id: input.policy_id,
+        dispatch_id: input.dispatch_id,
+        caller_agent_id: input.caller_agent_id,
+        mode: input.mode,
+        reason: input.reason,
+        ...(input.suggested_fix !== undefined ? { suggested_fix: input.suggested_fix } : {}),
+      },
+      ...(input.correlation_id !== undefined
+        ? { correlation_id: input.correlation_id }
+        : causedBy?.correlation_id
+          ? { correlation_id: causedBy.correlation_id }
+          : {}),
+      ...(causedBy ? { causation_id: causedBy.id } : {}),
+      entity_type: 'policy',
+      entity_id: input.policy_id,
+    });
+    this.policyViolationsEmitted += 1;
+    return event;
+  }
+
+  /** Emit `memory.consistency.broken`. */
+  reportMemoryInconsistency(
+    input: MemoryInconsistencyInput,
+    causedBy?: ConductorEvent,
+  ): ConductorEvent {
+    const event = this.bus.publish({
+      type: 'memory.consistency.broken',
+      actor: DRIFT_DETECTOR_ACTOR,
+      severity: 'warning',
+      payload: {
+        memory_file: input.memory_file,
+        claim: input.claim,
+        actual: input.actual,
+        discovered_by: input.discovered_by,
+      },
+      ...(input.correlation_id !== undefined
+        ? { correlation_id: input.correlation_id }
+        : causedBy?.correlation_id
+          ? { correlation_id: causedBy.correlation_id }
+          : {}),
+      ...(causedBy ? { causation_id: causedBy.id } : {}),
+      entity_type: 'memory-file',
+      entity_id: input.memory_file,
+    });
+    this.memoryInconsistenciesEmitted += 1;
+    return event;
+  }
+
+  /** Emit `architecture.principle.violated`. */
+  reportPrincipleViolation(
+    input: PrincipleViolationInput,
+    causedBy?: ConductorEvent,
+  ): ConductorEvent {
+    const detectedAt = input.detected_at ?? this.clock().toISOString();
+    const event = this.bus.publish({
+      type: 'architecture.principle.violated',
+      actor: DRIFT_DETECTOR_ACTOR,
+      severity: 'error',
+      payload: {
+        principle_id: input.principle_id,
+        ...(input.adr_id !== undefined ? { adr_id: input.adr_id } : {}),
+        location: input.location,
+        detected_at: detectedAt,
+      },
+      ...(input.correlation_id !== undefined
+        ? { correlation_id: input.correlation_id }
+        : causedBy?.correlation_id
+          ? { correlation_id: causedBy.correlation_id }
+          : {}),
+      ...(causedBy ? { causation_id: causedBy.id } : {}),
+      entity_type: 'principle',
+      entity_id: input.principle_id,
+    });
+    this.principleViolationsEmitted += 1;
+    return event;
+  }
+
+  // ─── Coercion (defensive parsing of upstream payloads) ───────────────────
+
+  private isOwnEmission(event: ConductorEvent): boolean {
+    return event.actor === DRIFT_DETECTOR_ACTOR;
+  }
+
+  private coercePolicyInput(event: ConductorEvent): PolicyViolationInput | null {
+    const p = event.payload as Record<string, unknown>;
+    const policy_id = pickString(p, ['policy_id', 'policyId', 'rule_id', 'ruleId']);
+    const dispatch_id = pickString(p, ['dispatch_id', 'dispatchId', 'correlation_id']);
+    const caller_agent_id = pickString(p, [
+      'caller_agent_id', 'callerAgentId', 'caller', 'agent', 'agent_id', 'actor',
+    ]) ?? event.actor;
+    const mode = normaliseMode(pickString(p, ['mode', 'severity_mode', 'enforcement']));
+    const reason = pickString(p, ['reason', 'message']);
+    if (policy_id === null || dispatch_id === null || reason === null) return null;
+    return {
+      policy_id,
+      dispatch_id,
+      caller_agent_id,
+      mode,
+      reason,
+      ...(pickString(p, ['suggested_fix', 'suggestion', 'fix']) !== null
+        ? { suggested_fix: pickString(p, ['suggested_fix', 'suggestion', 'fix'])! }
+        : {}),
+      ...(event.correlation_id !== undefined ? { correlation_id: event.correlation_id } : {}),
+    };
+  }
+
+  private coerceMemoryInput(event: ConductorEvent): MemoryInconsistencyInput | null {
+    const p = event.payload as Record<string, unknown>;
+    const memory_file = pickString(p, ['memory_file', 'memoryFile', 'file', 'path']);
+    const claim = pickString(p, ['claim', 'expected', 'stated']);
+    const actual = pickString(p, ['actual', 'reality', 'observed']);
+    const discovered_by = pickString(p, ['discovered_by', 'discoveredBy', 'source']) ?? event.actor;
+    if (memory_file === null || claim === null || actual === null) return null;
+    return {
+      memory_file,
+      claim,
+      actual,
+      discovered_by,
+      ...(event.correlation_id !== undefined ? { correlation_id: event.correlation_id } : {}),
+    };
+  }
+
+  private coercePrincipleInput(event: ConductorEvent): PrincipleViolationInput | null {
+    const p = event.payload as Record<string, unknown>;
+    const principle_id = pickString(p, ['principle_id', 'principleId']);
+    const location = pickString(p, ['location', 'file', 'path']);
+    if (principle_id === null || location === null) return null;
+    const adr_id = pickString(p, ['adr_id', 'adrId']);
+    const detected_at = pickString(p, ['detected_at', 'detectedAt']);
+    return {
+      principle_id,
+      location,
+      ...(adr_id !== null ? { adr_id } : {}),
+      ...(detected_at !== null ? { detected_at } : {}),
+      ...(event.correlation_id !== undefined ? { correlation_id: event.correlation_id } : {}),
+    };
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function pickString(p: Record<string, unknown>, keys: string[]): string | null {
+  for (const k of keys) {
+    const v = p[k];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return null;
+}
+
+function normaliseMode(v: string | null): 'hard-fail' | 'soft-fail' | 'advisory' {
+  if (v === 'hard-fail' || v === 'soft-fail' || v === 'advisory') return v;
+  if (v === 'hard' || v === 'error' || v === 'block') return 'hard-fail';
+  if (v === 'soft' || v === 'warn' || v === 'warning') return 'soft-fail';
+  return 'advisory';
+}

--- a/packages/pipeline-conductor/src/index.ts
+++ b/packages/pipeline-conductor/src/index.ts
@@ -1,6 +1,7 @@
 /**
  * @caia/pipeline-conductor — Pipeline Status Manager Agent.
- * Public surface. Per research/conductor_agent_spec_2026.md §6.
+ * Public surface. Per research/conductor_agent_spec_2026.md §6
+ * + research/ai_first_continuous_discipline_2026.md §7 (Layer 5).
  */
 
 export { ConductorClient } from './api.js';
@@ -47,3 +48,32 @@ export type {
   EscalationResolution,
   EscalationResult,
 } from './types.js';
+
+// ─── AI-First Continuous Discipline — Layer 5 ──────────────────────────────
+export {
+  DriftDetector,
+  DEFAULT_SOURCE_GLOBS,
+  DRIFT_DETECTOR_ACTOR,
+} from './drift-detector.js';
+export type {
+  DriftDetectorOptions,
+  PolicyViolationInput,
+  MemoryInconsistencyInput,
+  PrincipleViolationInput,
+} from './drift-detector.js';
+
+export {
+  Alerter,
+  DRIFT_EVENT_TYPES,
+  INBOX_SECTION_HEADER,
+  InMemoryAlerterFs,
+  isDriftEventType,
+  renderAlertEntry,
+} from './alerter.js';
+export type {
+  AlerterOptions,
+  AlerterFsAdapter,
+  DriftEventType,
+  OperatorNotifier,
+  OperatorNotification,
+} from './alerter.js';

--- a/packages/pipeline-conductor/tests/alerter.test.ts
+++ b/packages/pipeline-conductor/tests/alerter.test.ts
@@ -1,0 +1,327 @@
+/**
+ * @caia/pipeline-conductor — alerter tests.
+ *
+ * Verifies:
+ *   - subscribes to all three drift event types
+ *   - writes INBOX entry on first observation
+ *   - deduplicates repeat alerts within the dedup window
+ *   - releases the dedup key after the window expires
+ *   - writes one dashboard line per non-deduplicated alert
+ *   - calls the operator notifier with severity matching event.severity
+ *   - notifier errors do not crash the bus
+ *   - INBOX_SECTION_HEADER is created on the first write
+ *   - renderAlertEntry produces stable text for each event type
+ *   - isDriftEventType reflects the canonical list
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eventBus, type ConductorEvent } from '@chiefaia/event-bus-internal';
+
+import {
+  Alerter,
+  DRIFT_EVENT_TYPES,
+  INBOX_SECTION_HEADER,
+  InMemoryAlerterFs,
+  isDriftEventType,
+  renderAlertEntry,
+  type OperatorNotification,
+} from '../src/alerter.js';
+
+const FIXED_NOW = new Date('2026-05-25T03:00:00.000Z');
+const INBOX_PATH = '/tmp/test-inbox.md';
+const DASHBOARD_DIR = '/tmp/test-drift-dashboard';
+
+function makeAlerter(opts: { now?: Date; notifier?: (n: OperatorNotification) => void; dedupWindowMs?: number } = {}): {
+  alerter: Alerter;
+  fs: InMemoryAlerterFs;
+} {
+  const fs = new InMemoryAlerterFs();
+  const alerter = new Alerter({
+    fs,
+    clock: () => opts.now ?? FIXED_NOW,
+    inboxPath: INBOX_PATH,
+    dashboardDir: DASHBOARD_DIR,
+    ...(opts.notifier ? { notifier: opts.notifier } : {}),
+    ...(opts.dedupWindowMs !== undefined ? { dedupWindowMs: opts.dedupWindowMs } : {}),
+  });
+  return { alerter, fs };
+}
+
+function makePolicyEvent(overrides: Partial<ConductorEvent> = {}): ConductorEvent {
+  return {
+    id: overrides.id ?? 'ev_test_policy_1',
+    type: 'policy.violation.detected',
+    occurred_at: FIXED_NOW.toISOString(),
+    actor: 'pipeline-conductor',
+    severity: 'warning',
+    payload: {
+      policy_id: 'p005',
+      dispatch_id: 'disp-1',
+      caller_agent_id: '@caia/decomposer',
+      mode: 'soft-fail',
+      reason: 'admin merge missing',
+    },
+    ...overrides,
+  } as ConductorEvent;
+}
+
+function makeMemoryEvent(overrides: Partial<ConductorEvent> = {}): ConductorEvent {
+  return {
+    id: overrides.id ?? 'ev_test_memory_1',
+    type: 'memory.consistency.broken',
+    occurred_at: FIXED_NOW.toISOString(),
+    actor: 'pipeline-conductor',
+    severity: 'warning',
+    payload: {
+      memory_file: '/Users/x/agent-memory/feedback.md',
+      claim: 'cron loaded',
+      actual: 'cron not loaded',
+      discovered_by: 'memory-consolidation-cron',
+    },
+    ...overrides,
+  } as ConductorEvent;
+}
+
+function makePrincipleEvent(overrides: Partial<ConductorEvent> = {}): ConductorEvent {
+  return {
+    id: overrides.id ?? 'ev_test_principle_1',
+    type: 'architecture.principle.violated',
+    occurred_at: FIXED_NOW.toISOString(),
+    actor: 'pipeline-conductor',
+    severity: 'error',
+    payload: {
+      principle_id: 'P11',
+      adr_id: 'ADR-040',
+      location: 'packages/x/src/y.ts:42',
+      detected_at: FIXED_NOW.toISOString(),
+    },
+    ...overrides,
+  } as ConductorEvent;
+}
+
+describe('Alerter — direct handleDriftEvent', () => {
+  it('writes an INBOX entry on first policy violation', async () => {
+    const { alerter, fs } = makeAlerter();
+    await alerter.handleDriftEvent(makePolicyEvent());
+    expect(fs.exists(INBOX_PATH)).toBe(true);
+    const body = fs.readFile(INBOX_PATH);
+    expect(body).toContain(INBOX_SECTION_HEADER);
+    expect(body).toContain('drift: policy.violation.detected');
+    expect(body).toContain('p005');
+    expect(alerter.inboxEntriesWritten).toBe(1);
+  });
+
+  it('writes an INBOX entry on memory inconsistency', async () => {
+    const { alerter, fs } = makeAlerter();
+    await alerter.handleDriftEvent(makeMemoryEvent());
+    const body = fs.readFile(INBOX_PATH);
+    expect(body).toContain('drift: memory.consistency.broken');
+    expect(body).toContain('cron loaded');
+    expect(body).toContain('cron not loaded');
+  });
+
+  it('writes an INBOX entry on principle violation', async () => {
+    const { alerter, fs } = makeAlerter();
+    await alerter.handleDriftEvent(makePrincipleEvent());
+    const body = fs.readFile(INBOX_PATH);
+    expect(body).toContain('drift: architecture.principle.violated');
+    expect(body).toContain('P11');
+    expect(body).toContain('ADR-040');
+  });
+
+  it('writes a dashboard line in /tmp/test-drift-dashboard', async () => {
+    const { alerter, fs } = makeAlerter();
+    await alerter.handleDriftEvent(makePolicyEvent());
+    const day = FIXED_NOW.toISOString().slice(0, 10);
+    const path = `${DASHBOARD_DIR}/drift_dashboard_${day}.md`;
+    expect(fs.exists(path)).toBe(true);
+    expect(fs.readFile(path)).toContain('policy.violation.detected');
+    expect(alerter.dashboardLinesWritten).toBe(1);
+  });
+
+  it('deduplicates the same policy event within the dedup window', async () => {
+    const { alerter, fs } = makeAlerter();
+    await alerter.handleDriftEvent(makePolicyEvent());
+    await alerter.handleDriftEvent(makePolicyEvent({ id: 'ev_dup' }));
+    expect(alerter.inboxEntriesWritten).toBe(1);
+    expect(alerter.inboxEntriesDeduped).toBe(1);
+    // Only one entry appears in the body
+    const body = fs.readFile(INBOX_PATH);
+    const occurrences = (body.match(/drift: policy.violation.detected/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  it('does NOT dedup distinct policies', async () => {
+    const { alerter } = makeAlerter();
+    await alerter.handleDriftEvent(makePolicyEvent());
+    await alerter.handleDriftEvent(makePolicyEvent({
+      id: 'ev_other',
+      payload: {
+        policy_id: 'p006-different',
+        dispatch_id: 'disp-2',
+        caller_agent_id: '@caia/other',
+        mode: 'soft-fail',
+        reason: 'something else',
+      },
+    }));
+    expect(alerter.inboxEntriesWritten).toBe(2);
+    expect(alerter.inboxEntriesDeduped).toBe(0);
+  });
+
+  it('dedup window expires — second alert is written after window passes', async () => {
+    const fs = new InMemoryAlerterFs();
+    let now = FIXED_NOW.getTime();
+    const alerter = new Alerter({
+      fs,
+      clock: () => new Date(now),
+      inboxPath: INBOX_PATH,
+      dashboardDir: DASHBOARD_DIR,
+      dedupWindowMs: 1_000,
+    });
+    await alerter.handleDriftEvent(makePolicyEvent());
+    now += 2_000; // advance past the window
+    await alerter.handleDriftEvent(makePolicyEvent({ id: 'ev_after_window' }));
+    expect(alerter.inboxEntriesWritten).toBe(2);
+  });
+
+  it('calls the operator notifier with severity=warning on a warning event', async () => {
+    const notified: OperatorNotification[] = [];
+    const { alerter } = makeAlerter({ notifier: (n) => { notified.push(n); } });
+    await alerter.handleDriftEvent(makePolicyEvent());
+    expect(notified).toHaveLength(1);
+    expect(notified[0]!.type).toBe('policy.violation.detected');
+    expect(notified[0]!.severity).toBe('warning');
+    expect(alerter.notifierCalls).toBe(1);
+  });
+
+  it('calls the operator notifier with severity=error on a principle violation', async () => {
+    const notified: OperatorNotification[] = [];
+    const { alerter } = makeAlerter({ notifier: (n) => { notified.push(n); } });
+    await alerter.handleDriftEvent(makePrincipleEvent());
+    expect(notified[0]!.severity).toBe('error');
+  });
+
+  it('notifier exceptions are caught (no throw) and increment notifierErrors', async () => {
+    const { alerter } = makeAlerter({
+      notifier: () => { throw new Error('notifier-failed'); },
+    });
+    await expect(alerter.handleDriftEvent(makePolicyEvent())).resolves.toBeUndefined();
+    expect(alerter.notifierErrors).toBe(1);
+  });
+
+  it('non-drift events are silently ignored', async () => {
+    const { alerter, fs } = makeAlerter();
+    await alerter.handleDriftEvent({
+      ...makePolicyEvent(),
+      type: 'pipeline.started' as never,
+    });
+    expect(fs.exists(INBOX_PATH)).toBe(false);
+    expect(alerter.alertsObserved).toBe(0);
+  });
+
+  it('resetDedupCache allows re-emit of the same event', async () => {
+    const { alerter } = makeAlerter();
+    await alerter.handleDriftEvent(makePolicyEvent());
+    alerter.resetDedupCache();
+    await alerter.handleDriftEvent(makePolicyEvent({ id: 'ev_dup2' }));
+    expect(alerter.inboxEntriesWritten).toBe(2);
+  });
+});
+
+describe('Alerter — bus subscription wiring', () => {
+  let unsubGlobal: () => void;
+  beforeEach(() => {
+    unsubGlobal = (): void => undefined;
+  });
+  afterEach(() => {
+    unsubGlobal();
+  });
+
+  it('start() subscribes to all three drift event types', async () => {
+    const { alerter, fs } = makeAlerter();
+    alerter.start();
+    try {
+      eventBus.publish({
+        type: 'policy.violation.detected' as never,
+        actor: 'pipeline-conductor',
+        payload: {
+          policy_id: 'p', dispatch_id: 'd', caller_agent_id: 'a',
+          mode: 'soft-fail', reason: 'r',
+        },
+      });
+      // Give microtasks a chance to flush
+      await new Promise((r) => setTimeout(r, 0));
+    } finally { alerter.stop(); }
+    expect(fs.exists(INBOX_PATH)).toBe(true);
+  });
+
+  it('stop() unsubscribes', async () => {
+    const { alerter, fs } = makeAlerter();
+    alerter.start();
+    alerter.stop();
+    eventBus.publish({
+      type: 'policy.violation.detected' as never,
+      actor: 'pipeline-conductor',
+      payload: { policy_id: 'p', dispatch_id: 'd', caller_agent_id: 'a', mode: 'soft-fail', reason: 'r' },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fs.exists(INBOX_PATH)).toBe(false);
+  });
+});
+
+describe('Alerter — rendering + helpers', () => {
+  it('renderAlertEntry for policy.violation.detected contains policy_id and mode', () => {
+    const out = renderAlertEntry('policy.violation.detected', makePolicyEvent(), FIXED_NOW);
+    expect(out.inboxMarkdown).toContain('p005');
+    expect(out.inboxMarkdown).toContain('soft-fail');
+    expect(out.dashboardLine).toContain('policy=p005');
+  });
+
+  it('renderAlertEntry for memory.consistency.broken includes claim + actual', () => {
+    const out = renderAlertEntry('memory.consistency.broken', makeMemoryEvent(), FIXED_NOW);
+    expect(out.inboxMarkdown).toContain('cron loaded');
+    expect(out.inboxMarkdown).toContain('cron not loaded');
+  });
+
+  it('renderAlertEntry for architecture.principle.violated includes principle + adr', () => {
+    const out = renderAlertEntry('architecture.principle.violated', makePrincipleEvent(), FIXED_NOW);
+    expect(out.inboxMarkdown).toContain('P11');
+    expect(out.inboxMarkdown).toContain('ADR-040');
+  });
+
+  it('isDriftEventType returns true for canonical names, false otherwise', () => {
+    for (const t of DRIFT_EVENT_TYPES) expect(isDriftEventType(t)).toBe(true);
+    expect(isDriftEventType('pipeline.started')).toBe(false);
+    expect(isDriftEventType('')).toBe(false);
+  });
+
+  it('appendToInbox creates the section header on first write', async () => {
+    const { alerter, fs } = makeAlerter();
+    await alerter.handleDriftEvent(makePolicyEvent());
+    const body = fs.readFile(INBOX_PATH);
+    expect(body.indexOf(INBOX_SECTION_HEADER)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('appendToInbox inserts under existing section header without duplication', async () => {
+    const { alerter, fs } = makeAlerter();
+    fs.writeFile(INBOX_PATH, `# INBOX\n\n${INBOX_SECTION_HEADER}\n\n(prior entries)\n`);
+    await alerter.handleDriftEvent(makePolicyEvent());
+    const body = fs.readFile(INBOX_PATH);
+    const headerCount = (body.match(new RegExp(INBOX_SECTION_HEADER, 'g')) ?? []).length;
+    expect(headerCount).toBe(1);
+    expect(body).toContain('(prior entries)');
+    expect(body).toContain('drift: policy.violation.detected');
+  });
+
+  it('DRIFT_EVENT_TYPES has length 3 — the canonical Layer 5 trio', () => {
+    expect(DRIFT_EVENT_TYPES).toHaveLength(3);
+  });
+
+  it('notifier receives the event itself (not a copy without payload)', async () => {
+    const seen = vi.fn();
+    const { alerter } = makeAlerter({ notifier: (n) => seen(n.event.payload) });
+    await alerter.handleDriftEvent(makePolicyEvent());
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(seen.mock.calls[0]![0]).toMatchObject({ policy_id: 'p005' });
+  });
+});

--- a/packages/pipeline-conductor/tests/drift-detector.test.ts
+++ b/packages/pipeline-conductor/tests/drift-detector.test.ts
@@ -1,0 +1,349 @@
+/**
+ * @caia/pipeline-conductor — drift-detector tests.
+ *
+ * Verifies:
+ *   - the three direct-API methods emit the canonical event types
+ *   - bus subscriptions normalise upstream-shaped signals
+ *   - the re-emit guard short-circuits self-emitted events (no loops)
+ *   - malformed payloads are rejected without throwing
+ *   - severity is dynamic on `policy.violation.detected` based on `mode`
+ *   - subscriptions are unsubscribed cleanly on stop()
+ *   - causation_id propagates from source events to emitted drift events
+ *   - default source globs include the documented alias names
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eventBus, type ConductorEvent } from '@chiefaia/event-bus-internal';
+
+import {
+  DriftDetector,
+  DEFAULT_SOURCE_GLOBS,
+  DRIFT_DETECTOR_ACTOR,
+} from '../src/drift-detector.js';
+
+const FIXED_NOW = new Date('2026-05-25T03:00:00.000Z');
+
+let capturedDrift: ConductorEvent[];
+let unsubAll: () => void;
+
+function captureDrift(): void {
+  capturedDrift = [];
+  unsubAll = eventBus.subscribe('*', (e) => {
+    if (
+      e.type === 'policy.violation.detected' ||
+      e.type === 'memory.consistency.broken' ||
+      e.type === 'architecture.principle.violated'
+    ) capturedDrift.push(e);
+  });
+}
+
+beforeEach(() => {
+  captureDrift();
+});
+
+afterEach(() => {
+  unsubAll();
+});
+
+describe('DriftDetector — direct API', () => {
+  it('reportPolicyViolation emits policy.violation.detected with actor=pipeline-conductor', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPolicyViolation({
+      policy_id: 'p005-auto-merge-prs',
+      dispatch_id: 'disp-42',
+      caller_agent_id: '@caia/decomposer',
+      mode: 'soft-fail',
+      reason: 'PR opened without admin-merge intent',
+    });
+    expect(capturedDrift).toHaveLength(1);
+    expect(capturedDrift[0]!.type).toBe('policy.violation.detected');
+    expect(capturedDrift[0]!.actor).toBe(DRIFT_DETECTOR_ACTOR);
+    expect(capturedDrift[0]!.payload).toMatchObject({
+      policy_id: 'p005-auto-merge-prs',
+      caller_agent_id: '@caia/decomposer',
+      mode: 'soft-fail',
+      reason: 'PR opened without admin-merge intent',
+    });
+  });
+
+  it('reportPolicyViolation severity is warning on soft-fail', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPolicyViolation({
+      policy_id: 'p1', dispatch_id: 'd1', caller_agent_id: 'a',
+      mode: 'soft-fail', reason: 'r',
+    });
+    expect(capturedDrift[0]!.severity).toBe('warning');
+  });
+
+  it('reportPolicyViolation severity escalates to error on hard-fail', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPolicyViolation({
+      policy_id: 'p1', dispatch_id: 'd1', caller_agent_id: 'a',
+      mode: 'hard-fail', reason: 'r',
+    });
+    expect(capturedDrift[0]!.severity).toBe('error');
+  });
+
+  it('reportPolicyViolation includes suggested_fix when provided', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPolicyViolation({
+      policy_id: 'p1', dispatch_id: 'd1', caller_agent_id: 'a',
+      mode: 'advisory', reason: 'r',
+      suggested_fix: 'add --admin to gh pr merge',
+    });
+    expect((capturedDrift[0]!.payload as Record<string, unknown>).suggested_fix)
+      .toBe('add --admin to gh pr merge');
+  });
+
+  it('reportMemoryInconsistency emits memory.consistency.broken with severity=warning', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportMemoryInconsistency({
+      memory_file: '/Users/x/agent-memory/feedback_X.md',
+      claim: 'cron loaded',
+      actual: 'cron not loaded',
+      discovered_by: 'memory-consolidation-cron',
+    });
+    expect(capturedDrift).toHaveLength(1);
+    expect(capturedDrift[0]!.type).toBe('memory.consistency.broken');
+    expect(capturedDrift[0]!.severity).toBe('warning');
+    expect(capturedDrift[0]!.actor).toBe(DRIFT_DETECTOR_ACTOR);
+  });
+
+  it('reportPrincipleViolation emits architecture.principle.violated with severity=error', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPrincipleViolation({
+      principle_id: 'P11',
+      adr_id: 'ADR-040',
+      location: 'packages/x/src/y.ts:42',
+    });
+    expect(capturedDrift).toHaveLength(1);
+    expect(capturedDrift[0]!.type).toBe('architecture.principle.violated');
+    expect(capturedDrift[0]!.severity).toBe('error');
+  });
+
+  it('reportPrincipleViolation injects clock-provided detected_at when omitted', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPrincipleViolation({
+      principle_id: 'P11', location: 'a:1',
+    });
+    expect((capturedDrift[0]!.payload as Record<string, unknown>).detected_at)
+      .toBe(FIXED_NOW.toISOString());
+  });
+
+  it('reportPrincipleViolation preserves explicit detected_at', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPrincipleViolation({
+      principle_id: 'P11', location: 'a:1',
+      detected_at: '2026-01-01T00:00:00.000Z',
+    });
+    expect((capturedDrift[0]!.payload as Record<string, unknown>).detected_at)
+      .toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('telemetry counters increment per emission', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPolicyViolation({ policy_id: 'p', dispatch_id: 'd', caller_agent_id: 'a', mode: 'advisory', reason: 'r' });
+    d.reportMemoryInconsistency({ memory_file: 'f', claim: 'c', actual: 'a', discovered_by: 'x' });
+    d.reportPrincipleViolation({ principle_id: 'P1', location: 'l' });
+    expect(d.policyViolationsEmitted).toBe(1);
+    expect(d.memoryInconsistenciesEmitted).toBe(1);
+    expect(d.principleViolationsEmitted).toBe(1);
+  });
+
+  it('propagates correlation_id from input', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPolicyViolation({
+      policy_id: 'p', dispatch_id: 'd', caller_agent_id: 'a', mode: 'advisory', reason: 'r',
+      correlation_id: 'corr-42',
+    });
+    expect(capturedDrift[0]!.correlation_id).toBe('corr-42');
+  });
+
+  it('passes entity_type=policy and entity_id=policy_id', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.reportPolicyViolation({ policy_id: 'p007', dispatch_id: 'd', caller_agent_id: 'a', mode: 'advisory', reason: 'r' });
+    expect(capturedDrift[0]!.entity_type).toBe('policy');
+    expect(capturedDrift[0]!.entity_id).toBe('p007');
+  });
+});
+
+describe('DriftDetector — bus subscriptions', () => {
+  it('normalises a policy-linter.violation source event', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    try {
+      eventBus.publish({
+        type: 'policy-linter.violation' as never,
+        actor: 'system',
+        payload: {
+          policy_id: 'p1',
+          dispatch_id: 'd1',
+          caller: '@caia/x',
+          mode: 'soft-fail',
+          reason: 'broken',
+        },
+        entity_type: 'policy',
+        entity_id: 'p1',
+      });
+    } finally { d.stop(); }
+    const normalised = capturedDrift.filter((e) => e.type === 'policy.violation.detected');
+    expect(normalised).toHaveLength(1);
+    expect((normalised[0]!.payload as Record<string, unknown>).caller_agent_id).toBe('@caia/x');
+  });
+
+  it('normalises an ea-drift-sentinel.violation.confirmed source event', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    try {
+      eventBus.publish({
+        type: 'ea-drift-sentinel.violation.confirmed' as never,
+        actor: 'system',
+        payload: {
+          principleId: 'P11',
+          location: 'packages/x/src/y.ts:42',
+          adrId: 'ADR-040',
+        },
+      });
+    } finally { d.stop(); }
+    const normalised = capturedDrift.filter((e) => e.type === 'architecture.principle.violated');
+    expect(normalised).toHaveLength(1);
+    expect((normalised[0]!.payload as Record<string, unknown>).principle_id).toBe('P11');
+    expect((normalised[0]!.payload as Record<string, unknown>).adr_id).toBe('ADR-040');
+  });
+
+  it('normalises memory-consolidator.inconsistency-found', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    try {
+      eventBus.publish({
+        type: 'memory-consolidator.inconsistency-found' as never,
+        actor: 'system',
+        payload: {
+          memory_file: '/tmp/foo.md',
+          claim: 'A',
+          actual: 'B',
+          discovered_by: 'cron',
+        },
+      });
+    } finally { d.stop(); }
+    expect(capturedDrift.filter((e) => e.type === 'memory.consistency.broken')).toHaveLength(1);
+  });
+
+  it('re-emit guard blocks own emissions (no infinite loop)', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    try {
+      // Direct report emits an event with actor=pipeline-conductor; the
+      // bus subscription would see it again. The guard must reject it.
+      d.reportPolicyViolation({
+        policy_id: 'p', dispatch_id: 'd', caller_agent_id: 'a',
+        mode: 'advisory', reason: 'r',
+      });
+    } finally { d.stop(); }
+    expect(capturedDrift.filter((e) => e.type === 'policy.violation.detected')).toHaveLength(1);
+    expect(d.reemitLoopsBlocked).toBeGreaterThan(0);
+  });
+
+  it('malformed payloads are rejected without throwing', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    try {
+      eventBus.publish({
+        type: 'policy-linter.violation' as never,
+        actor: 'system',
+        payload: { /* empty */ },
+      });
+    } finally { d.stop(); }
+    expect(capturedDrift.filter((e) => e.type === 'policy.violation.detected')).toHaveLength(0);
+    expect(d.malformedSourceEvents).toBeGreaterThan(0);
+  });
+
+  it('stop() unsubscribes — subsequent publishes are ignored', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    d.stop();
+    eventBus.publish({
+      type: 'policy-linter.violation' as never,
+      actor: 'system',
+      payload: { policy_id: 'p', dispatch_id: 'd', mode: 'advisory', reason: 'r' },
+    });
+    expect(capturedDrift).toHaveLength(0);
+  });
+
+  it('start() is idempotent — calling twice does not double-subscribe', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    d.start(); // no-op
+    try {
+      eventBus.publish({
+        type: 'policy-linter.violation' as never,
+        actor: 'system',
+        payload: { policy_id: 'p', dispatch_id: 'd', caller: 'a', mode: 'advisory', reason: 'r' },
+      });
+    } finally { d.stop(); }
+    expect(capturedDrift.filter((e) => e.type === 'policy.violation.detected')).toHaveLength(1);
+  });
+
+  it('propagates causation_id when normalising a source event', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    let source: ConductorEvent | null = null;
+    try {
+      source = eventBus.publish({
+        type: 'policy-linter.violation' as never,
+        actor: 'system',
+        payload: { policy_id: 'p', dispatch_id: 'd', caller: 'a', mode: 'advisory', reason: 'r' },
+      });
+    } finally { d.stop(); }
+    const normalised = capturedDrift.filter((e) => e.type === 'policy.violation.detected');
+    expect(normalised[0]!.causation_id).toBe(source!.id);
+  });
+
+  it('coerces "block" mode synonym to hard-fail', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    try {
+      eventBus.publish({
+        type: 'policy-linter.violation' as never,
+        actor: 'system',
+        payload: { policy_id: 'p', dispatch_id: 'd', caller: 'a', mode: 'block', reason: 'r' },
+      });
+    } finally { d.stop(); }
+    const normalised = capturedDrift.filter((e) => e.type === 'policy.violation.detected');
+    expect((normalised[0]!.payload as Record<string, unknown>).mode).toBe('hard-fail');
+    expect(normalised[0]!.severity).toBe('error');
+  });
+
+  it('accepts camelCase payload keys (principleId, ruleId, memoryFile)', () => {
+    const d = new DriftDetector({ clock: () => FIXED_NOW });
+    d.start();
+    try {
+      eventBus.publish({
+        type: 'policy-linter.violation' as never,
+        actor: 'system',
+        payload: { ruleId: 'p1', dispatch_id: 'd', caller: 'a', mode: 'advisory', reason: 'r' },
+      });
+      eventBus.publish({
+        type: 'memory-consolidator.inconsistency-found' as never,
+        actor: 'system',
+        payload: { memoryFile: '/x', claim: 'c', actual: 'a', discovered_by: 'cron' },
+      });
+    } finally { d.stop(); }
+    expect(capturedDrift.filter((e) => e.type === 'policy.violation.detected')).toHaveLength(1);
+    expect(capturedDrift.filter((e) => e.type === 'memory.consistency.broken')).toHaveLength(1);
+  });
+});
+
+describe('DriftDetector — defaults', () => {
+  it('DEFAULT_SOURCE_GLOBS includes the canonical drift event names', () => {
+    expect(DEFAULT_SOURCE_GLOBS.policyViolation).toContain('policy.violation.detected');
+    expect(DEFAULT_SOURCE_GLOBS.memoryInconsistency).toContain('memory.consistency.broken');
+    expect(DEFAULT_SOURCE_GLOBS.principleViolation).toContain('architecture.principle.violated');
+  });
+
+  it('DEFAULT_SOURCE_GLOBS includes the documented alias names', () => {
+    expect(DEFAULT_SOURCE_GLOBS.policyViolation).toContain('policy-linter.violation');
+    expect(DEFAULT_SOURCE_GLOBS.memoryInconsistency).toContain('memory-consolidator.inconsistency-found');
+    expect(DEFAULT_SOURCE_GLOBS.principleViolation).toContain('ea-drift-sentinel.violation.confirmed');
+  });
+});

--- a/packages/pipeline-conductor/tests/drift-integration.test.ts
+++ b/packages/pipeline-conductor/tests/drift-integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @caia/pipeline-conductor — drift detection integration test.
+ *
+ * The full closed loop:
+ *
+ *   fake @caia/policy-linter publishes `policy-linter.violation`
+ *      → DriftDetector normalises → emits `policy.violation.detected`
+ *      → Alerter receives → writes INBOX entry + dashboard line + notifier
+ *
+ * All in-process. Real `eventBus`. In-memory FS. Demonstrates the
+ * subscription-only contract: the detector imports nothing from the
+ * linter; the alerter imports nothing from the detector. Loose coupling
+ * via the shared bus IS the wiring.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { eventBus } from '@chiefaia/event-bus-internal';
+
+import { DriftDetector } from '../src/drift-detector.js';
+import {
+  Alerter,
+  INBOX_SECTION_HEADER,
+  InMemoryAlerterFs,
+  type OperatorNotification,
+} from '../src/alerter.js';
+
+describe('Drift detection integration', () => {
+  it('fake policy-linter violation → drift event → INBOX entry + dashboard + notifier', async () => {
+    const fs = new InMemoryAlerterFs();
+    const inboxPath = '/tmp/integ-inbox.md';
+    const dashboardDir = '/tmp/integ-drift-dashboard';
+    const notified: OperatorNotification[] = [];
+
+    const now = new Date('2026-05-25T03:00:00.000Z');
+    const detector = new DriftDetector({ clock: () => now });
+    const alerter = new Alerter({
+      fs,
+      clock: () => now,
+      inboxPath,
+      dashboardDir,
+      notifier: (n) => { notified.push(n); },
+    });
+
+    detector.start();
+    alerter.start();
+    try {
+      // 1. Fake @caia/policy-linter publishes its violation event.
+      eventBus.publish({
+        type: 'policy-linter.violation' as never,
+        actor: 'system',
+        payload: {
+          policy_id: 'p005-auto-merge-prs',
+          dispatch_id: 'disp-integration-1',
+          caller_agent_id: '@caia/decomposer',
+          mode: 'hard-fail',
+          reason: 'Opened PR without --admin merge intent',
+          suggested_fix: 'append --admin to the gh pr merge call',
+        },
+      });
+
+      // Allow microtasks (notifier is async) to flush.
+      await new Promise((r) => setTimeout(r, 0));
+    } finally {
+      detector.stop();
+      alerter.stop();
+    }
+
+    // 2. Drift detector emitted exactly one canonical event.
+    expect(detector.policyViolationsEmitted).toBe(1);
+
+    // 3. Alerter wrote the INBOX entry under the dedicated section.
+    expect(fs.exists(inboxPath)).toBe(true);
+    const inboxBody = fs.readFile(inboxPath);
+    expect(inboxBody).toContain(INBOX_SECTION_HEADER);
+    expect(inboxBody).toContain('drift: policy.violation.detected');
+    expect(inboxBody).toContain('p005-auto-merge-prs');
+    expect(inboxBody).toContain('hard-fail');
+    expect(inboxBody).toContain('append --admin');
+
+    // 4. Alerter wrote the daily dashboard line.
+    const dashFile = `${dashboardDir}/drift_dashboard_2026-05-25.md`;
+    expect(fs.exists(dashFile)).toBe(true);
+    expect(fs.readFile(dashFile)).toContain('policy.violation.detected');
+    expect(fs.readFile(dashFile)).toContain('mode=hard-fail');
+
+    // 5. Notifier invoked with severity=error (because mode=hard-fail).
+    expect(notified).toHaveLength(1);
+    expect(notified[0]!.severity).toBe('error');
+    expect(notified[0]!.type).toBe('policy.violation.detected');
+
+    // 6. Re-emit guard kept us from looping (the detector saw its own
+    //    emission via the bus subscription and rejected it).
+    expect(detector.reemitLoopsBlocked).toBeGreaterThan(0);
+  });
+
+  it('end-to-end with the documented three sources fires three INBOX entries', async () => {
+    const fs = new InMemoryAlerterFs();
+    const inboxPath = '/tmp/integ-inbox-3.md';
+    const dashboardDir = '/tmp/integ-drift-dashboard-3';
+    const now = new Date('2026-05-25T03:00:00.000Z');
+
+    const detector = new DriftDetector({ clock: () => now });
+    const alerter = new Alerter({
+      fs, clock: () => now, inboxPath, dashboardDir,
+    });
+    detector.start();
+    alerter.start();
+    try {
+      eventBus.publish({
+        type: 'policy-linter.violation' as never,
+        actor: 'system',
+        payload: {
+          policy_id: 'p1', dispatch_id: 'd1', caller_agent_id: 'a',
+          mode: 'soft-fail', reason: 'r1',
+        },
+      });
+      eventBus.publish({
+        type: 'memory-consolidator.inconsistency-found' as never,
+        actor: 'system',
+        payload: {
+          memory_file: '/tmp/feedback.md',
+          claim: 'cron loaded',
+          actual: 'cron not loaded',
+          discovered_by: 'memory-consolidation-cron',
+        },
+      });
+      eventBus.publish({
+        type: 'ea-drift-sentinel.violation.confirmed' as never,
+        actor: 'system',
+        payload: {
+          principleId: 'P14',
+          location: 'packages/x/src/y.ts:42',
+          adrId: 'ADR-061',
+        },
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    } finally {
+      detector.stop();
+      alerter.stop();
+    }
+
+    expect(detector.policyViolationsEmitted).toBe(1);
+    expect(detector.memoryInconsistenciesEmitted).toBe(1);
+    expect(detector.principleViolationsEmitted).toBe(1);
+
+    const body = fs.readFile(inboxPath);
+    expect(body).toContain('drift: policy.violation.detected');
+    expect(body).toContain('drift: memory.consistency.broken');
+    expect(body).toContain('drift: architecture.principle.violated');
+    expect(alerter.inboxEntriesWritten).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Layer 5** of the AI-First Continuous Discipline framework (`research/ai_first_continuous_discipline_2026.md` §7) by extending `@caia/pipeline-conductor` with two new modules — `drift-detector.ts` and `alerter.ts` — plus three new event types in `@chiefaia/events-taxonomy-internal`.

Builds on PR #564 (pipeline-conductor base). Reviewed via `@caia/ea-architect.submitPlan` (PR #568) — approved.

## What changed

### Three new canonical drift event types

Added to `packages/events-taxonomy-internal/registry.yaml` + `index.ts`:

| Event type                          | Severity      | Emitter actor                                 |
|-------------------------------------|---------------|-----------------------------------------------|
| `policy.violation.detected`         | warning\|error | `pipeline-conductor` / `policy-linter`        |
| `memory.consistency.broken`         | warning       | `pipeline-conductor` / `memory-consolidator`  |
| `architecture.principle.violated`   | error         | `pipeline-conductor` / `ea-drift-sentinel`    |

`policy.violation.detected` severity is dynamic — the detector escalates to `error` when `mode === 'hard-fail'`.

### `src/drift-detector.ts`

A normalising bus adapter that subscribes to upstream drift signals from sibling packages and emits exactly the three canonical drift event types.

Default source globs (overridable via `DriftDetectorOptions.sourceGlobs`):

- policy: `policy.violation.detected`, `policy-linter.violation`, `policy-linter.violation.detected`, `ea-policy.violation`
- memory: `memory.consistency.broken`, `memory-consolidator.inconsistency-found`, `memory-consolidator.claim-broken`
- principle: `architecture.principle.violated`, `ea-drift-sentinel.violation.confirmed`, `ea-drift-sentinel.confirmed-violation`

**Re-emit guard**: events with `actor === 'pipeline-conductor'` are short-circuited so the detector never amplifies its own emissions (no subscription loops).

**Direct API** (for in-process callers): `reportPolicyViolation`, `reportMemoryInconsistency`, `reportPrincipleViolation`.

**Defensive payload coercion**: accepts both snake_case and camelCase keys, multiple aliases for `mode` (`block` → `hard-fail`, `warn` → `soft-fail`, …), and rejects malformed payloads silently (`malformedSourceEvents` counter).

### `src/alerter.ts`

Subscribes to the three canonical drift events and surfaces each to operator visibility:

1. **INBOX** — appends a markdown entry under `## DRIFT ALERTS` in `~/Documents/projects/agent-memory/INBOX.md` (configurable), with deduplication (24h window default, configurable via `dedupWindowMs`).
2. **Dashboard** — appends a line per alert to a daily `drift_dashboard_YYYY-MM-DD.md` in the configured directory.
3. **Operator notifier** — optional pluggable hook (no-op default). Notifier exceptions never throw to the bus (`notifierErrors` counter).

`InMemoryAlerterFs` is exported for in-process tests.

### Subscription-only design

The detector imports **nothing** from `@caia/policy-linter`, `@caia/memory-consolidator`, or `@caia/ea-drift-sentinel`. The alerter imports **nothing** from the detector. Loose coupling via the shared `@chiefaia/event-bus-internal` IS the contract (P9 / P14). The two sibling packages (`policy-linter`, `memory-consolidator`) can ship independently without coordination.

## Tests

- **23 unit tests** for `drift-detector` — direct API, bus subscriptions, re-emit guard, malformed-payload rejection, severity dynamics on `mode`, `causation_id` propagation, alias coverage, idempotent `start()`.
- **22 unit tests** for `alerter` — INBOX section management, dedup window expiry, dashboard daily file, notifier severity mapping, notifier exception handling, rendering helpers, `DRIFT_EVENT_TYPES` invariant.
- **2 integration tests** covering the full closed loop:

  ```
  fake @caia/policy-linter event
    → DriftDetector normalises → emits policy.violation.detected
    → Alerter writes INBOX entry + dashboard + notifier
  ```

Full pipeline-conductor suite: **146 tests passing** across 11 files (was 99; added 47).

## Reviews

- **EA Architect** (`@caia/ea-architect.submitPlan`, PR #568): approved (modelTier=opus). Sign-off recorded at `caia-ea/plans/_submissions/pipeline-conductor-drift-detection-2026-05-24.json`.

## Refs

- `research/ai_first_continuous_discipline_2026.md` §7 Layer 5
- PR #564 (`@caia/pipeline-conductor` base)
- PR #568 (`@caia/ea-architect` `submitPlan`)
