### PR TITLE
feat(@caia/test-reviewer): ship Stage 11 — ticket-level tests review gate

### DIFF
--- a/packages/test-reviewer/README.md
+++ b/packages/test-reviewer/README.md
@@ -1,0 +1,76 @@
+# @caia/test-reviewer
+
+Stage 11 of the canonical CAIA pipeline — the **Tests Review Gate**.
+
+Audits the `ticket.testCases` set produced by the Test Author agent (Stage 10)
+against the strategy declarations the Testing Architect emitted into the
+composed `tickets.architecture.testing.*` slice. On pass, the orchestrator
+transitions the ticket from `tests-authored` → `tests-reviewed`. On fail, it
+chains `tests-authored` → `tests-reviewed` → `tests-review-failed`, and the
+Test Author re-runs.
+
+Mirrors `@caia/ea-reviewer` exactly — same lens architecture, same decision
+envelope, same DI seams. The only difference is _what_ it audits.
+
+## Four audit lenses
+
+- **AC coverage** — every `ticket.acceptance_criteria[i]` has at least one
+  `TestCase` with `linkedAcceptanceCriterionIndex === i` AND
+  `category === 'happy'`. Missing AC → P1 rerun directive on `test-author`.
+- **Pyramid balance** — per-layer test mix is compared against the Testing
+  Architect's `testing.testTypeMixPercentages[ticketType]`. Layers far
+  below target (< 50% of declared share) fire P1; layers far above (> 200%)
+  fire P2 advisories. The architect's hard floors (`unit ≥ 30`, `e2e ≤ 50`)
+  are enforced as P1 even when the architect's mix is absent.
+- **Edge cases** — `testCases.filter(c => c.category === 'edge').length >=
+  max(1, floor(totalCases / 10))`. Missing edge-case coverage → P1.
+- **Error states** — at least one `category === 'error'` test, plus
+  conditional quality-tag floors: if `architecture['a11y.wcagLevel']` is
+  set, require ≥1 accessibility test; if `architecture['security.dataClassification']`
+  is `PII | confidential`, require ≥1 security test.
+
+Plus the **correctness lens** (LLM-judge) for case quality — wired behind a
+`CriticAdapter` DI seam. Default: `NullCriticAdapter`. Production:
+`@chiefaia/claude-spawner` subscription-only adapter (per P14).
+
+## Decision envelope
+
+```ts
+{
+  decision: 'pass' | 'fail',
+  finalState: 'tests-reviewed' | 'tests-review-failed',
+  rerunAuthor: RerunDirective[],   // ← orchestrator dispatches to test-author
+  advisories: Advisory[],          // ← dashboard surfaces these
+  findings: { acCoverage, pyramid, edge, error, correctness },
+  summary: string,
+}
+```
+
+## State machine
+
+```
+tests-authored
+   │
+   ├── pass ───► tests-reviewed                  (single transition)
+   │
+   └── fail ───► tests-reviewed                  (intermediate, payload.intermediate=true)
+                   │
+                   └──► tests-review-failed      (canonical recovery target)
+```
+
+Per `@caia/state-machine`'s transition table:
+- `tests-authored → tests-reviewed`
+- `tests-reviewed → tests-review-failed`
+- `tests-review-failed → tests-authored` (Test Author re-runs)
+
+## Spec
+
+Sourced from:
+- `research/state_machine_handoff_spec_2026.md` (canonical pipeline)
+- `research/caia_v3_final_plan_2026.md` (Stage 11 ownership)
+- `research/17_architect_framework_spec_2026.md` §6 (reviewer pattern)
+- Plan: `plans/plan-2026-05-24-test-reviewer-subagent.md`
+- Submission: `plans/_submissions/test-reviewer-stage-11-2026-05-25.json`
+
+Submitted via `@caia/ea-architect.submitPlan` per CAIA constitutional process
+(PR #568); status: approved.

--- a/packages/test-reviewer/package.json
+++ b/packages/test-reviewer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@caia/test-reviewer",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Critic-style audit for the test cases produced by @caia/test-author. Stage 11 of the canonical CAIA pipeline; gates ticket transition from `tests-authored` to `tests-reviewed`. Runs four deterministic lenses (AC coverage, pyramid balance vs Testing Architect's strategy, edge-case floor, error-state floor) plus an LLM-judge for case quality. Emits {decision: 'pass'|'fail', finalState: 'tests-reviewed'|'tests-review-failed', rerunAuthor, advisories}. Mirrors @caia/ea-reviewer template; subscription-only LLM via @chiefaia/claude-spawner adapter seam.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@caia/state-machine": "workspace:*",
+    "@chiefaia/ticket-template": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/test-reviewer/src/api.ts
+++ b/packages/test-reviewer/src/api.ts
@@ -1,0 +1,174 @@
+/**
+ * @caia/test-reviewer — api.ts
+ *
+ * The orchestrator-facing entrypoint: `reviewTicket(ticketId)`. Loads
+ * the ticket + composed architecture via DI seams, runs the reviewer,
+ * emits the canonical state-machine transition(s), and returns a
+ * `ReviewOutcome` envelope.
+ *
+ * State-machine emission (per `@caia/state-machine`'s transition table):
+ *
+ *   pass:
+ *     tests-authored → tests-reviewed                  (one transition)
+ *
+ *   fail:
+ *     tests-authored → tests-reviewed                  (intermediate)
+ *     tests-reviewed → tests-review-failed             (terminal — the
+ *                                                       Test Author then
+ *                                                       re-runs via the
+ *                                                       table's
+ *                                                       tests-review-failed
+ *                                                       → tests-authored
+ *                                                       edge)
+ *
+ * The fail chain is required because the canonical transition table
+ * doesn't allow `tests-authored → tests-review-failed` directly — the
+ * reviewer must first land the ticket in `tests-reviewed` (it WAS
+ * reviewed, just unfavourably) before flagging the failure. Each
+ * intermediate row carries `payload.intermediate = true` so dashboards
+ * can suppress it.
+ */
+
+import {
+  REVIEWER_AGENT_ID,
+  REVIEWER_FAIL_INTERMEDIATE_STATE,
+  REVIEWER_FAIL_STATE,
+  REVIEWER_PASS_STATE,
+  REVIEWER_PRE_STATE,
+  type ArchitectureStore,
+  type CriticAdapter,
+  type ReviewerOptions,
+  type ReviewOutcome,
+  type StateMachineAdapter,
+  type TicketStore,
+} from './types.js';
+import { TestReviewer } from './reviewer.js';
+import type { ProjectState } from '@caia/state-machine';
+
+export interface ReviewTicketDeps {
+  ticketStore: TicketStore;
+  architectureStore?: ArchitectureStore;
+  stateMachine: StateMachineAdapter;
+  critic?: CriticAdapter;
+}
+
+export interface ReviewTicketOptions extends ReviewerOptions {
+  /**
+   * Override the pre-state. The reviewer only emits transitions from
+   * `REVIEWER_PRE_STATE` (`tests-authored`); supply a different value
+   * for tests that want to assert behaviour with a custom starting
+   * state.
+   */
+  fromState?: ProjectState;
+}
+
+/**
+ * The orchestrator-facing entrypoint. Loads the ticket + composed
+ * architecture, runs the audit, emits the FSM transitions, returns the
+ * outcome envelope.
+ */
+export async function reviewTicket(
+  ticketId: string,
+  deps: ReviewTicketDeps,
+  opts: ReviewTicketOptions = {},
+): Promise<ReviewOutcome> {
+  const ticket = await deps.ticketStore.loadTicket(ticketId);
+
+  // Resolve the composed architecture: prefer the explicit store, else
+  // fall back to the ticket's own `architecture` field.
+  let composedArchitecture: Record<string, unknown> = {};
+  if (deps.architectureStore) {
+    composedArchitecture =
+      await deps.architectureStore.loadArchitecture(ticketId);
+  } else if (
+    ticket.architecture &&
+    typeof ticket.architecture === 'object' &&
+    !Array.isArray(ticket.architecture)
+  ) {
+    composedArchitecture = ticket.architecture as Record<string, unknown>;
+  }
+
+  // Build + invoke the reviewer.
+  const reviewer = new TestReviewer(
+    deps.critic ? { critic: deps.critic } : {},
+    splitReviewerOptions(opts),
+  );
+  const decision = await reviewer.review({
+    ticket,
+    composedArchitecture,
+  });
+
+  const fromState: ProjectState = opts.fromState ?? REVIEWER_PRE_STATE;
+  const emittedTransitions: Array<{ from: ProjectState; to: ProjectState; intermediate: boolean }> = [];
+
+  if (decision.decision === 'pass') {
+    // Single transition.
+    await deps.stateMachine.transition({
+      ticketId,
+      from: fromState,
+      to: REVIEWER_PASS_STATE,
+      triggeredBy: { kind: 'agent', id: REVIEWER_AGENT_ID },
+      payload: {
+        decision: 'pass',
+        findings: decision.findings,
+        summary: decision.summary,
+      },
+    });
+    emittedTransitions.push({
+      from: fromState,
+      to: REVIEWER_PASS_STATE,
+      intermediate: false,
+    });
+  } else {
+    // Chain: tests-authored → tests-reviewed (intermediate) → tests-review-failed.
+    await deps.stateMachine.transition({
+      ticketId,
+      from: fromState,
+      to: REVIEWER_FAIL_INTERMEDIATE_STATE,
+      triggeredBy: { kind: 'agent', id: REVIEWER_AGENT_ID },
+      payload: {
+        intermediate: true,
+        decision: 'fail',
+        // Don't carry findings on the intermediate row — they'd be
+        // duplicated on the terminal row below.
+      },
+    });
+    emittedTransitions.push({
+      from: fromState,
+      to: REVIEWER_FAIL_INTERMEDIATE_STATE,
+      intermediate: true,
+    });
+
+    await deps.stateMachine.transition({
+      ticketId,
+      from: REVIEWER_FAIL_INTERMEDIATE_STATE,
+      to: REVIEWER_FAIL_STATE,
+      triggeredBy: { kind: 'agent', id: REVIEWER_AGENT_ID },
+      payload: {
+        decision: 'fail',
+        findings: decision.findings,
+        summary: decision.summary,
+      },
+    });
+    emittedTransitions.push({
+      from: REVIEWER_FAIL_INTERMEDIATE_STATE,
+      to: REVIEWER_FAIL_STATE,
+      intermediate: false,
+    });
+  }
+
+  return {
+    ticketId,
+    decision,
+    emittedTransitions,
+  };
+}
+
+/**
+ * Strip the api-only `fromState` option before passing through to the
+ * reviewer.
+ */
+function splitReviewerOptions(opts: ReviewTicketOptions): ReviewerOptions {
+  const { fromState: _fromState, ...rest } = opts;
+  return rest;
+}

--- a/packages/test-reviewer/src/critic.ts
+++ b/packages/test-reviewer/src/critic.ts
@@ -1,0 +1,140 @@
+/**
+ * @caia/test-reviewer — critic adapter (correctness lens).
+ *
+ * Mirrors `@caia/ea-reviewer`'s `critic.ts` exactly in shape. In production
+ * this would spawn a Claude subagent (subscription-only per P14, no
+ * API-key billing); in tests we want determinism and zero LLM calls — so
+ * the production path is behind a `CriticAdapter` DI seam and the default
+ * in-process impl is a keyword-overlap heuristic.
+ *
+ * The heuristic adapter:
+ *   - tokenizes each acceptance criterion
+ *   - for each criterion, searches the corresponding linked-test's
+ *     `given/when/then` for token overlap
+ *   - emits a P2 finding when overlap is < 25% (cheap signal that the
+ *     test doesn't actually exercise the criterion)
+ *
+ * This isn't *correct* in the LLM-judgment sense — it's a deterministic
+ * placeholder that fails closed (flags weak coverage) and is cheap to
+ * test. Production callers inject a Claude-backed adapter.
+ */
+
+import type { TestCase } from '@chiefaia/ticket-template';
+import type { CorrectnessFinding, CriticAdapter } from './types.js';
+
+function tokenize(s: string): readonly string[] {
+  return s
+    .toLowerCase()
+    .split(/[\s,.;:!?()/\\"'`<>{}[\]|&^%$#@~+=*-]+/)
+    .filter((t) => t.length >= 4)
+    .filter((t) => !STOPWORDS.has(t));
+}
+
+const STOPWORDS = new Set([
+  'this',
+  'that',
+  'with',
+  'from',
+  'when',
+  'then',
+  'where',
+  'which',
+  'they',
+  'their',
+  'them',
+  'have',
+  'been',
+  'must',
+  'will',
+  'shall',
+  'should',
+  'would',
+  'into',
+  'than',
+  'also',
+  'such',
+  'each',
+  'some',
+  'more',
+  'less',
+  'over',
+  'under',
+  'page',
+  'load',
+  'user',
+  'data',
+  'given',
+  'test',
+]);
+
+/**
+ * Heuristic critic — for each AC, examine the linked test case(s) and
+ * flag any whose given+when+then text doesn't share at least 25% of the
+ * AC's content tokens.
+ *
+ * Fails closed: returns a finding when in doubt.
+ */
+export class HeuristicCriticAdapter implements CriticAdapter {
+  async judge(input: {
+    testCases: readonly TestCase[];
+    acceptanceCriteria: readonly string[];
+    composedArchitecture: Record<string, unknown>;
+  }): Promise<readonly CorrectnessFinding[]> {
+    const findings: CorrectnessFinding[] = [];
+    for (let i = 0; i < input.acceptanceCriteria.length; i++) {
+      const ac = input.acceptanceCriteria[i] ?? '';
+      const acTokens = tokenize(ac);
+      if (acTokens.length === 0) continue;
+
+      const linked = input.testCases.filter(
+        (tc) => tc.linkedAcceptanceCriterionIndex === i,
+      );
+      if (linked.length === 0) {
+        // AC-coverage lens handles "no linked test"; we don't double-fire.
+        continue;
+      }
+      for (const tc of linked) {
+        const corpus = `${tc.given} ${tc.when} ${tc.then}`.toLowerCase();
+        const matched = acTokens.filter((t) => corpus.includes(t));
+        const ratio = matched.length / acTokens.length;
+        if (ratio < 0.25) {
+          findings.push({
+            testCaseId: tc.id,
+            reason: `test '${tc.id}' linked to AC #${i} but only ${matched.length}/${acTokens.length} criterion tokens appear in given/when/then`,
+            severity: 'P2',
+          });
+        }
+      }
+    }
+    return findings;
+  }
+}
+
+/**
+ * No-op critic — returns no findings. Default. Lets the deterministic
+ * lenses do all the work.
+ */
+export class NullCriticAdapter implements CriticAdapter {
+  async judge(_input: {
+    testCases: readonly TestCase[];
+    acceptanceCriteria: readonly string[];
+    composedArchitecture: Record<string, unknown>;
+  }): Promise<readonly CorrectnessFinding[]> {
+    return [];
+  }
+}
+
+/**
+ * Fixed-output critic — for tests that need to assert the reviewer
+ * handles correctness findings correctly without invoking the heuristic.
+ */
+export class FixedCriticAdapter implements CriticAdapter {
+  constructor(private readonly findings: readonly CorrectnessFinding[]) {}
+  async judge(_input: {
+    testCases: readonly TestCase[];
+    acceptanceCriteria: readonly string[];
+    composedArchitecture: Record<string, unknown>;
+  }): Promise<readonly CorrectnessFinding[]> {
+    return this.findings;
+  }
+}

--- a/packages/test-reviewer/src/index.ts
+++ b/packages/test-reviewer/src/index.ts
@@ -1,0 +1,77 @@
+/**
+ * @caia/test-reviewer — public surface.
+ *
+ * Stage 11 of the canonical CAIA pipeline. Audits `ticket.testCases` from
+ * the Test Author against the Testing Architect's strategy declarations
+ * and emits the state-machine transitions that gate the ticket through
+ * `tests-reviewed`.
+ */
+
+// -- Reviewer class + functional flavour -----------------------------------
+export { TestReviewer, review, REVIEWER_AGENT_ID } from './reviewer.js';
+export type { ReviewerDeps } from './reviewer.js';
+
+// -- Orchestrator-facing entrypoint ----------------------------------------
+export { reviewTicket } from './api.js';
+export type {
+  ReviewTicketDeps,
+  ReviewTicketOptions,
+} from './api.js';
+
+// -- Critic adapters (correctness-lens DI seam) ----------------------------
+export {
+  HeuristicCriticAdapter,
+  NullCriticAdapter,
+  FixedCriticAdapter,
+} from './critic.js';
+
+// -- Individual lenses (exported so callers can run them in isolation) -----
+export { runAcCoverageLens } from './lenses/ac-coverage.js';
+export type { AcCoverageInput } from './lenses/ac-coverage.js';
+
+export { runPyramidLens, resolveMix } from './lenses/pyramid.js';
+export type { PyramidInput } from './lenses/pyramid.js';
+
+export { runEdgeLens } from './lenses/edge.js';
+export type { EdgeInput } from './lenses/edge.js';
+
+export { runErrorLens } from './lenses/error.js';
+export type { ErrorInput } from './lenses/error.js';
+
+// -- Types -----------------------------------------------------------------
+export type {
+  // input/output envelopes
+  ReviewerInput,
+  ReviewerDecision,
+  ReviewerFindings,
+  ReviewerTicket,
+  ReviewerOptions,
+  ReviewOutcome,
+  // findings
+  AcCoverageFinding,
+  PyramidFinding,
+  EdgeFinding,
+  ErrorFinding,
+  CorrectnessFinding,
+  // directives + advisories
+  RerunDirective,
+  Advisory,
+  LensName,
+  // adapters
+  CriticAdapter,
+  StateMachineAdapter,
+  TicketStore,
+  ArchitectureStore,
+  // primitives
+  Severity,
+  PassFinalState,
+  FailFinalState,
+} from './types.js';
+
+export {
+  DEFAULT_REVIEWER_OPTIONS,
+  REVIEWER_PRE_STATE,
+  REVIEWER_PASS_STATE,
+  REVIEWER_FAIL_INTERMEDIATE_STATE,
+  REVIEWER_FAIL_STATE,
+} from './types.js';

--- a/packages/test-reviewer/src/lenses/ac-coverage.ts
+++ b/packages/test-reviewer/src/lenses/ac-coverage.ts
@@ -1,0 +1,55 @@
+/**
+ * @caia/test-reviewer — AC coverage lens.
+ *
+ * For each acceptance criterion `acceptanceCriteria[i]`, require at least
+ * one `TestCase` with:
+ *   - `linkedAcceptanceCriterionIndex === i`, AND
+ *   - `category === 'happy'`
+ *
+ * The happy-path requirement is deliberate: an edge or error test that
+ * happens to link to an AC doesn't prove the criterion's success path
+ * works. A green-light happy test does.
+ *
+ * Missing AC → P1 (default) rerun directive blaming the Test Author.
+ */
+
+import type { TestCase } from '@chiefaia/ticket-template';
+import type { AcCoverageFinding, Severity } from '../types.js';
+
+export interface AcCoverageInput {
+  testCases: readonly TestCase[];
+  acceptanceCriteria: readonly string[];
+  severity?: Severity;
+}
+
+export function runAcCoverageLens(
+  input: AcCoverageInput,
+): readonly AcCoverageFinding[] {
+  const severity = input.severity ?? 'P1';
+  const findings: AcCoverageFinding[] = [];
+
+  for (let i = 0; i < input.acceptanceCriteria.length; i++) {
+    const acText = input.acceptanceCriteria[i] ?? '';
+    const happyCase = input.testCases.find(
+      (tc) =>
+        tc.linkedAcceptanceCriterionIndex === i && tc.category === 'happy',
+    );
+    if (!happyCase) {
+      // Distinguish "no test at all" from "non-happy test only" for better
+      // operator feedback.
+      const anyLinked = input.testCases.some(
+        (tc) => tc.linkedAcceptanceCriterionIndex === i,
+      );
+      findings.push({
+        acIndex: i,
+        acText,
+        reason: anyLinked
+          ? `acceptance criterion #${i} has linked test cases but none with category='happy'`
+          : `acceptance criterion #${i} has no linked test case`,
+        severity,
+      });
+    }
+  }
+
+  return findings;
+}

--- a/packages/test-reviewer/src/lenses/edge.ts
+++ b/packages/test-reviewer/src/lenses/edge.ts
@@ -1,0 +1,46 @@
+/**
+ * @caia/test-reviewer — edge-case lens.
+ *
+ * Require at least `max(edgeCaseFloor, ceil(totalCases / 10))` test cases
+ * with `category === 'edge'`. The ratio scales with suite size: a
+ * 5-case suite needs 1 edge case; a 50-case suite needs 5.
+ *
+ * Edge cases are the tests that catch off-by-one, empty-collection,
+ * boundary-of-range, and Unicode-surprise bugs — the bread and butter of
+ * software defects. A test suite without them is a smoke screen.
+ */
+
+import type { TestCase } from '@chiefaia/ticket-template';
+import type { EdgeFinding, Severity } from '../types.js';
+
+export interface EdgeInput {
+  testCases: readonly TestCase[];
+  /** Hard floor — at least this many edge cases regardless of suite size. */
+  floor?: number;
+  severity?: Severity;
+}
+
+export function runEdgeLens(input: EdgeInput): readonly EdgeFinding[] {
+  const total = input.testCases.length;
+  // Zero cases — handled by AC-coverage lens; don't double-fire.
+  if (total === 0) return [];
+
+  const floor = input.floor ?? 1;
+  const severity = input.severity ?? 'P1';
+  const required = Math.max(floor, Math.ceil(total / 10));
+
+  const actual = input.testCases.filter((tc) => tc.category === 'edge').length;
+
+  if (actual < required) {
+    return [
+      {
+        reason:
+          actual === 0
+            ? `no edge-case tests (need ${required} for a ${total}-case suite)`
+            : `only ${actual} edge-case test(s) — need ${required} for a ${total}-case suite`,
+        severity,
+      },
+    ];
+  }
+  return [];
+}

--- a/packages/test-reviewer/src/lenses/error.ts
+++ b/packages/test-reviewer/src/lenses/error.ts
@@ -1,0 +1,78 @@
+/**
+ * @caia/test-reviewer — error-state lens.
+ *
+ * Baseline requirement: at least one `category === 'error'` test in the
+ * suite. Error tests prove the negative — that bad inputs fail loudly
+ * instead of silently corrupting state.
+ *
+ * Conditional quality-tag floors (driven by the composed architecture):
+ *   - If `architecture['a11y.wcagLevel']` is set (any value), require at
+ *     least one `category === 'accessibility'` test. (Setting a WCAG
+ *     level without testing accessibility is theatre.)
+ *   - If `architecture['security.dataClassification']` ∈ {PII,
+ *     confidential}, require at least one `category === 'security'` test.
+ *     (Sensitive data without security tests is a P1 audit finding by
+ *     itself.)
+ */
+
+import type { TestCase } from '@chiefaia/ticket-template';
+import type { ErrorFinding, Severity } from '../types.js';
+
+export interface ErrorInput {
+  testCases: readonly TestCase[];
+  composedArchitecture: Record<string, unknown>;
+  severity?: Severity;
+}
+
+export function runErrorLens(input: ErrorInput): readonly ErrorFinding[] {
+  const severity = input.severity ?? 'P1';
+  const total = input.testCases.length;
+  // Zero cases — handled by AC-coverage lens; don't double-fire.
+  if (total === 0) return [];
+
+  const findings: ErrorFinding[] = [];
+
+  // Baseline: ≥1 error test.
+  const errorCount = input.testCases.filter((tc) => tc.category === 'error')
+    .length;
+  if (errorCount === 0) {
+    findings.push({
+      qualifier: 'baseline',
+      reason:
+        'no error-state tests — every suite needs at least one negative-path test',
+      severity,
+    });
+  }
+
+  // A11y floor.
+  const wcag = input.composedArchitecture['a11y.wcagLevel'];
+  if (typeof wcag === 'string' && wcag.length > 0) {
+    const a11yCount = input.testCases.filter(
+      (tc) => tc.category === 'accessibility',
+    ).length;
+    if (a11yCount === 0) {
+      findings.push({
+        qualifier: 'a11y',
+        reason: `architecture declares WCAG ${wcag} but the suite has no accessibility tests`,
+        severity,
+      });
+    }
+  }
+
+  // Security floor.
+  const dataClass = input.composedArchitecture['security.dataClassification'];
+  if (dataClass === 'PII' || dataClass === 'confidential') {
+    const secCount = input.testCases.filter(
+      (tc) => tc.category === 'security',
+    ).length;
+    if (secCount === 0) {
+      findings.push({
+        qualifier: 'security',
+        reason: `data classification '${dataClass}' requires at least one security test`,
+        severity,
+      });
+    }
+  }
+
+  return findings;
+}

--- a/packages/test-reviewer/src/lenses/pyramid.ts
+++ b/packages/test-reviewer/src/lenses/pyramid.ts
@@ -1,0 +1,212 @@
+/**
+ * @caia/test-reviewer — pyramid balance lens.
+ *
+ * Compares the actual per-layer distribution of `ticket.testCases` against
+ * the Testing Architect's `testing.testTypeMixPercentages[ticketType]`.
+ *
+ * The architect's mix is a 6-axis split (unit, integration, e2e, visual,
+ * a11y, perf) that sums to 100 — but `TestCase.layer` is a 5-axis split
+ * (unit, integration, e2e, visual, accessibility). We map:
+ *   - `a11y` (architect axis) ↔ `accessibility` (TestCase.layer)
+ *   - `perf` (architect axis) has no `TestCase.layer` counterpart in v1
+ *     of the ticket-template, so we fold its target into `unit+integration`
+ *     for the comparison.
+ *
+ * Findings:
+ *   - Layer well below target (< 50% of declared share) → underfill (P1).
+ *   - Layer well above target (> 200% of declared share, when target > 0)
+ *     → overfill (P2, advisory).
+ *
+ * Hard floors (apply even when the architect's mix is absent):
+ *   - `unit` layer share ≥ `unitFloorPct` (default 30).
+ *   - `e2e`  layer share ≤ `e2eCeilingPct`  (default 50).
+ *   These mirror the Testing Architect's own invariants (see
+ *   `@caia/testing-architect`'s `testing.mix-is-realistic-not-100-pct-unit`).
+ *
+ * Smoothing: layers whose expected case-count rounds below 1 are skipped —
+ * flagging a missing 0.5-case is noise on small suites.
+ */
+
+import type { TestCase } from '@chiefaia/ticket-template';
+import type { PyramidFinding, Severity } from '../types.js';
+
+const LAYERS: readonly TestCase['layer'][] = [
+  'unit',
+  'integration',
+  'e2e',
+  'visual',
+  'accessibility',
+] as const;
+
+export interface PyramidInput {
+  testCases: readonly TestCase[];
+  ticketType: string | undefined;
+  composedArchitecture: Record<string, unknown>;
+  underfillSeverity?: Severity;
+  overfillSeverity?: Severity;
+  unitFloorPct?: number;
+  e2eCeilingPct?: number;
+}
+
+interface NormalizedMix {
+  unit: number;
+  integration: number;
+  e2e: number;
+  visual: number;
+  accessibility: number;
+}
+
+function asObject(v: unknown): Record<string, unknown> | null {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+function asNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Resolve the architect's mix for `ticketType` from the composed
+ * architecture, mapping axes onto `TestCase.layer` space. Returns null
+ * if the architect didn't ship a mix for this ticket type.
+ */
+export function resolveMix(
+  composed: Record<string, unknown>,
+  ticketType: string | undefined,
+): NormalizedMix | null {
+  if (!ticketType) return null;
+  const mix = asObject(composed['testing.testTypeMixPercentages']);
+  if (!mix) return null;
+  const perType = asObject(mix[ticketType]);
+  if (!perType) return null;
+
+  const unit = asNumber(perType['unit']);
+  const integration = asNumber(perType['integration']);
+  const e2e = asNumber(perType['e2e']);
+  const visual = asNumber(perType['visual']);
+  const a11y = asNumber(perType['a11y']);
+  const perf = asNumber(perType['perf']);
+
+  if (
+    unit === null ||
+    integration === null ||
+    e2e === null ||
+    visual === null ||
+    a11y === null ||
+    perf === null
+  ) {
+    return null;
+  }
+
+  // Fold `perf` into unit+integration proportionally (perf tests in v1 of
+  // ticket-template don't have a `TestCase.layer` of their own; they're
+  // typically authored as unit or integration tests with a perf-budget
+  // assertion).
+  const split = unit + integration;
+  const unitAdj = split > 0 ? unit + perf * (unit / split) : unit + perf / 2;
+  const integrationAdj =
+    split > 0
+      ? integration + perf * (integration / split)
+      : integration + perf / 2;
+
+  return {
+    unit: unitAdj,
+    integration: integrationAdj,
+    e2e,
+    visual,
+    accessibility: a11y,
+  };
+}
+
+export function runPyramidLens(
+  input: PyramidInput,
+): readonly PyramidFinding[] {
+  const underfillSeverity = input.underfillSeverity ?? 'P1';
+  const overfillSeverity = input.overfillSeverity ?? 'P2';
+  const unitFloor = input.unitFloorPct ?? 30;
+  const e2eCeiling = input.e2eCeilingPct ?? 50;
+
+  const total = input.testCases.length;
+  const findings: PyramidFinding[] = [];
+
+  // Zero cases — no pyramid to evaluate. The AC-coverage lens will catch
+  // this; we don't double-fire.
+  if (total === 0) return findings;
+
+  // Compute per-layer histogram.
+  const counts: NormalizedMix = {
+    unit: 0,
+    integration: 0,
+    e2e: 0,
+    visual: 0,
+    accessibility: 0,
+  };
+  for (const tc of input.testCases) counts[tc.layer] += 1;
+
+  const actualPct: NormalizedMix = {
+    unit: (counts.unit / total) * 100,
+    integration: (counts.integration / total) * 100,
+    e2e: (counts.e2e / total) * 100,
+    visual: (counts.visual / total) * 100,
+    accessibility: (counts.accessibility / total) * 100,
+  };
+
+  // Hard floors (always run).
+  if (actualPct.unit < unitFloor) {
+    findings.push({
+      layer: 'unit',
+      actualPct: round1(actualPct.unit),
+      targetPct: null,
+      reason: `unit-layer share ${round1(actualPct.unit)}% is below the hard floor of ${unitFloor}%`,
+      severity: underfillSeverity,
+    });
+  }
+  if (actualPct.e2e > e2eCeiling) {
+    findings.push({
+      layer: 'e2e',
+      actualPct: round1(actualPct.e2e),
+      targetPct: null,
+      reason: `e2e-layer share ${round1(actualPct.e2e)}% exceeds the hard ceiling of ${e2eCeiling}% — suite will be slow + flaky`,
+      severity: underfillSeverity,
+    });
+  }
+
+  // Architect-mix comparison (if available).
+  const mix = resolveMix(input.composedArchitecture, input.ticketType);
+  if (mix) {
+    for (const layer of LAYERS) {
+      const target = mix[layer];
+      const actual = actualPct[layer];
+      // Smoothing: if the expected case-count rounds below 1, skip — both
+      // under-fill (missing 0.5-case is noise) and over-fill (a single
+      // test in a layer with a 3%% target on a 10-case suite is fine)
+      // suffer from small-target spam.
+      const expectedCount = (target * total) / 100;
+      if (expectedCount < 1) continue;
+      if (target > 0 && actual < target * 0.5) {
+        findings.push({
+          layer,
+          actualPct: round1(actual),
+          targetPct: round1(target),
+          reason: `${layer}-layer share ${round1(actual)}% is < 50% of the Testing Architect's target ${round1(target)}%`,
+          severity: underfillSeverity,
+        });
+      } else if (target > 0 && actual > target * 2) {
+        findings.push({
+          layer,
+          actualPct: round1(actual),
+          targetPct: round1(target),
+          reason: `${layer}-layer share ${round1(actual)}% is > 200% of the Testing Architect's target ${round1(target)}%`,
+          severity: overfillSeverity,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}

--- a/packages/test-reviewer/src/reviewer.ts
+++ b/packages/test-reviewer/src/reviewer.ts
@@ -1,0 +1,294 @@
+/**
+ * @caia/test-reviewer — reviewer.ts
+ *
+ * Drives the four deterministic lenses (AC coverage, pyramid, edge,
+ * error) plus the LLM-judge correctness lens. Rolls every finding into
+ * a single decision envelope: a `RerunDirective` list for the Test
+ * Author and an `Advisory` list for the dashboard.
+ *
+ * Mirrors `@caia/ea-reviewer`'s `Reviewer` class verbatim in shape and
+ * behaviour. The only differences:
+ *   - reruns target `'test-author'` (single agent), not architects.
+ *   - finalState is `tests-reviewed` / `tests-review-failed`, not
+ *     `ea-complete-verified` / `ea-rejected`.
+ *   - lens set is AC-coverage / pyramid / edge / error / correctness.
+ *
+ * The reviewer is intentionally DI-heavy: the critic adapter is
+ * injected, the option set is injected, so tests can exercise every
+ * code path deterministically without spawning an LLM.
+ */
+
+import { NullCriticAdapter } from './critic.js';
+import { runAcCoverageLens } from './lenses/ac-coverage.js';
+import { runEdgeLens } from './lenses/edge.js';
+import { runErrorLens } from './lenses/error.js';
+import { runPyramidLens } from './lenses/pyramid.js';
+import {
+  DEFAULT_REVIEWER_OPTIONS,
+  REVIEWER_AGENT_ID,
+  type Advisory,
+  type CorrectnessFinding,
+  type CriticAdapter,
+  type LensName,
+  type RerunDirective,
+  type ReviewerDecision,
+  type ReviewerFindings,
+  type ReviewerInput,
+  type ReviewerOptions,
+  type Severity,
+} from './types.js';
+
+export interface ReviewerDeps {
+  critic?: CriticAdapter;
+}
+
+export class TestReviewer {
+  private readonly opts: Required<ReviewerOptions>;
+  private readonly critic: CriticAdapter;
+
+  constructor(deps: ReviewerDeps = {}, opts: ReviewerOptions = {}) {
+    this.opts = { ...DEFAULT_REVIEWER_OPTIONS, ...opts };
+    this.critic = deps.critic ?? new NullCriticAdapter();
+  }
+
+  async review(input: ReviewerInput): Promise<ReviewerDecision> {
+    const testCases = input.ticket.testCases ?? [];
+    const acceptanceCriteria =
+      input.acceptanceCriteria ?? input.ticket.acceptance_criteria ?? [];
+
+    // 1. Run the four deterministic lenses.
+    const acCoverage = runAcCoverageLens({
+      testCases,
+      acceptanceCriteria,
+      severity: this.opts.acCoverageMissSeverity,
+    });
+    const pyramid = runPyramidLens({
+      testCases,
+      ticketType: input.ticket.type,
+      composedArchitecture: input.composedArchitecture,
+      underfillSeverity: this.opts.pyramidUnderfillSeverity,
+      overfillSeverity: this.opts.pyramidOverfillSeverity,
+      unitFloorPct: this.opts.unitFloorPct,
+      e2eCeilingPct: this.opts.e2eCeilingPct,
+    });
+    const edge = runEdgeLens({
+      testCases,
+      floor: this.opts.edgeCaseFloor,
+      severity: this.opts.edgeCaseMissSeverity,
+    });
+    const error = runErrorLens({
+      testCases,
+      composedArchitecture: input.composedArchitecture,
+      severity: this.opts.errorMissSeverity,
+    });
+
+    // 2. Run the LLM-judge correctness lens — only if there are ACs.
+    const correctness: readonly CorrectnessFinding[] =
+      acceptanceCriteria.length > 0
+        ? await this.critic.judge({
+            testCases,
+            acceptanceCriteria,
+            composedArchitecture: input.composedArchitecture,
+          })
+        : [];
+
+    const findings: ReviewerFindings = {
+      acCoverage,
+      pyramid,
+      edge,
+      error,
+      correctness,
+    };
+
+    // 3. Roll each lens's findings into rerun directives + advisories.
+    const blocking = new Set<Severity>(this.opts.blockingSeverities);
+
+    const allDirectives: RerunDirective[] = [];
+    const allAdvisories: Advisory[] = [];
+
+    // AC coverage — always blames test-author.
+    for (const f of acCoverage) {
+      const d: RerunDirective = {
+        agent: 'test-author',
+        reason: f.reason,
+        severity: f.severity,
+        lens: 'acCoverage',
+      };
+      if (blocking.has(f.severity)) allDirectives.push(d);
+      else
+        allAdvisories.push({
+          agent: 'test-author',
+          advisory: d.reason,
+          severity: d.severity,
+          lens: 'acCoverage',
+        });
+    }
+
+    // Pyramid — under-fill blames test-author; over-fill is advisory.
+    for (const f of pyramid) {
+      const d: RerunDirective = {
+        agent: 'test-author',
+        reason: f.reason,
+        severity: f.severity,
+        lens: 'pyramid',
+      };
+      if (blocking.has(f.severity)) allDirectives.push(d);
+      else
+        allAdvisories.push({
+          agent:
+            f.targetPct === null
+              ? 'test-author' // hard-floor violation — author's fault
+              : 'testing-architect', // strategy-target mismatch — architect could rebalance
+          advisory: d.reason,
+          severity: d.severity,
+          lens: 'pyramid',
+        });
+    }
+
+    // Edge — always blames test-author.
+    for (const f of edge) {
+      const d: RerunDirective = {
+        agent: 'test-author',
+        reason: f.reason,
+        severity: f.severity,
+        lens: 'edge',
+      };
+      if (blocking.has(f.severity)) allDirectives.push(d);
+      else
+        allAdvisories.push({
+          agent: 'test-author',
+          advisory: d.reason,
+          severity: d.severity,
+          lens: 'edge',
+        });
+    }
+
+    // Error — always blames test-author.
+    for (const f of error) {
+      const d: RerunDirective = {
+        agent: 'test-author',
+        reason: f.reason,
+        severity: f.severity,
+        lens: 'error',
+      };
+      if (blocking.has(f.severity)) allDirectives.push(d);
+      else
+        allAdvisories.push({
+          agent: 'test-author',
+          advisory: d.reason,
+          severity: d.severity,
+          lens: 'error',
+        });
+    }
+
+    // Correctness — blames test-author if a specific case id is named,
+    // else routes to advisory (global). Critic findings default to P2;
+    // we honour their severity verbatim.
+    for (const f of correctness) {
+      if (f.testCaseId && blocking.has(f.severity)) {
+        allDirectives.push({
+          agent: 'test-author',
+          reason: f.reason,
+          severity: f.severity,
+          lens: 'correctness',
+        });
+      } else {
+        allAdvisories.push({
+          agent: f.testCaseId ? 'test-author' : 'global',
+          advisory: f.reason,
+          severity: f.severity,
+          lens: 'correctness',
+        });
+      }
+    }
+
+    // 4. Dedup directives: collapse to ONE entry per (agent, lens),
+    // keeping the highest severity and concatenating reasons. We don't
+    // bother per-architect dedup like ea-reviewer because there's one
+    // author — but per-lens dedup makes the feedback navigable.
+    const rerunByLens = new Map<LensName, RerunDirective>();
+    for (const d of allDirectives) {
+      const existing = rerunByLens.get(d.lens);
+      if (!existing) {
+        rerunByLens.set(d.lens, d);
+      } else if (severityRank(d.severity) < severityRank(existing.severity)) {
+        rerunByLens.set(d.lens, {
+          ...d,
+          reason: `${existing.reason}; ${d.reason}`,
+        });
+      } else if (severityRank(d.severity) === severityRank(existing.severity)) {
+        rerunByLens.set(d.lens, {
+          ...existing,
+          reason: existing.reason.includes(d.reason)
+            ? existing.reason
+            : `${existing.reason}; ${d.reason}`,
+        });
+      } else {
+        // existing is more severe — append d's reason to it
+        rerunByLens.set(d.lens, {
+          ...existing,
+          reason: existing.reason.includes(d.reason)
+            ? existing.reason
+            : `${existing.reason}; ${d.reason}`,
+        });
+      }
+    }
+    const rerunAuthor = [...rerunByLens.values()];
+
+    // 5. Decide.
+    const decision: ReviewerDecision['decision'] =
+      rerunAuthor.length > 0 ? 'fail' : 'pass';
+    const finalState =
+      decision === 'pass'
+        ? ('tests-reviewed' as const)
+        : ('tests-review-failed' as const);
+
+    const summary = buildSummary(decision, findings, rerunAuthor);
+
+    return {
+      decision,
+      finalState,
+      rerunAuthor,
+      advisories: allAdvisories,
+      findings,
+      summary,
+    };
+  }
+}
+
+function severityRank(s: Severity): number {
+  // Lower number = more severe (matches ea-reviewer).
+  return s === 'P0' ? 0 : s === 'P1' ? 1 : 2;
+}
+
+function buildSummary(
+  decision: 'pass' | 'fail',
+  findings: ReviewerFindings,
+  rerunAuthor: readonly RerunDirective[],
+): string {
+  if (decision === 'pass') {
+    const m =
+      findings.acCoverage.length +
+      findings.pyramid.length +
+      findings.edge.length +
+      findings.error.length +
+      findings.correctness.length;
+    if (m === 0) {
+      return 'Audit passed: AC-coverage, pyramid, edge, error, and correctness lenses all clean.';
+    }
+    return `Audit passed with ${m} non-blocking advisor${m === 1 ? 'y' : 'ies'}.`;
+  }
+  const lenses = rerunAuthor.map((r) => r.lens).join(', ');
+  return `Audit failed: ${rerunAuthor.length} lens(es) fired — ${lenses}. Test Author must re-run.`;
+}
+
+/** Functional flavour for tests + scripts. */
+export async function review(
+  input: ReviewerInput,
+  deps: ReviewerDeps = {},
+  opts: ReviewerOptions = {},
+): Promise<ReviewerDecision> {
+  return new TestReviewer(deps, opts).review(input);
+}
+
+export { REVIEWER_AGENT_ID };

--- a/packages/test-reviewer/src/types.ts
+++ b/packages/test-reviewer/src/types.ts
@@ -1,0 +1,350 @@
+/**
+ * @caia/test-reviewer — types.
+ *
+ * Sourced from:
+ *   - research/state_machine_handoff_spec_2026.md (canonical pipeline)
+ *   - research/caia_v3_final_plan_2026.md (Stage 11 ownership)
+ *   - plans/plan-2026-05-24-test-reviewer-subagent.md
+ *
+ * The Test Reviewer audits `ticket.testCases` (populated by the Test Author
+ * agent in Stage 10) against the testing strategy the Testing Architect
+ * declared into `tickets.architecture.testing.*`. It emits a single decision
+ * envelope the orchestrator consumes to either:
+ *
+ *   - pass → transition `tests-authored` → `tests-reviewed` (ticket → Scheduler).
+ *   - fail → chain `tests-authored` → `tests-reviewed` → `tests-review-failed`
+ *            (Test Author re-runs).
+ *
+ * The reviewer CANNOT write to `tickets.testCases` directly. It writes only
+ * to `tickets.review_status` and `tickets.review_feedback` (consistent with
+ * the @caia/ea-reviewer contract — both reviewers are critic-style audits,
+ * not authors).
+ */
+
+import type { Ticket } from '@caia/architect-kit';
+import type { TestCase } from '@chiefaia/ticket-template';
+import type { ProjectState } from '@caia/state-machine';
+
+// ─── Severity ──────────────────────────────────────────────────────────────
+
+export type Severity = 'P0' | 'P1' | 'P2';
+
+// ─── Inputs ────────────────────────────────────────────────────────────────
+
+/**
+ * The minimum subset of the canonical `Ticket` shape the reviewer needs.
+ * Real callers pass a full `Ticket`; tests can pass this narrow shape.
+ *
+ * `testCases` is required (Stage 10's Test Author populates it). An empty
+ * array is a legitimate input — it means the author produced no cases at
+ * all, which the AC-coverage lens will catch.
+ */
+export interface ReviewerTicket extends Ticket {
+  /** Test Author output — array of typed test cases. */
+  testCases?: readonly TestCase[];
+  /** Test Author metadata (totalCases, categoryCounts, etc.) — optional. */
+  testDesign?: {
+    designedBy?: string;
+    totalCases?: number;
+    categoryCounts?: Partial<Record<TestCase['category'], number>>;
+  };
+}
+
+/**
+ * The full input shape for `TestReviewer.review()`. Mirrors
+ * `@caia/ea-reviewer`'s `ReviewerInput`.
+ */
+export interface ReviewerInput {
+  ticket: ReviewerTicket;
+  /**
+   * The composed `tickets.architecture` JSONB — disjoint-key merge from the
+   * EA dispatcher. The reviewer reads the `testing.*` slice (the Testing
+   * Architect's strategy) and a handful of cross-architect fields
+   * (`a11y.wcagLevel`, `security.dataClassification`, `backend.*`,
+   * `frontend.componentTree`) to drive quality-tag floors.
+   */
+  composedArchitecture: Record<string, unknown>;
+  /**
+   * Acceptance criteria — usually `ticket.acceptance_criteria`, but the
+   * caller can override (e.g. if the criteria were normalized upstream).
+   * Drives the AC-coverage lens.
+   */
+  acceptanceCriteria?: readonly string[];
+}
+
+// ─── Outputs ───────────────────────────────────────────────────────────────
+
+/**
+ * The orchestrator dispatches `rerunAuthor` to `@caia/test-author`. Empty
+ * on pass. Mirrors `@caia/ea-reviewer`'s `RerunDirective` (which targets
+ * specific architects); we have one author so the directive is uniform.
+ */
+export interface RerunDirective {
+  /** Always `'test-author'` in v0.1 — kept as a field for forward compat. */
+  agent: 'test-author';
+  reason: string;
+  severity: Severity;
+  /** Lens that produced the directive (for traceability). */
+  lens: LensName;
+}
+
+export interface Advisory {
+  /** Either the agent that owns the issue, or `'global'` for cross-cutting. */
+  agent: 'test-author' | 'testing-architect' | 'global';
+  advisory: string;
+  severity: Severity;
+  lens: LensName;
+}
+
+export type LensName =
+  | 'acCoverage'
+  | 'pyramid'
+  | 'edge'
+  | 'error'
+  | 'correctness';
+
+/** The final state the orchestrator transitions to on pass. */
+export type PassFinalState = 'tests-reviewed';
+
+/** The final state the orchestrator transitions to on fail. */
+export type FailFinalState = 'tests-review-failed';
+
+/**
+ * Output of the reviewer. Identical shape to `@caia/ea-reviewer`'s
+ * `ReviewerDecision`, swapping `rerunArchitects → rerunAuthor`.
+ */
+export interface ReviewerDecision {
+  decision: 'pass' | 'fail';
+  /**
+   * `tests-reviewed` on pass; `tests-review-failed` on fail. Note the
+   * orchestrator must emit the canonical chain (see api.ts) to satisfy the
+   * @caia/state-machine transition table.
+   */
+  finalState: PassFinalState | FailFinalState;
+  rerunAuthor: readonly RerunDirective[];
+  advisories: readonly Advisory[];
+  findings: ReviewerFindings;
+  summary: string;
+}
+
+export interface ReviewerFindings {
+  acCoverage: readonly AcCoverageFinding[];
+  pyramid: readonly PyramidFinding[];
+  edge: readonly EdgeFinding[];
+  error: readonly ErrorFinding[];
+  correctness: readonly CorrectnessFinding[];
+}
+
+export interface AcCoverageFinding {
+  /** 0-based index into `acceptanceCriteria`. */
+  acIndex: number;
+  acText: string;
+  reason: string;
+  severity: Severity;
+}
+
+export interface PyramidFinding {
+  layer: TestCase['layer'];
+  /** Actual % of cases at this layer. */
+  actualPct: number;
+  /** Target % per Testing Architect's mix; null if architect absent. */
+  targetPct: number | null;
+  reason: string;
+  severity: Severity;
+}
+
+export interface EdgeFinding {
+  reason: string;
+  severity: Severity;
+}
+
+export interface ErrorFinding {
+  /**
+   * The qualifier this finding hangs off — `'baseline'` (one error test),
+   * `'a11y'` (wcagLevel set), `'security'` (PII / confidential), etc.
+   */
+  qualifier: 'baseline' | 'a11y' | 'security';
+  reason: string;
+  severity: Severity;
+}
+
+export interface CorrectnessFinding {
+  testCaseId?: string;
+  reason: string;
+  severity: Severity;
+}
+
+// ─── Critic adapter (correctness-lens DI seam) ────────────────────────────
+
+/**
+ * The reviewer delegates LLM-judge case-quality review to an adapter so
+ * tests can swap in a mock. Default impl: `NullCriticAdapter` (returns no
+ * findings; the deterministic lenses do all the work). Heuristic impl:
+ * `HeuristicCriticAdapter` (token-overlap on AC vs `given/when/then`).
+ * Production: `@chiefaia/claude-spawner`-backed adapter (subscription-only
+ * per P14, no API-key billing).
+ */
+export interface CriticAdapter {
+  judge(input: {
+    testCases: readonly TestCase[];
+    acceptanceCriteria: readonly string[];
+    composedArchitecture: Record<string, unknown>;
+  }): Promise<readonly CorrectnessFinding[]>;
+}
+
+// ─── Reviewer options ─────────────────────────────────────────────────────
+
+export interface ReviewerOptions {
+  /**
+   * Severities that count as blocking — any finding at or above this level
+   * forces `decision: 'fail'`. Default: ['P0', 'P1'].
+   */
+  blockingSeverities?: readonly Severity[];
+  /**
+   * Severity attached to AC-coverage misses. Default: 'P1'.
+   */
+  acCoverageMissSeverity?: Severity;
+  /**
+   * Severity for a pyramid layer below target (< 50% of declared share).
+   * Default: 'P1'.
+   */
+  pyramidUnderfillSeverity?: Severity;
+  /**
+   * Severity for a pyramid layer well above target (> 200% of declared share).
+   * Default: 'P2' (advisory).
+   */
+  pyramidOverfillSeverity?: Severity;
+  /**
+   * Minimum number of edge-case tests required. The reviewer takes the max
+   * of this floor and `ceil(totalCases / 10)`. Default: 1.
+   */
+  edgeCaseFloor?: number;
+  /**
+   * Severity attached to insufficient edge cases. Default: 'P1'.
+   */
+  edgeCaseMissSeverity?: Severity;
+  /**
+   * Severity attached to missing error-state coverage. Default: 'P1'.
+   */
+  errorMissSeverity?: Severity;
+  /**
+   * Hard floor on `unit` layer share when the Testing Architect's mix is
+   * absent (or the ticket type doesn't appear in the mix). Default: 30.
+   */
+  unitFloorPct?: number;
+  /**
+   * Hard ceiling on `e2e` layer share when the architect's mix is absent.
+   * Default: 50.
+   */
+  e2eCeilingPct?: number;
+}
+
+export const DEFAULT_REVIEWER_OPTIONS: Required<ReviewerOptions> = {
+  blockingSeverities: ['P0', 'P1'],
+  acCoverageMissSeverity: 'P1',
+  pyramidUnderfillSeverity: 'P1',
+  pyramidOverfillSeverity: 'P2',
+  edgeCaseFloor: 1,
+  edgeCaseMissSeverity: 'P1',
+  errorMissSeverity: 'P1',
+  unitFloorPct: 30,
+  e2eCeilingPct: 50,
+};
+
+// ─── State-machine integration ────────────────────────────────────────────
+
+/**
+ * The single canonical agent ID used in state-machine transitions
+ * (`triggeredBy.id`). Mirrors `@caia/ea-reviewer`'s `REVIEWER_AGENT_ID`.
+ */
+export const REVIEWER_AGENT_ID = 'test-reviewer' as const;
+
+/**
+ * The fixed pre-state the reviewer reads tickets from. The orchestrator
+ * guarantees the ticket is in this state before invoking the reviewer.
+ */
+export const REVIEWER_PRE_STATE: ProjectState = 'tests-authored';
+
+/**
+ * The pass target. Single transition: `tests-authored → tests-reviewed`.
+ */
+export const REVIEWER_PASS_STATE: PassFinalState = 'tests-reviewed';
+
+/**
+ * The intermediate state on the fail path. Per the canonical transition
+ * table (`@caia/state-machine`), `tests-review-failed` is only reachable
+ * FROM `tests-reviewed`, so the fail path must chain through it.
+ */
+export const REVIEWER_FAIL_INTERMEDIATE_STATE: PassFinalState =
+  'tests-reviewed';
+
+/**
+ * The fail target.
+ */
+export const REVIEWER_FAIL_STATE: FailFinalState = 'tests-review-failed';
+
+// ─── State-machine adapter (DI seam) ──────────────────────────────────────
+
+/**
+ * Narrow interface the api.ts wrapper uses to emit transitions. The
+ * production adapter wraps `@caia/state-machine`'s `StateMachine` class;
+ * tests can pass an in-memory stub that records the transitions emitted.
+ */
+export interface StateMachineAdapter {
+  transition(input: {
+    ticketId: string;
+    from: ProjectState;
+    to: ProjectState;
+    triggeredBy: { kind: 'agent'; id: typeof REVIEWER_AGENT_ID };
+    payload: {
+      /** True for the intermediate hop on the fail chain. */
+      intermediate?: boolean;
+      decision: ReviewerDecision['decision'];
+      findings?: ReviewerFindings;
+      summary?: string;
+    };
+  }): Promise<void>;
+}
+
+// ─── Ticket store (DI seam) ───────────────────────────────────────────────
+
+/**
+ * The narrow interface api.ts uses to load a ticket by ID. Production
+ * wires this to whatever store the orchestrator owns; tests pass an
+ * in-memory map.
+ */
+export interface TicketStore {
+  loadTicket(ticketId: string): Promise<ReviewerTicket>;
+}
+
+/**
+ * The narrow interface api.ts uses to load the composed architecture for
+ * a ticket. Often the architecture is on the ticket itself (`ticket.architecture`),
+ * but this seam lets callers source it from a separate table.
+ */
+export interface ArchitectureStore {
+  loadArchitecture(ticketId: string): Promise<Record<string, unknown>>;
+}
+
+// ─── ReviewOutcome (api.ts return) ────────────────────────────────────────
+
+/**
+ * The thing `reviewTicket(ticketId)` returns to the orchestrator. Wraps
+ * the reviewer's `ReviewerDecision` with the list of state-machine
+ * transitions actually emitted, for audit/replay.
+ */
+export interface ReviewOutcome {
+  ticketId: string;
+  decision: ReviewerDecision;
+  /**
+   * Every transition the api.ts wrapper emitted, in order. On pass: one
+   * row (`tests-authored → tests-reviewed`). On fail: two rows
+   * (`tests-authored → tests-reviewed` with `intermediate: true`, then
+   * `tests-reviewed → tests-review-failed`).
+   */
+  emittedTransitions: ReadonlyArray<{
+    from: ProjectState;
+    to: ProjectState;
+    intermediate: boolean;
+  }>;
+}

--- a/packages/test-reviewer/tests/ac-coverage.test.ts
+++ b/packages/test-reviewer/tests/ac-coverage.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { runAcCoverageLens } from '../src/lenses/ac-coverage.js';
+import { makeTestCase } from './fixtures.js';
+
+describe('runAcCoverageLens', () => {
+  it('returns no findings when every AC has a happy linked test', () => {
+    const findings = runAcCoverageLens({
+      testCases: [
+        makeTestCase({ category: 'happy', linkedAcceptanceCriterionIndex: 0 }),
+        makeTestCase({ category: 'happy', linkedAcceptanceCriterionIndex: 1 }),
+      ],
+      acceptanceCriteria: ['AC0', 'AC1'],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('flags an AC with no linked test at all', () => {
+    const findings = runAcCoverageLens({
+      testCases: [
+        makeTestCase({ category: 'happy', linkedAcceptanceCriterionIndex: 0 }),
+      ],
+      acceptanceCriteria: ['AC0', 'AC1'],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.acIndex).toBe(1);
+    expect(findings[0]?.reason).toMatch(/no linked test case/);
+  });
+
+  it('flags an AC linked only by edge/error tests (missing happy)', () => {
+    const findings = runAcCoverageLens({
+      testCases: [
+        makeTestCase({ category: 'error', linkedAcceptanceCriterionIndex: 0 }),
+        makeTestCase({ category: 'edge', linkedAcceptanceCriterionIndex: 0 }),
+      ],
+      acceptanceCriteria: ['AC0'],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.reason).toMatch(/none with category='happy'/);
+  });
+
+  it('emits no findings on empty acceptance-criteria array', () => {
+    const findings = runAcCoverageLens({
+      testCases: [makeTestCase({ category: 'happy' })],
+      acceptanceCriteria: [],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('emits findings for every AC when test-cases is empty', () => {
+    const findings = runAcCoverageLens({
+      testCases: [],
+      acceptanceCriteria: ['A', 'B', 'C'],
+    });
+    expect(findings).toHaveLength(3);
+    expect(findings.map((f) => f.acIndex)).toEqual([0, 1, 2]);
+  });
+
+  it('honors a custom severity', () => {
+    const findings = runAcCoverageLens({
+      testCases: [],
+      acceptanceCriteria: ['AC0'],
+      severity: 'P0',
+    });
+    expect(findings[0]?.severity).toBe('P0');
+  });
+
+  it('records the AC text on the finding', () => {
+    const findings = runAcCoverageLens({
+      testCases: [],
+      acceptanceCriteria: ['User can log in'],
+    });
+    expect(findings[0]?.acText).toBe('User can log in');
+  });
+});

--- a/packages/test-reviewer/tests/api.test.ts
+++ b/packages/test-reviewer/tests/api.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import { reviewTicket } from '../src/api.js';
+import {
+  cleanComposedArchitecture,
+  cleanTestCases,
+  InMemoryArchitectureStore,
+  InMemoryTicketStore,
+  makeTestCase,
+  RecordingStateMachine,
+  stubTicket,
+} from './fixtures.js';
+
+describe('reviewTicket — pass path', () => {
+  it('emits a single tests-authored → tests-reviewed transition', async () => {
+    const sm = new RecordingStateMachine();
+    const ticket = stubTicket({
+      id: 't-pass',
+      testCases: cleanTestCases(),
+    });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+    const as = new InMemoryArchitectureStore(
+      new Map([[ticket.id, cleanComposedArchitecture()]]),
+    );
+
+    const outcome = await reviewTicket('t-pass', {
+      ticketStore: ts,
+      architectureStore: as,
+      stateMachine: sm,
+    });
+
+    expect(outcome.decision.decision).toBe('pass');
+    expect(sm.emissions).toHaveLength(1);
+    expect(sm.emissions[0]?.from).toBe('tests-authored');
+    expect(sm.emissions[0]?.to).toBe('tests-reviewed');
+    expect(outcome.emittedTransitions).toHaveLength(1);
+    expect(outcome.emittedTransitions[0]?.intermediate).toBe(false);
+  });
+
+  it('marks the agent id on the transition', async () => {
+    const sm = new RecordingStateMachine();
+    const ticket = stubTicket({
+      id: 't-pass-2',
+      testCases: cleanTestCases(),
+    });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+    const as = new InMemoryArchitectureStore(
+      new Map([[ticket.id, cleanComposedArchitecture()]]),
+    );
+
+    await reviewTicket('t-pass-2', {
+      ticketStore: ts,
+      architectureStore: as,
+      stateMachine: sm,
+    });
+
+    expect(sm.emissions[0]?.triggeredById).toBe('test-reviewer');
+  });
+});
+
+describe('reviewTicket — fail path', () => {
+  it('emits the canonical chain on fail', async () => {
+    const sm = new RecordingStateMachine();
+    // Suite with empty testCases — fails the AC-coverage lens.
+    const ticket = stubTicket({ id: 't-fail', testCases: [] });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+    const as = new InMemoryArchitectureStore(
+      new Map([[ticket.id, cleanComposedArchitecture()]]),
+    );
+
+    const outcome = await reviewTicket('t-fail', {
+      ticketStore: ts,
+      architectureStore: as,
+      stateMachine: sm,
+    });
+
+    expect(outcome.decision.decision).toBe('fail');
+    expect(sm.emissions).toHaveLength(2);
+    expect(sm.emissions[0]?.from).toBe('tests-authored');
+    expect(sm.emissions[0]?.to).toBe('tests-reviewed');
+    expect(sm.emissions[1]?.from).toBe('tests-reviewed');
+    expect(sm.emissions[1]?.to).toBe('tests-review-failed');
+    expect(outcome.emittedTransitions[0]?.intermediate).toBe(true);
+    expect(outcome.emittedTransitions[1]?.intermediate).toBe(false);
+  });
+
+  it('intermediate row has payload.intermediate=true and no findings', async () => {
+    const sm = new RecordingStateMachine();
+    const ticket = stubTicket({ id: 't-fail-2', testCases: [] });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+    const as = new InMemoryArchitectureStore(
+      new Map([[ticket.id, cleanComposedArchitecture()]]),
+    );
+
+    await reviewTicket('t-fail-2', {
+      ticketStore: ts,
+      architectureStore: as,
+      stateMachine: sm,
+    });
+
+    const intermediate = sm.emissions[0]?.payload as {
+      intermediate?: boolean;
+      findings?: unknown;
+    };
+    expect(intermediate.intermediate).toBe(true);
+    expect(intermediate.findings).toBeUndefined();
+
+    const terminal = sm.emissions[1]?.payload as {
+      intermediate?: boolean;
+      findings?: unknown;
+    };
+    expect(terminal.intermediate).toBeUndefined();
+    expect(terminal.findings).toBeDefined();
+  });
+});
+
+describe('reviewTicket — architecture sourcing', () => {
+  it('falls back to ticket.architecture when no architectureStore', async () => {
+    const sm = new RecordingStateMachine();
+    const ticket = stubTicket({
+      id: 't-arch-on-ticket',
+      testCases: cleanTestCases(),
+      architecture: cleanComposedArchitecture(),
+    });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+
+    const outcome = await reviewTicket('t-arch-on-ticket', {
+      ticketStore: ts,
+      stateMachine: sm,
+    });
+    expect(outcome.decision.decision).toBe('pass');
+  });
+
+  it('uses empty architecture when neither store nor ticket has one', async () => {
+    const sm = new RecordingStateMachine();
+    const ticket = stubTicket({
+      id: 't-no-arch',
+      // Suite that doesn't depend on any architecture-driven floors:
+      testCases: [
+        makeTestCase({
+          category: 'happy',
+          linkedAcceptanceCriterionIndex: 0,
+        }),
+        makeTestCase({
+          category: 'happy',
+          linkedAcceptanceCriterionIndex: 1,
+        }),
+        makeTestCase({ category: 'edge' }),
+        makeTestCase({ category: 'error' }),
+        makeTestCase({ category: 'happy', layer: 'integration' }),
+      ],
+    });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+
+    const outcome = await reviewTicket('t-no-arch', {
+      ticketStore: ts,
+      stateMachine: sm,
+    });
+    expect(outcome.decision.decision).toBe('pass');
+  });
+});
+
+describe('reviewTicket — error paths', () => {
+  it('propagates "ticket not found" from the store', async () => {
+    const sm = new RecordingStateMachine();
+    const ts = new InMemoryTicketStore(new Map());
+
+    await expect(
+      reviewTicket('missing', { ticketStore: ts, stateMachine: sm }),
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+describe('reviewTicket — option pass-through', () => {
+  it('respects fromState override', async () => {
+    const sm = new RecordingStateMachine();
+    const ticket = stubTicket({
+      id: 't-from',
+      testCases: cleanTestCases(),
+    });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+    const as = new InMemoryArchitectureStore(
+      new Map([[ticket.id, cleanComposedArchitecture()]]),
+    );
+    await reviewTicket(
+      't-from',
+      { ticketStore: ts, architectureStore: as, stateMachine: sm },
+      { fromState: 'paused' },
+    );
+    expect(sm.emissions[0]?.from).toBe('paused');
+  });
+
+  it('respects custom blockingSeverities', async () => {
+    const sm = new RecordingStateMachine();
+    // Suite that fires P1 edge finding by default.
+    const ticket = stubTicket({
+      id: 't-block',
+      testCases: [
+        makeTestCase({
+          category: 'happy',
+          linkedAcceptanceCriterionIndex: 0,
+        }),
+        makeTestCase({
+          category: 'happy',
+          linkedAcceptanceCriterionIndex: 1,
+        }),
+        makeTestCase({ category: 'happy', layer: 'integration' }),
+        makeTestCase({ category: 'error' }),
+        makeTestCase({
+          category: 'accessibility',
+          layer: 'accessibility',
+        }),
+      ],
+    });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+    const as = new InMemoryArchitectureStore(
+      new Map([[ticket.id, cleanComposedArchitecture()]]),
+    );
+    const outcome = await reviewTicket(
+      't-block',
+      { ticketStore: ts, architectureStore: as, stateMachine: sm },
+      { blockingSeverities: ['P0'] },
+    );
+    expect(outcome.decision.decision).toBe('pass');
+  });
+});

--- a/packages/test-reviewer/tests/critic.test.ts
+++ b/packages/test-reviewer/tests/critic.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FixedCriticAdapter,
+  HeuristicCriticAdapter,
+  NullCriticAdapter,
+} from '../src/critic.js';
+import { makeTestCase } from './fixtures.js';
+
+describe('NullCriticAdapter', () => {
+  it('returns no findings regardless of input', async () => {
+    const a = new NullCriticAdapter();
+    expect(
+      await a.judge({
+        testCases: [],
+        acceptanceCriteria: ['a'],
+        composedArchitecture: {},
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('FixedCriticAdapter', () => {
+  it('returns its canned findings', async () => {
+    const canned = [
+      { testCaseId: 'tc-1', reason: 'forced', severity: 'P1' as const },
+    ];
+    const a = new FixedCriticAdapter(canned);
+    expect(
+      await a.judge({
+        testCases: [],
+        acceptanceCriteria: [],
+        composedArchitecture: {},
+      }),
+    ).toEqual(canned);
+  });
+});
+
+describe('HeuristicCriticAdapter', () => {
+  it('returns no findings when test gwt overlaps the AC tokens', async () => {
+    const a = new HeuristicCriticAdapter();
+    const findings = await a.judge({
+      testCases: [
+        makeTestCase({
+          id: 'tc-good',
+          linkedAcceptanceCriterionIndex: 0,
+          given: 'a registered customer',
+          when: 'attempts to register again',
+          then: 'a duplicate-registration error appears',
+        }),
+      ],
+      acceptanceCriteria: ['customer registration cannot duplicate'],
+      composedArchitecture: {},
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('flags a linked test whose gwt does not overlap the AC tokens', async () => {
+    const a = new HeuristicCriticAdapter();
+    const findings = await a.judge({
+      testCases: [
+        makeTestCase({
+          id: 'tc-bad',
+          linkedAcceptanceCriterionIndex: 0,
+          given: 'unrelated stuff',
+          when: 'nothing relevant',
+          then: 'asserts something else',
+        }),
+      ],
+      acceptanceCriteria: ['admin can revoke api credentials'],
+      composedArchitecture: {},
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.testCaseId).toBe('tc-bad');
+  });
+
+  it('skips ACs with no linked tests (delegated to AC-coverage lens)', async () => {
+    const a = new HeuristicCriticAdapter();
+    expect(
+      await a.judge({
+        testCases: [],
+        acceptanceCriteria: ['anything'],
+        composedArchitecture: {},
+      }),
+    ).toEqual([]);
+  });
+
+  it('ignores ACs that tokenize to nothing (all stopwords)', async () => {
+    const a = new HeuristicCriticAdapter();
+    expect(
+      await a.judge({
+        testCases: [
+          makeTestCase({ linkedAcceptanceCriterionIndex: 0 }),
+        ],
+        acceptanceCriteria: ['this that with from'],
+        composedArchitecture: {},
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/test-reviewer/tests/edge.test.ts
+++ b/packages/test-reviewer/tests/edge.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { runEdgeLens } from '../src/lenses/edge.js';
+import { makeTestCase } from './fixtures.js';
+
+describe('runEdgeLens', () => {
+  it('emits no findings on empty test-cases', () => {
+    expect(runEdgeLens({ testCases: [] })).toEqual([]);
+  });
+
+  it('passes a small suite with one edge case', () => {
+    expect(
+      runEdgeLens({
+        testCases: [
+          makeTestCase({ category: 'happy' }),
+          makeTestCase({ category: 'edge' }),
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it('fires when a 5-case suite has no edge cases', () => {
+    const findings = runEdgeLens({
+      testCases: [
+        makeTestCase({ category: 'happy' }),
+        makeTestCase({ category: 'happy' }),
+        makeTestCase({ category: 'happy' }),
+        makeTestCase({ category: 'happy' }),
+        makeTestCase({ category: 'happy' }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.reason).toMatch(/no edge-case tests/);
+  });
+
+  it('scales with suite size — 20-case suite needs 2', () => {
+    const cases = Array.from({ length: 20 }, () =>
+      makeTestCase({ category: 'happy' }),
+    );
+    cases[0] = makeTestCase({ category: 'edge' });
+    const findings = runEdgeLens({ testCases: cases });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.reason).toMatch(/only 1 edge-case test/);
+  });
+
+  it('passes when ratio is met for a large suite', () => {
+    const cases = Array.from({ length: 30 }, (_, i) =>
+      makeTestCase({ category: i < 3 ? 'edge' : 'happy' }),
+    );
+    expect(runEdgeLens({ testCases: cases })).toEqual([]);
+  });
+
+  it('honors a custom floor', () => {
+    const findings = runEdgeLens({
+      testCases: [
+        makeTestCase({ category: 'happy' }),
+        makeTestCase({ category: 'edge' }),
+      ],
+      floor: 3,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it('honors a custom severity', () => {
+    const findings = runEdgeLens({
+      testCases: [
+        makeTestCase({ category: 'happy' }),
+        makeTestCase({ category: 'happy' }),
+      ],
+      severity: 'P0',
+    });
+    expect(findings[0]?.severity).toBe('P0');
+  });
+});

--- a/packages/test-reviewer/tests/error.test.ts
+++ b/packages/test-reviewer/tests/error.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { runErrorLens } from '../src/lenses/error.js';
+import { makeTestCase } from './fixtures.js';
+
+describe('runErrorLens', () => {
+  it('emits no findings on empty test-cases', () => {
+    expect(
+      runErrorLens({ testCases: [], composedArchitecture: {} }),
+    ).toEqual([]);
+  });
+
+  it('fires the baseline finding when no error test exists', () => {
+    const findings = runErrorLens({
+      testCases: [
+        makeTestCase({ category: 'happy' }),
+        makeTestCase({ category: 'edge' }),
+      ],
+      composedArchitecture: {},
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.qualifier).toBe('baseline');
+  });
+
+  it('passes when at least one error test exists and no quality-tag floors fire', () => {
+    expect(
+      runErrorLens({
+        testCases: [
+          makeTestCase({ category: 'happy' }),
+          makeTestCase({ category: 'error' }),
+        ],
+        composedArchitecture: {},
+      }),
+    ).toEqual([]);
+  });
+
+  it('fires the a11y floor when wcagLevel is set but no accessibility tests exist', () => {
+    const findings = runErrorLens({
+      testCases: [
+        makeTestCase({ category: 'happy' }),
+        makeTestCase({ category: 'error' }),
+      ],
+      composedArchitecture: { 'a11y.wcagLevel': 'AA' },
+    });
+    expect(findings.some((f) => f.qualifier === 'a11y')).toBe(true);
+  });
+
+  it('passes the a11y floor when an accessibility test exists', () => {
+    const findings = runErrorLens({
+      testCases: [
+        makeTestCase({ category: 'error' }),
+        makeTestCase({ category: 'accessibility' }),
+      ],
+      composedArchitecture: { 'a11y.wcagLevel': 'AA' },
+    });
+    expect(findings.some((f) => f.qualifier === 'a11y')).toBe(false);
+  });
+
+  it('fires the security floor when dataClassification is PII', () => {
+    const findings = runErrorLens({
+      testCases: [
+        makeTestCase({ category: 'happy' }),
+        makeTestCase({ category: 'error' }),
+      ],
+      composedArchitecture: { 'security.dataClassification': 'PII' },
+    });
+    expect(findings.some((f) => f.qualifier === 'security')).toBe(true);
+  });
+
+  it('fires the security floor when dataClassification is confidential', () => {
+    const findings = runErrorLens({
+      testCases: [makeTestCase({ category: 'error' })],
+      composedArchitecture: { 'security.dataClassification': 'confidential' },
+    });
+    expect(findings.some((f) => f.qualifier === 'security')).toBe(true);
+  });
+
+  it('does NOT fire the security floor when data classification is public', () => {
+    const findings = runErrorLens({
+      testCases: [makeTestCase({ category: 'error' })],
+      composedArchitecture: { 'security.dataClassification': 'public' },
+    });
+    expect(findings.some((f) => f.qualifier === 'security')).toBe(false);
+  });
+
+  it('passes the security floor when a security test exists', () => {
+    expect(
+      runErrorLens({
+        testCases: [
+          makeTestCase({ category: 'error' }),
+          makeTestCase({ category: 'security' }),
+        ],
+        composedArchitecture: { 'security.dataClassification': 'PII' },
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/test-reviewer/tests/fixtures.ts
+++ b/packages/test-reviewer/tests/fixtures.ts
@@ -1,0 +1,188 @@
+/**
+ * Test fixtures for @caia/test-reviewer.
+ */
+
+import type { TestCase } from '@chiefaia/ticket-template';
+import type { ProjectState } from '@caia/state-machine';
+import type {
+  ArchitectureStore,
+  ReviewerInput,
+  ReviewerTicket,
+  StateMachineAdapter,
+  TicketStore,
+} from '../src/types.js';
+
+let counter = 0;
+function nextId(): string {
+  counter += 1;
+  return `tc-${counter}`;
+}
+
+export function makeTestCase(overrides: Partial<TestCase> = {}): TestCase {
+  return {
+    id: overrides.id ?? nextId(),
+    title: overrides.title ?? 'Sample test',
+    category: overrides.category ?? 'happy',
+    layer: overrides.layer ?? 'unit',
+    given: overrides.given ?? 'a sample given',
+    when: overrides.when ?? 'the action is taken',
+    then: overrides.then ?? 'the expected outcome holds',
+    linkedAcceptanceCriterionIndex: overrides.linkedAcceptanceCriterionIndex,
+    selectorHints: overrides.selectorHints ?? [],
+    mocks: overrides.mocks ?? [],
+    status: overrides.status ?? 'pending',
+    designedBy: overrides.designedBy ?? 'testing-agent',
+  } as TestCase;
+}
+
+export function stubTicket(overrides: Partial<ReviewerTicket> = {}): ReviewerTicket {
+  return {
+    id: 't-1',
+    type: 'Page',
+    acceptance_criteria: [
+      'User can sign up via the signup form',
+      'User sees a confirmation message after signup',
+    ],
+    ...overrides,
+  } as ReviewerTicket;
+}
+
+export function cleanComposedArchitecture(): Record<string, unknown> {
+  return {
+    'testing.testingStrategy': {
+      pyramidShape: 'broad-base',
+      rationale: 'standard',
+      riskAreas: ['signup'],
+      owner: 'test-author',
+      reviewer: 'test-reviewer',
+    },
+    'testing.testTypeMixPercentages': {
+      Page: { unit: 60, integration: 20, e2e: 10, visual: 5, a11y: 3, perf: 2 },
+      Story: { unit: 60, integration: 20, e2e: 10, visual: 5, a11y: 3, perf: 2 },
+    },
+    'a11y.wcagLevel': 'AA',
+    'security.dataClassification': 'public',
+    'frontend.componentTree': [{ id: 'signup-form', interactive: true }],
+    'backend.endpointEnumeration': [{ path: '/api/signup' }],
+  };
+}
+
+/**
+ * A clean test suite — 10 cases:
+ *   6 unit (4 happy, 1 edge, 1 error)
+ *   2 integration happy (linking ACs 0 + 1)
+ *   1 e2e happy
+ *   1 accessibility (WCAG floor)
+ * Both ACs covered by happy tests at unit layer (tc-u1 ↔ AC#0, tc-u2 ↔ AC#1).
+ */
+export function cleanTestCases(): TestCase[] {
+  counter = 0;
+  return [
+    makeTestCase({
+      id: 'tc-u1',
+      category: 'happy',
+      layer: 'unit',
+      linkedAcceptanceCriterionIndex: 0,
+      given: 'a fresh user',
+      when: 'they submit the signup form',
+      then: 'the signup request is accepted',
+    }),
+    makeTestCase({
+      id: 'tc-u2',
+      category: 'happy',
+      layer: 'unit',
+      linkedAcceptanceCriterionIndex: 1,
+      given: 'a successful signup',
+      when: 'the user lands on the post-signup page',
+      then: 'a confirmation message is shown',
+    }),
+    makeTestCase({ id: 'tc-u3', category: 'happy', layer: 'unit' }),
+    makeTestCase({ id: 'tc-u4', category: 'happy', layer: 'unit' }),
+    makeTestCase({
+      id: 'tc-u5',
+      category: 'edge',
+      layer: 'unit',
+      given: 'an empty form',
+      when: 'submitted',
+      then: 'validation fires',
+    }),
+    makeTestCase({
+      id: 'tc-u6',
+      category: 'error',
+      layer: 'unit',
+      given: 'a duplicate signup',
+      when: 'submitted',
+      then: 'a 409 is returned',
+    }),
+    makeTestCase({
+      id: 'tc-i1',
+      category: 'happy',
+      layer: 'integration',
+      linkedAcceptanceCriterionIndex: 0,
+    }),
+    makeTestCase({
+      id: 'tc-i2',
+      category: 'happy',
+      layer: 'integration',
+      linkedAcceptanceCriterionIndex: 1,
+    }),
+    makeTestCase({ id: 'tc-e1', category: 'happy', layer: 'e2e' }),
+    makeTestCase({
+      id: 'tc-a1',
+      category: 'accessibility',
+      layer: 'accessibility',
+    }),
+  ];
+}
+
+export function cleanReviewerInput(): ReviewerInput {
+  return {
+    ticket: stubTicket({ testCases: cleanTestCases() }),
+    composedArchitecture: cleanComposedArchitecture(),
+  };
+}
+
+// ─── In-memory stores ──────────────────────────────────────────────────────
+
+export class InMemoryTicketStore implements TicketStore {
+  constructor(private readonly tickets: Map<string, ReviewerTicket>) {}
+  async loadTicket(ticketId: string): Promise<ReviewerTicket> {
+    const t = this.tickets.get(ticketId);
+    if (!t) throw new Error(`ticket not found: ${ticketId}`);
+    return t;
+  }
+}
+
+export class InMemoryArchitectureStore implements ArchitectureStore {
+  constructor(private readonly archs: Map<string, Record<string, unknown>>) {}
+  async loadArchitecture(ticketId: string): Promise<Record<string, unknown>> {
+    return this.archs.get(ticketId) ?? {};
+  }
+}
+
+export interface RecordedTransition {
+  ticketId: string;
+  from: ProjectState;
+  to: ProjectState;
+  triggeredById: string;
+  payload: unknown;
+}
+
+export class RecordingStateMachine implements StateMachineAdapter {
+  readonly emissions: RecordedTransition[] = [];
+  async transition(input: {
+    ticketId: string;
+    from: ProjectState;
+    to: ProjectState;
+    triggeredBy: { kind: 'agent'; id: 'test-reviewer' };
+    payload: unknown;
+  }): Promise<void> {
+    this.emissions.push({
+      ticketId: input.ticketId,
+      from: input.from,
+      to: input.to,
+      triggeredById: input.triggeredBy.id,
+      payload: input.payload,
+    });
+  }
+}

--- a/packages/test-reviewer/tests/golden.test.ts
+++ b/packages/test-reviewer/tests/golden.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Golden tests — pin the exact structure of the `ReviewerDecision`
+ * envelope on representative inputs. If anyone changes the shape of
+ * the output, these break and force a deliberate update.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { review } from '../src/reviewer.js';
+import { NullCriticAdapter } from '../src/critic.js';
+import {
+  cleanComposedArchitecture,
+  cleanTestCases,
+  makeTestCase,
+  stubTicket,
+} from './fixtures.js';
+
+describe('golden — clean pass', () => {
+  it('matches the canonical clean-pass envelope', async () => {
+    const d = await review(
+      {
+        ticket: stubTicket({ testCases: cleanTestCases() }),
+        composedArchitecture: cleanComposedArchitecture(),
+      },
+      { critic: new NullCriticAdapter() },
+    );
+    expect({
+      decision: d.decision,
+      finalState: d.finalState,
+      rerunAuthorCount: d.rerunAuthor.length,
+      advisoriesCount: d.advisories.length,
+      findingsKeys: Object.keys(d.findings).sort(),
+    }).toEqual({
+      decision: 'pass',
+      finalState: 'tests-reviewed',
+      rerunAuthorCount: 0,
+      advisoriesCount: 0,
+      findingsKeys: [
+        'acCoverage',
+        'correctness',
+        'edge',
+        'error',
+        'pyramid',
+      ],
+    });
+  });
+});
+
+describe('golden — empty-testcases fail envelope', () => {
+  it('produces exactly one rerunAuthor entry per lens that fired', async () => {
+    const d = await review(
+      {
+        ticket: stubTicket({ testCases: [] }),
+        composedArchitecture: cleanComposedArchitecture(),
+      },
+      { critic: new NullCriticAdapter() },
+    );
+
+    // Empty test-cases fires acCoverage. Pyramid/edge/error short-circuit
+    // on empty input by design. Exactly one rerun lens: 'acCoverage'.
+    const lenses = d.rerunAuthor.map((r) => r.lens).sort();
+    expect(lenses).toEqual(['acCoverage']);
+    expect(d.decision).toBe('fail');
+    expect(d.finalState).toBe('tests-review-failed');
+  });
+});
+
+describe('golden — pyramid fail envelope', () => {
+  it('shape on a 100% e2e suite', async () => {
+    const ticket = stubTicket({
+      testCases: [
+        makeTestCase({
+          id: 'e1',
+          category: 'happy',
+          layer: 'e2e',
+          linkedAcceptanceCriterionIndex: 0,
+        }),
+        makeTestCase({
+          id: 'e2',
+          category: 'happy',
+          layer: 'e2e',
+          linkedAcceptanceCriterionIndex: 1,
+        }),
+        makeTestCase({ id: 'e3', category: 'edge', layer: 'e2e' }),
+        makeTestCase({ id: 'e4', category: 'error', layer: 'e2e' }),
+        makeTestCase({ id: 'e5', category: 'accessibility', layer: 'e2e' }),
+      ],
+    });
+    const d = await review(
+      { ticket, composedArchitecture: cleanComposedArchitecture() },
+      { critic: new NullCriticAdapter() },
+    );
+    expect(d.decision).toBe('fail');
+    expect(d.rerunAuthor.some((r) => r.lens === 'pyramid')).toBe(true);
+    expect(
+      d.rerunAuthor.every((r) => r.severity === 'P0' || r.severity === 'P1'),
+    ).toBe(true);
+  });
+});
+
+describe('golden — every rerun directive targets test-author', () => {
+  it('agent field is always "test-author"', async () => {
+    const d = await review(
+      {
+        ticket: stubTicket({ testCases: [] }),
+        composedArchitecture: cleanComposedArchitecture(),
+      },
+      { critic: new NullCriticAdapter() },
+    );
+    expect(d.rerunAuthor.every((r) => r.agent === 'test-author')).toBe(true);
+  });
+});
+
+describe('golden — overfill advisory shape', () => {
+  it('overfill pyramid finding lands in advisories with testing-architect agent', async () => {
+    // 23-case suite tuned so the integration layer overshoots its target.
+    //   9 unit (39.1%): 2 happy linked AC#0+#1, 3 happy, 3 edge, 1 error
+    //   10 integration happy (43.5%) → over-fill threshold 41% → fires
+    //   2 e2e happy (8.7%) — within range
+    //   1 visual (4.3%) — meets ~5% target
+    //   1 accessibility (4.3%) — covers WCAG floor (a11y target 3% expected
+    //     0.7 < 1 → skipped from over-fill check)
+    // unit-floor (30%) cleared; edge ratio (ceil(23/10)=3) met; one error;
+    // one accessibility.
+    const cases = [
+      makeTestCase({ id: 'u1', category: 'happy', layer: 'unit', linkedAcceptanceCriterionIndex: 0 }),
+      makeTestCase({ id: 'u2', category: 'happy', layer: 'unit', linkedAcceptanceCriterionIndex: 1 }),
+      makeTestCase({ id: 'u3', category: 'happy', layer: 'unit' }),
+      makeTestCase({ id: 'u4', category: 'happy', layer: 'unit' }),
+      makeTestCase({ id: 'u5', category: 'happy', layer: 'unit' }),
+      makeTestCase({ id: 'u6', category: 'edge', layer: 'unit' }),
+      makeTestCase({ id: 'u7', category: 'edge', layer: 'unit' }),
+      makeTestCase({ id: 'u8', category: 'edge', layer: 'unit' }),
+      makeTestCase({ id: 'u9', category: 'error', layer: 'unit' }),
+      makeTestCase({ id: 'i1', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'i2', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'i3', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'i4', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'i5', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'i6', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'i7', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'i8', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'i9', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'i10', category: 'happy', layer: 'integration' }),
+      makeTestCase({ id: 'e1', category: 'happy', layer: 'e2e' }),
+      makeTestCase({ id: 'e2', category: 'happy', layer: 'e2e' }),
+      makeTestCase({ id: 'v1', category: 'visual', layer: 'visual' }),
+      makeTestCase({ id: 'a1', category: 'accessibility', layer: 'accessibility' }),
+    ];
+    const ticket = stubTicket({ testCases: cases });
+    const d = await review(
+      { ticket, composedArchitecture: cleanComposedArchitecture() },
+      { critic: new NullCriticAdapter() },
+    );
+    const overfill = d.advisories.find(
+      (a) => a.lens === 'pyramid' && a.agent === 'testing-architect',
+    );
+    expect(overfill).toBeDefined();
+    expect(d.decision).toBe('pass');
+  });
+});

--- a/packages/test-reviewer/tests/integration.test.ts
+++ b/packages/test-reviewer/tests/integration.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Integration test — full pass → fail → fix → pass cycle, end-to-end
+ * through reviewTicket() with FSM emission verified at every step.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { reviewTicket } from '../src/api.js';
+import {
+  cleanComposedArchitecture,
+  cleanTestCases,
+  InMemoryArchitectureStore,
+  InMemoryTicketStore,
+  RecordingStateMachine,
+  stubTicket,
+} from './fixtures.js';
+
+describe('integration — full audit cycle', () => {
+  it('clean pass → tests-reviewed; broken → chain; fixed → pass', async () => {
+    const ticketId = 't-integration';
+    const sm = new RecordingStateMachine();
+
+    // ─── 1. Broken first pass — empty test-cases. ────────────────────────
+    const brokenTicket = stubTicket({ id: ticketId, testCases: [] });
+    const brokenStore = new InMemoryTicketStore(
+      new Map([[ticketId, brokenTicket]]),
+    );
+    const as = new InMemoryArchitectureStore(
+      new Map([[ticketId, cleanComposedArchitecture()]]),
+    );
+
+    const failOutcome = await reviewTicket(ticketId, {
+      ticketStore: brokenStore,
+      architectureStore: as,
+      stateMachine: sm,
+    });
+    expect(failOutcome.decision.decision).toBe('fail');
+    expect(failOutcome.emittedTransitions).toHaveLength(2);
+
+    // ─── 2. Fixed second pass — clean test-cases. ────────────────────────
+    const fixedTicket = stubTicket({
+      id: ticketId,
+      testCases: cleanTestCases(),
+    });
+    const fixedStore = new InMemoryTicketStore(
+      new Map([[ticketId, fixedTicket]]),
+    );
+    const passOutcome = await reviewTicket(ticketId, {
+      ticketStore: fixedStore,
+      architectureStore: as,
+      stateMachine: sm,
+    });
+    expect(passOutcome.decision.decision).toBe('pass');
+    expect(passOutcome.emittedTransitions).toHaveLength(1);
+    expect(passOutcome.emittedTransitions[0]?.to).toBe('tests-reviewed');
+
+    // 2 emissions (fail chain) + 1 emission (pass) = 3 total
+    expect(sm.emissions).toHaveLength(3);
+  });
+
+  it('preserves ticketId across all emissions', async () => {
+    const sm = new RecordingStateMachine();
+    const ticket = stubTicket({ id: 't-id-check', testCases: [] });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+    await reviewTicket('t-id-check', { ticketStore: ts, stateMachine: sm });
+    expect(sm.emissions.every((e) => e.ticketId === 't-id-check')).toBe(true);
+  });
+
+  it('summary on fail names the lenses that fired', async () => {
+    const sm = new RecordingStateMachine();
+    const ticket = stubTicket({ id: 't-summary', testCases: [] });
+    const ts = new InMemoryTicketStore(new Map([[ticket.id, ticket]]));
+    const outcome = await reviewTicket('t-summary', {
+      ticketStore: ts,
+      stateMachine: sm,
+    });
+    expect(outcome.decision.summary).toMatch(/Audit failed/);
+    expect(outcome.decision.summary).toMatch(/acCoverage/);
+  });
+});

--- a/packages/test-reviewer/tests/pyramid.test.ts
+++ b/packages/test-reviewer/tests/pyramid.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMix, runPyramidLens } from '../src/lenses/pyramid.js';
+import { cleanComposedArchitecture, makeTestCase } from './fixtures.js';
+import type { TestCase } from '@chiefaia/ticket-template';
+
+function build(layers: Array<TestCase['layer']>): TestCase[] {
+  return layers.map((l, i) =>
+    makeTestCase({ id: `p-${i}`, category: 'happy', layer: l }),
+  );
+}
+
+describe('resolveMix', () => {
+  it('returns null when ticketType is undefined', () => {
+    expect(
+      resolveMix(cleanComposedArchitecture(), undefined),
+    ).toBeNull();
+  });
+
+  it('returns null when the architect has no mix for ticketType', () => {
+    expect(resolveMix(cleanComposedArchitecture(), 'Widget')).toBeNull();
+  });
+
+  it('returns null when the testing.testTypeMixPercentages key is absent', () => {
+    expect(resolveMix({}, 'Page')).toBeNull();
+  });
+
+  it('folds perf% into unit + integration proportionally', () => {
+    const mix = resolveMix(cleanComposedArchitecture(), 'Page');
+    expect(mix).not.toBeNull();
+    // unit 60 + perf 2 * (60/80) = 60 + 1.5 = 61.5
+    expect(mix?.unit).toBeCloseTo(61.5, 1);
+    // integration 20 + perf 2 * (20/80) = 20 + 0.5 = 20.5
+    expect(mix?.integration).toBeCloseTo(20.5, 1);
+    // a11y (3) maps to accessibility
+    expect(mix?.accessibility).toBe(3);
+  });
+});
+
+describe('runPyramidLens — no architect mix', () => {
+  it('emits no findings when test-cases is empty', () => {
+    expect(
+      runPyramidLens({
+        testCases: [],
+        ticketType: 'Page',
+        composedArchitecture: {},
+      }),
+    ).toEqual([]);
+  });
+
+  it('fires the unit-floor finding for a 100% e2e suite', () => {
+    const findings = runPyramidLens({
+      testCases: build(['e2e', 'e2e', 'e2e', 'e2e']),
+      ticketType: 'Page',
+      composedArchitecture: {},
+    });
+    const layers = findings.map((f) => f.layer);
+    expect(layers).toContain('unit');
+    expect(layers).toContain('e2e'); // also exceeds e2e ceiling
+  });
+
+  it('fires the e2e-ceiling finding for a 60% e2e suite', () => {
+    const findings = runPyramidLens({
+      testCases: build([
+        'e2e',
+        'e2e',
+        'e2e',
+        'unit',
+        'unit',
+      ]),
+      ticketType: 'Page',
+      composedArchitecture: {},
+    });
+    expect(findings.some((f) => f.layer === 'e2e')).toBe(true);
+  });
+
+  it('passes a balanced suite with no architect mix', () => {
+    const findings = runPyramidLens({
+      testCases: build([
+        'unit',
+        'unit',
+        'unit',
+        'unit',
+        'unit',
+        'unit',
+        'integration',
+        'integration',
+        'e2e',
+        'e2e',
+      ]),
+      ticketType: 'Page',
+      composedArchitecture: {},
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe('runPyramidLens — with architect mix', () => {
+  it('flags layers far below target', () => {
+    const findings = runPyramidLens({
+      // All 10 cases are e2e — unit/integration are 0% vs 60/20% targets.
+      testCases: build([
+        'e2e',
+        'e2e',
+        'e2e',
+        'e2e',
+        'e2e',
+        'e2e',
+        'e2e',
+        'e2e',
+        'e2e',
+        'e2e',
+      ]),
+      ticketType: 'Page',
+      composedArchitecture: cleanComposedArchitecture(),
+    });
+    // Hard-floor unit + hard-ceiling e2e + below-target unit + below-target integration
+    expect(findings.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('emits an advisory (overfill) at >200% target', () => {
+    const findings = runPyramidLens({
+      // 50% e2e — target is 10% → 5x over.
+      testCases: build([
+        'unit',
+        'unit',
+        'unit',
+        'unit',
+        'unit',
+        'e2e',
+        'e2e',
+        'e2e',
+        'e2e',
+        'e2e',
+      ]),
+      ticketType: 'Page',
+      composedArchitecture: cleanComposedArchitecture(),
+    });
+    const e2eFinding = findings.find((f) => f.layer === 'e2e');
+    expect(e2eFinding).toBeDefined();
+    expect(e2eFinding?.targetPct).not.toBeNull();
+  });
+
+  it('honors custom severities', () => {
+    const findings = runPyramidLens({
+      testCases: build(['e2e', 'e2e', 'e2e', 'e2e']),
+      ticketType: 'Page',
+      composedArchitecture: {},
+      underfillSeverity: 'P0',
+    });
+    expect(findings.every((f) => f.severity === 'P0')).toBe(true);
+  });
+});

--- a/packages/test-reviewer/tests/reviewer.test.ts
+++ b/packages/test-reviewer/tests/reviewer.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from 'vitest';
+import { TestReviewer, review } from '../src/reviewer.js';
+import { FixedCriticAdapter, NullCriticAdapter } from '../src/critic.js';
+import {
+  cleanComposedArchitecture,
+  cleanReviewerInput,
+  cleanTestCases,
+  makeTestCase,
+  stubTicket,
+} from './fixtures.js';
+
+describe('TestReviewer.review — pass path', () => {
+  it('passes a clean suite', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const d = await r.review(cleanReviewerInput());
+    expect(d.decision).toBe('pass');
+    expect(d.finalState).toBe('tests-reviewed');
+    expect(d.rerunAuthor).toEqual([]);
+  });
+
+  it('clean-pass summary mentions all lenses', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const d = await r.review(cleanReviewerInput());
+    expect(d.summary).toMatch(/passed/i);
+  });
+
+  it('exposes all five findings groups on the decision', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const d = await r.review(cleanReviewerInput());
+    expect(d.findings).toHaveProperty('acCoverage');
+    expect(d.findings).toHaveProperty('pyramid');
+    expect(d.findings).toHaveProperty('edge');
+    expect(d.findings).toHaveProperty('error');
+    expect(d.findings).toHaveProperty('correctness');
+  });
+});
+
+describe('TestReviewer.review — AC-coverage fail path', () => {
+  it('fails when an AC has no happy test', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const ticket = stubTicket({
+      testCases: [
+        // AC#0 covered by happy
+        makeTestCase({ category: 'happy', linkedAcceptanceCriterionIndex: 0 }),
+        // AC#1 covered only by error
+        makeTestCase({ category: 'error', linkedAcceptanceCriterionIndex: 1 }),
+        // Make sure edge + error floors don't double-fire
+        makeTestCase({ category: 'edge' }),
+        makeTestCase({ category: 'error' }),
+      ],
+    });
+    const d = await r.review({
+      ticket,
+      composedArchitecture: cleanComposedArchitecture(),
+    });
+    expect(d.decision).toBe('fail');
+    expect(d.finalState).toBe('tests-review-failed');
+    expect(d.rerunAuthor.some((r) => r.lens === 'acCoverage')).toBe(true);
+  });
+});
+
+describe('TestReviewer.review — pyramid fail path', () => {
+  it('fails when the suite is 100% e2e', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const ticket = stubTicket({
+      testCases: [
+        makeTestCase({
+          id: 'a',
+          category: 'happy',
+          layer: 'e2e',
+          linkedAcceptanceCriterionIndex: 0,
+        }),
+        makeTestCase({
+          id: 'b',
+          category: 'happy',
+          layer: 'e2e',
+          linkedAcceptanceCriterionIndex: 1,
+        }),
+        makeTestCase({ id: 'c', category: 'edge', layer: 'e2e' }),
+        makeTestCase({ id: 'd', category: 'error', layer: 'e2e' }),
+        // a11y test (covers WCAG floor — error lens won't double-fire)
+        makeTestCase({
+          id: 'e',
+          category: 'accessibility',
+          layer: 'accessibility',
+        }),
+      ],
+    });
+    const d = await r.review({
+      ticket,
+      composedArchitecture: cleanComposedArchitecture(),
+    });
+    expect(d.decision).toBe('fail');
+    expect(d.rerunAuthor.some((r) => r.lens === 'pyramid')).toBe(true);
+  });
+});
+
+describe('TestReviewer.review — edge fail path', () => {
+  it('fails when no edge case is present in a 5-case suite', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const ticket = stubTicket({
+      testCases: [
+        makeTestCase({ category: 'happy', linkedAcceptanceCriterionIndex: 0 }),
+        makeTestCase({ category: 'happy', linkedAcceptanceCriterionIndex: 1 }),
+        makeTestCase({ category: 'happy', layer: 'integration' }),
+        makeTestCase({ category: 'error' }),
+        makeTestCase({
+          category: 'accessibility',
+          layer: 'accessibility',
+        }),
+      ],
+    });
+    const d = await r.review({
+      ticket,
+      composedArchitecture: cleanComposedArchitecture(),
+    });
+    expect(d.rerunAuthor.some((r) => r.lens === 'edge')).toBe(true);
+  });
+});
+
+describe('TestReviewer.review — error fail path', () => {
+  it('fires the security floor for PII data', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const ticket = stubTicket({ testCases: cleanTestCases() });
+    const arch = {
+      ...cleanComposedArchitecture(),
+      'security.dataClassification': 'PII',
+    };
+    const d = await r.review({ ticket, composedArchitecture: arch });
+    expect(d.rerunAuthor.some((r) => r.lens === 'error')).toBe(true);
+  });
+
+  it('fires the a11y floor when WCAG set but no a11y test', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const cases = cleanTestCases().filter(
+      (c) => c.category !== 'accessibility',
+    );
+    const ticket = stubTicket({ testCases: cases });
+    const d = await r.review({
+      ticket,
+      composedArchitecture: cleanComposedArchitecture(),
+    });
+    expect(
+      d.rerunAuthor.some(
+        (r) => r.lens === 'error' && r.reason.match(/WCAG/),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('TestReviewer.review — correctness lens', () => {
+  it('routes a P1 critic finding with testCaseId into rerunAuthor', async () => {
+    const fixed = new FixedCriticAdapter([
+      { testCaseId: 'tc-x', reason: 'weak link', severity: 'P1' },
+    ]);
+    const r = new TestReviewer({ critic: fixed });
+    const d = await r.review(cleanReviewerInput());
+    expect(d.decision).toBe('fail');
+    expect(d.rerunAuthor.some((r) => r.lens === 'correctness')).toBe(true);
+  });
+
+  it('routes a P2 critic finding into advisories, not rerunAuthor', async () => {
+    const fixed = new FixedCriticAdapter([
+      { testCaseId: 'tc-x', reason: 'weak link', severity: 'P2' },
+    ]);
+    const r = new TestReviewer({ critic: fixed });
+    const d = await r.review(cleanReviewerInput());
+    expect(d.decision).toBe('pass');
+    expect(d.advisories.some((a) => a.lens === 'correctness')).toBe(true);
+  });
+
+  it('global critic findings (no testCaseId) become advisories', async () => {
+    const fixed = new FixedCriticAdapter([
+      { reason: 'whole suite feels thin', severity: 'P1' },
+    ]);
+    const r = new TestReviewer({ critic: fixed });
+    const d = await r.review(cleanReviewerInput());
+    expect(d.decision).toBe('pass'); // no testCaseId → no rerun
+    expect(d.advisories.some((a) => a.agent === 'global')).toBe(true);
+  });
+
+  it('skips the critic when there are no ACs', async () => {
+    const calls: number[] = [];
+    const fixed = new FixedCriticAdapter([
+      { testCaseId: 'tc-x', reason: 'forced', severity: 'P1' },
+    ]);
+    // Monkey-patch to count
+    const orig = fixed.judge.bind(fixed);
+    fixed.judge = async (i) => {
+      calls.push(1);
+      return orig(i);
+    };
+    const r = new TestReviewer({ critic: fixed });
+    await r.review({
+      ticket: stubTicket({ acceptance_criteria: [], testCases: [] }),
+      composedArchitecture: {},
+    });
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('TestReviewer.review — dedup + severity', () => {
+  it('dedups multiple findings per lens into a single directive', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    // Three ACs all missing happy tests → three acCoverage findings →
+    // ONE acCoverage rerun directive with concatenated reasons.
+    const d = await r.review({
+      ticket: stubTicket({
+        acceptance_criteria: ['A', 'B', 'C'],
+        testCases: [
+          makeTestCase({ category: 'edge' }),
+          makeTestCase({ category: 'error' }),
+        ],
+      }),
+      composedArchitecture: {},
+    });
+    const acDirs = d.rerunAuthor.filter((r) => r.lens === 'acCoverage');
+    expect(acDirs).toHaveLength(1);
+    expect(acDirs[0]?.reason).toMatch(/;/);
+  });
+
+  it('honors a custom blockingSeverities set', async () => {
+    const r = new TestReviewer(
+      { critic: new NullCriticAdapter() },
+      { blockingSeverities: ['P0'] },
+    );
+    // A 5-case suite with no edge tests is P1 by default; with blocking=P0
+    // only, this becomes an advisory and the audit passes.
+    const ticket = stubTicket({
+      testCases: [
+        makeTestCase({ category: 'happy', linkedAcceptanceCriterionIndex: 0 }),
+        makeTestCase({ category: 'happy', linkedAcceptanceCriterionIndex: 1 }),
+        makeTestCase({ category: 'happy', layer: 'integration' }),
+        makeTestCase({ category: 'error' }),
+        makeTestCase({
+          category: 'accessibility',
+          layer: 'accessibility',
+        }),
+      ],
+    });
+    const d = await r.review({
+      ticket,
+      composedArchitecture: cleanComposedArchitecture(),
+    });
+    expect(d.decision).toBe('pass');
+    expect(d.advisories.length).toBeGreaterThan(0);
+  });
+});
+
+describe('functional review() flavour', () => {
+  it('works without explicit deps', async () => {
+    const d = await review(cleanReviewerInput());
+    expect(d.decision).toBe('pass');
+  });
+});
+
+describe('TestReviewer — edge cases', () => {
+  it('handles a ticket with no testCases (treats as empty array)', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const ticket = stubTicket({
+      acceptance_criteria: ['AC0'],
+      // testCases omitted
+    });
+    const d = await r.review({ ticket, composedArchitecture: {} });
+    expect(d.decision).toBe('fail');
+    expect(d.rerunAuthor.some((r) => r.lens === 'acCoverage')).toBe(true);
+  });
+
+  it('handles a ticket with no ACs (clean pass on empty suite)', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const d = await r.review({
+      ticket: stubTicket({ acceptance_criteria: [], testCases: [] }),
+      composedArchitecture: {},
+    });
+    expect(d.decision).toBe('pass');
+  });
+
+  it('preserves the override acceptanceCriteria from the input', async () => {
+    const r = new TestReviewer({ critic: new NullCriticAdapter() });
+    const d = await r.review({
+      ticket: stubTicket({
+        testCases: [
+          makeTestCase({
+            category: 'happy',
+            linkedAcceptanceCriterionIndex: 0,
+          }),
+          makeTestCase({ category: 'edge' }),
+          makeTestCase({ category: 'error' }),
+        ],
+        acceptance_criteria: ['orig0', 'orig1'],
+      }),
+      composedArchitecture: {},
+      // Override — only one AC. Without override, AC#1 would fire.
+      acceptanceCriteria: ['orig0'],
+    });
+    expect(
+      d.findings.acCoverage.some((f) => f.acIndex === 1),
+    ).toBe(false);
+  });
+});

--- a/packages/test-reviewer/tsconfig.json
+++ b/packages/test-reviewer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/test-reviewer/vitest.config.ts
+++ b/packages/test-reviewer/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    reporters: ['default'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3168,6 +3168,28 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/test-reviewer:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@caia/state-machine':
+        specifier: workspace:*
+        version: link:../state-machine
+      '@chiefaia/ticket-template':
+        specifier: workspace:*
+        version: link:../ticket-template
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/testing-architect:
     dependencies:
       '@caia/architect-kit':


### PR DESCRIPTION
Stage 11 of the canonical CAIA pipeline. Critic-style audit for the test cases produced by `@caia/test-author`; gates the ticket transition from `tests-authored` → `tests-reviewed` per the `@caia/state-machine` canonical transition table.

Mirrors the `@caia/ea-reviewer` template (PR-merged); same lens architecture, same decision envelope, same DI seams. The only difference is what's being audited.

## Four deterministic lenses + one LLM-judge

- **AC coverage** — every `ticket.acceptance_criteria[i]` has a `TestCase` with `linkedAcceptanceCriterionIndex===i` AND `category==='happy'`. Missing → P1 rerun directive on test-author.
- **Pyramid balance** — per-layer histogram vs Testing Architect's `testing.testTypeMixPercentages[ticketType]`. <50% of target → underfill (P1); >200% → overfill (P2 advisory). Hard floors apply when the architect's mix is absent (unit ≥ 30%, e2e ≤ 50%). Layers with expected count <1 are skipped (small-suite noise).
- **Edge cases** — `edgeCount >= max(1, ceil(total/10))`.
- **Error states** — baseline ≥1 error test, plus conditional quality floors: WCAG level set → ≥1 accessibility test; PII/confidential data classification → ≥1 security test.
- **Correctness** (LLM-judge) — DI seam with `NullCriticAdapter` default. `HeuristicCriticAdapter` ships for cheap deterministic checks; production wires `@chiefaia/claude-spawner` (subscription-only per P14).

## State-machine integration

```
pass:  tests-authored → tests-reviewed                       (1 row)
fail:  tests-authored → tests-reviewed (intermediate=true)
       tests-reviewed → tests-review-failed                  (terminal)
```

The chain on fail is required because the canonical transitions table doesn't allow `tests-authored → tests-review-failed` directly.

## Reused deps (no new external installs)

`@caia/architect-kit` (Ticket), `@chiefaia/ticket-template` (TestCase), `@caia/state-machine` (ProjectState + transition seam).

## Testing

**75 vitest cases** (≥ the 30-test floor per the directive) + **5 golden tests** pinning the decision envelope shape. All green; typecheck clean.

## EA review

Submitted via `@caia/ea-architect.submitPlan` (PR #568) before implementation; outcome: **approved**. Submission record: `plans/_submissions/test-reviewer-stage-11-2026-05-25.json`.

Plan: `plans/plan-2026-05-24-test-reviewer-subagent.md`.

True-Zero: admin-merge per CAIA constitutional process.