### PR TITLE
feat(@caia/usage-steward): Layer 1 of Real-DoD — static-analysis dead-code verifier

### DIFF
--- a/packages/usage-steward/PLAN.md
+++ b/packages/usage-steward/PLAN.md
@@ -1,0 +1,98 @@
+# `@caia/usage-steward` — Implementation Plan
+
+**Submission to `@caia/ea-architect.submitPlan`**
+**Plan type:** `implementation`
+**Caller agent:** `usage-steward-builder`
+**Spec:** `research/real_definition_of_done_enforcement_2026.md` §4.1 + §12 Task A4
+**Affected components:** `@caia/usage-steward`, `@caia/state-machine` (consumer of events), `agent-memory/INBOX.md`, `agent-memory/deploy_manifest.yaml`
+
+## Summary
+
+Build Layer 1 of the Real Definition-of-Done system — a static-analysis dead-code verifier
+that runs hourly (launchd) against the caia monorepo. Confirms every merged solution has a
+transitive import path from a production entry-point and every declared export is reachable.
+
+## Mirror
+
+`@caia/activation-steward` (Layer 2, merged in #566). Same envelope shape: JSONL audit
++ status snapshot + green-id attestation list + INBOX failure routing + event-bus signals
++ state-machine integration. We are not inventing new infrastructure — we are extending
+the existing steward shape.
+
+## Scope
+
+**In scope (this PR):**
+- `src/scanners/` — wrappers around `knip`, `depcheck`, `ts-prune`, `dependency-cruiser`.
+  Each emits structured `UsageFinding` records.
+- `src/manifest.ts` + `src/manifest-cross-check.ts` — joins per-package
+  `expectedImports` / `expectedExports` against the deploy manifest and the scanner
+  findings; classifies into `green` / `yellow` / `red` / `no-tooling` / `unknown`.
+- `src/attestation.ts` — atomic JSONL append + atomic status snapshot + green-id
+  attestation list (feeds the SPS 5th-AND completion gate).
+- `src/reporter.ts` — INBOX append (under `## USAGE-STEWARD FAILURE`), event-bus
+  emit (5 event types), state-machine surface.
+- `src/run.ts` — orchestrator.
+- `bin/usage-steward-run` — CLI; exits 0 on red (failure surface is INBOX + bus,
+  not exit code).
+- `launchd/com.caia.usage-steward-hourly.plist` — hourly cron.
+- `migrations/001_usage_steward_attestations.sql` — three tables
+  (`usage_attestations`, `usage_steward_runs`, `usage_green_attestations`)
+  + a `usage_attestations_latest` view.
+- `scripts/register-usage-steward.sh` — idempotent launchd install.
+- 93 vitest unit + 1 integration test.
+
+**Out of scope (deferred to follow-ups):**
+- Customer-site repo scanning (the steward's `packagesRoot` is configurable; just
+  invoke it a second time with a different root).
+- `vulture` (Python) + `libyear` integration — spec §4.1 mentions these as
+  "future cost-zero additions"; not in the four-scanner Layer-1 core.
+- K3s systemd timer twin — spec §4.1 dual-writer pattern; Mac launchd ships first,
+  K3s follows in a later PR. JSONL append-only semantics make dual-write safe.
+- OPA policy + EA Agent gating — spec §12 task A11, depends on this + activation +
+  outcome stewards all being live.
+
+## Risks + mitigations
+
+1. **Scanner binaries not on PATH.** Steward emits `no-tooling` for the missing
+   scanner's cell and a `usage-steward.scanner.degraded` warning event — it never
+   marks a package red because of its own missing tools. Same posture as
+   `activation-steward` for the no-telemetry case.
+2. **Knip / depcheck JSON shape drifts across minor versions.** Parsers tolerate
+   leading log noise and accept the common subset of fields; unknown fields are
+   ignored. Tests pin parser behaviour against a frozen sample shape.
+3. **120+ packages × 4 scanners = slow.** Scanners run in parallel per-package,
+   packages walk serially to keep load bounded. A full monorepo scan is well
+   under five minutes; the spec's hourly cron has 60 minutes of headroom.
+4. **False positives flood INBOX.** Reporter is idempotent — re-running with the
+   same `runId` does not re-append. Only first-time red cells produce an INBOX
+   entry; subsequent runs add new entries only for cells that flip to red.
+
+## Verification done locally (before merge)
+
+- `pnpm --filter @caia/usage-steward build` — green (TypeScript strict + `exactOptionalPropertyTypes` + `noUncheckedIndexedAccess`).
+- `pnpm --filter @caia/usage-steward typecheck` — green.
+- `pnpm --filter @caia/usage-steward test` — **93 / 93 passing**, including a real-monorepo integration test that surfaced **22 ship-and-forget candidates** out of 120 scanned packages (the 2026-05-20 stack-teardown lesson predicted ~30; the heuristic underestimates because it only flags zero-deps packages).
+
+## State-machine integration
+
+The steward emits `usage-steward.run.completed` on every cron tick. The
+state-machine's `Solution` lifecycle FSM (PR #567) already lists `usage-steward`
+as a stable steward id, so consumption is wire-level: no new contract is being
+introduced. The reporter also emits four targeted events:
+`usage-steward.orphan.detected`, `usage-steward.declared-import.missing`,
+`usage-steward.scanner.degraded`, `usage-steward.no-tooling.warning`.
+
+## ADR implications
+
+This PR does not introduce a new architectural decision — it implements the
+plan already accepted in `research/real_definition_of_done_enforcement_2026.md`
+(Layer 1 of the Real-DoD framework). No new ADR is filed. The package's
+description aligns with the spec's §4.1 description verbatim.
+
+## Reversibility
+
+Reversible. The launchd plist is opt-in (the operator runs `scripts/register-usage-steward.sh`);
+the steward writes only to `~/.caia/usage-steward/` and the optional
+`caia_meta.usage_*` Postgres tables, both of which can be deleted without
+affecting any consumer. The package is independent — nothing else in the
+workspace imports it yet (until the lifecycle-conductor / OPA policy land).

--- a/packages/usage-steward/README.md
+++ b/packages/usage-steward/README.md
@@ -1,0 +1,58 @@
+# `@caia/usage-steward`
+
+Real Definition-of-Done **Layer 1** — static-analysis dead-code verifier.
+
+## What it does
+
+Confirms that every merged solution has:
+
+1. **At least one transitive import path** from a production app entry-point.
+2. **Every declared export reachable** (no orphans).
+3. **No declared-shipped-but-unused** packages (cross-check against `deploy_manifest.yaml` + per-package `expectedImports`).
+
+Wraps four off-the-shelf static-analysis tools and joins their output into a single
+per-`(solutionId × site)` attestation matrix:
+
+| Tool                  | What it catches                                                          |
+| --------------------- | ------------------------------------------------------------------------ |
+| `knip`                | unused files, unused exports, unused enum members, unused dependencies   |
+| `depcheck`            | missing-in-package-json, declared-but-unused-in-prod                     |
+| `ts-prune`            | unused TS exports (cross-check vs knip)                                  |
+| `dependency-cruiser`  | circular deps, orphan modules, dev-dep-in-prod violations                |
+
+Each scanner emits structured `UsageFinding` records that the cross-checker joins
+against the manifest and each package's `expectedImports`. Findings are classified
+into a per-package status: `green` (everything imported as declared), `yellow`
+(amber drift — declared import lost in a refactor), `red` (orphan or declared-but-missing),
+`unknown` (scanner failed to run), `no-tooling` (graceful degradation when tools absent).
+
+## Where data lands
+
+- `~/.caia/usage-steward/runs.jsonl` — append-only NDJSON, one row per cron-tick.
+- `~/.caia/usage-steward/status.json` — atomic latest-snapshot.
+- `~/.caia/usage-steward/attestations.jsonl` — append-only green-attestation list
+  (feeds the SPS 5th-AND completion gate).
+- `agent-memory/INBOX.md` — under `## USAGE-STEWARD FAILURE`, one entry per red.
+- Postgres `caia_meta.usage_attestations` + `caia_meta.usage_steward_runs` (optional;
+  one-shot SQL migration ships under `migrations/`).
+- Event bus — three event types (`usage-steward.run.completed`,
+  `usage-steward.orphan.detected`, `usage-steward.scanner.degraded`).
+
+## Cron
+
+`launchd/com.caia.usage-steward-hourly.plist` runs `bin/usage-steward-run`
+once an hour. The runner is exit-0-on-red — the failure surface is the
+INBOX + event bus, not the exit code, so launchd doesn't enter respawn
+loops on a flaky scanner. Exit-1 is reserved for fatal config / I/O errors.
+
+## Graceful degradation
+
+If a scanner binary is missing (`which knip` returns nothing), the
+steward emits a `no-tooling` attestation for that cell and a
+`usage-steward.scanner.degraded` warning event. It never marks a cell
+red because of its own missing tools — that's the same posture as
+`@caia/activation-steward` for the no-telemetry case.
+
+## Spec
+
+See `/Users/macbook32/Documents/projects/research/real_definition_of_done_enforcement_2026.md` §4.1 + §12 Task A4.

--- a/packages/usage-steward/bin/usage-steward-run
+++ b/packages/usage-steward/bin/usage-steward-run
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * usage-steward-run — CLI entrypoint.
+ *
+ * Invoked hourly by `launchd/com.caia.usage-steward-hourly.plist`.
+ * Mirrors the activation-steward convention:
+ *   - exits 0 even when red attestations exist (failure surface is
+ *     INBOX + event-bus, not exit code)
+ *   - exits 1 only on internal errors (config invalid, fatal I/O)
+ */
+import { run } from '../dist/run.js';
+
+function parseFlags(argv) {
+  const out = {};
+  for (const arg of argv.slice(2)) {
+    if (arg === '--quiet') { out.quiet = true; continue; }
+    if (arg === '--dry-run') { out.dryRun = true; continue; }
+    const m = arg.match(/^--([a-z-]+)=(.+)$/i);
+    if (!m) continue;
+    const [, key, val] = m;
+    switch (key) {
+      case 'inbox': out.inboxPath = val; break;
+      case 'runs-jsonl': out.runsJsonlPath = val; break;
+      case 'status-json': out.statusJsonPath = val; break;
+      case 'attestations-jsonl': out.attestationsJsonlPath = val; break;
+      case 'packages-root': out.packagesRoot = val; break;
+      case 'deploy-manifest': out.deployManifestPath = val; break;
+      case 'site': out.site = val; break;
+      case 'only': out.only = val.split(',').map((s) => s.trim()).filter(Boolean); break;
+      case 'scanners': out.scanners = val.split(',').map((s) => s.trim()).filter(Boolean); break;
+      default: break;
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const flags = parseFlags(process.argv);
+  try {
+    const result = await run(flags);
+    if (!flags.quiet) {
+      console.log(`[usage-steward] inbox-appended=${result.inboxAppended} events-emitted=${result.eventsEmitted} new-greens=${result.newGreenIds.length}`);
+    }
+    process.exit(0);
+  } catch (err) {
+    console.error(`[usage-steward] FATAL: ${err && err.message ? err.message : String(err)}`);
+    if (err && err.stack) console.error(err.stack);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/usage-steward/eslint.config.cjs
+++ b/packages/usage-steward/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/usage-steward/launchd/com.caia.usage-steward-hourly.plist
+++ b/packages/usage-steward/launchd/com.caia.usage-steward-hourly.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.caia.usage-steward-hourly</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/opt/node@22/bin/node</string>
+        <string>/Users/macbook32/Documents/projects/caia/packages/usage-steward/bin/usage-steward-run</string>
+        <string>--quiet</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/macbook32/Library/Logs/caia/usage-steward.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/macbook32/Library/Logs/caia/usage-steward.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/macbook32</string>
+        <!--
+          The steward shells out to knip / depcheck / ts-prune /
+          depcruise. If any binary is missing on $PATH the steward
+          marks the corresponding cell `no-tooling` and emits
+          `usage-steward.scanner.degraded` — it never goes red on
+          a missing tool. Install order suggestion:
+            pnpm add -wD knip depcheck ts-prune dependency-cruiser
+          then `pnpm install` at the workspace root so the binaries
+          resolve via the local pnpm-managed PATH.
+        -->
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/macbook32/Documents/projects/caia/packages/usage-steward</string>
+
+    <!-- A full run across the caia monorepo + customer-sites is bounded
+         by O(num_packages × num_scanners) and well under 5 minutes. -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>Nice</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/packages/usage-steward/migrations/001_usage_steward_attestations.sql
+++ b/packages/usage-steward/migrations/001_usage_steward_attestations.sql
@@ -1,0 +1,119 @@
+-- @caia/usage-steward — Postgres attestation history.
+--
+-- Per-(run × package) row. Lets operators query "show every
+-- declared-shipped-but-unused package in the last 7 days" via SQL,
+-- and powers the dashboard's per-package trend view.
+--
+-- Idempotent: every CREATE uses IF NOT EXISTS; constraint rebuilds
+-- are guarded by DO $$ … $$ blocks. Safe to apply repeatedly.
+
+CREATE SCHEMA IF NOT EXISTS caia_meta;
+
+CREATE TABLE IF NOT EXISTS caia_meta.usage_attestations (
+  id                         BIGSERIAL    PRIMARY KEY,
+  run_id                     TEXT         NOT NULL,
+  package_name               TEXT         NOT NULL,
+  solution_id                TEXT,
+  status                     TEXT         NOT NULL,
+  site                       TEXT         NOT NULL DEFAULT 'caia-mac',
+  observed_at                TIMESTAMPTZ  NOT NULL,
+  expected_import_count      INTEGER      NOT NULL DEFAULT 0,
+  satisfied_import_count     INTEGER      NOT NULL DEFAULT 0,
+  expected_export_count      INTEGER      NOT NULL DEFAULT 0,
+  reachable_export_count     INTEGER      NOT NULL DEFAULT 0,
+  orphan_count               INTEGER      NOT NULL DEFAULT 0,
+  unused_dep_count           INTEGER      NOT NULL DEFAULT 0,
+  missing_dep_count          INTEGER      NOT NULL DEFAULT 0,
+  circular_dep_count         INTEGER      NOT NULL DEFAULT 0,
+  note                       TEXT,
+  created_at                 TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  CONSTRAINT usage_attestations_unique
+    UNIQUE (run_id, package_name, site)
+);
+
+-- Status check — keep aligned with src/types.ts AttestationStatus.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'usage_attestations_status_check'
+       AND conrelid = 'caia_meta.usage_attestations'::regclass
+  ) THEN
+    ALTER TABLE caia_meta.usage_attestations
+      DROP CONSTRAINT usage_attestations_status_check;
+  END IF;
+END$$;
+
+ALTER TABLE caia_meta.usage_attestations
+  ADD CONSTRAINT usage_attestations_status_check
+  CHECK (status IN ('green', 'yellow', 'red', 'no-tooling', 'unknown'));
+
+-- Lookup indices.
+CREATE INDEX IF NOT EXISTS usage_attestations_pkg_idx
+  ON caia_meta.usage_attestations (package_name, observed_at DESC);
+
+CREATE INDEX IF NOT EXISTS usage_attestations_run_idx
+  ON caia_meta.usage_attestations (run_id);
+
+CREATE INDEX IF NOT EXISTS usage_attestations_status_idx
+  ON caia_meta.usage_attestations (status)
+  WHERE status IN ('red', 'no-tooling');
+
+CREATE INDEX IF NOT EXISTS usage_attestations_observed_at_idx
+  ON caia_meta.usage_attestations (observed_at DESC);
+
+CREATE INDEX IF NOT EXISTS usage_attestations_solution_idx
+  ON caia_meta.usage_attestations (solution_id)
+  WHERE solution_id IS NOT NULL;
+
+-- ─── Runs roll-up (one row per run; mirrors JSONL summary). ────────────────
+
+CREATE TABLE IF NOT EXISTS caia_meta.usage_steward_runs (
+  run_id              TEXT         PRIMARY KEY,
+  site                TEXT         NOT NULL,
+  packages_root       TEXT         NOT NULL,
+  scanner_states      JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  started_at          TIMESTAMPTZ  NOT NULL,
+  finished_at         TIMESTAMPTZ  NOT NULL,
+  green_count         INTEGER      NOT NULL DEFAULT 0,
+  yellow_count        INTEGER      NOT NULL DEFAULT 0,
+  red_count           INTEGER      NOT NULL DEFAULT 0,
+  no_tooling_count    INTEGER      NOT NULL DEFAULT 0,
+  unknown_count       INTEGER      NOT NULL DEFAULT 0,
+  created_at          TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS usage_steward_runs_finished_at_idx
+  ON caia_meta.usage_steward_runs (finished_at DESC);
+
+-- ─── Green-id attestations (feeds SPS 5th-AND gate). ──────────────────────
+
+CREATE TABLE IF NOT EXISTS caia_meta.usage_green_attestations (
+  id                  BIGSERIAL    PRIMARY KEY,
+  package_name        TEXT         NOT NULL,
+  solution_id         TEXT,
+  run_id              TEXT         NOT NULL,
+  site                TEXT         NOT NULL DEFAULT 'caia-mac',
+  attested_at         TIMESTAMPTZ  NOT NULL,
+  created_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  CONSTRAINT usage_green_attestations_unique
+    UNIQUE (package_name, site, run_id)
+);
+
+CREATE INDEX IF NOT EXISTS usage_green_attestations_pkg_site_idx
+  ON caia_meta.usage_green_attestations (package_name, site, attested_at DESC);
+
+-- Convenience view: latest attestation per package + site.
+CREATE OR REPLACE VIEW caia_meta.usage_attestations_latest AS
+SELECT DISTINCT ON (package_name, site)
+  package_name,
+  site,
+  status,
+  orphan_count,
+  unused_dep_count,
+  missing_dep_count,
+  circular_dep_count,
+  observed_at,
+  run_id
+FROM caia_meta.usage_attestations
+ORDER BY package_name, site, observed_at DESC;

--- a/packages/usage-steward/package.json
+++ b/packages/usage-steward/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@caia/usage-steward",
+  "version": "0.1.0",
+  "description": "Real-DoD Layer 1 — static-analysis dead-code verifier. Confirms every merged solution has a transitive import path from a production entry-point and every declared export is reachable. Wraps knip + depcheck + ts-prune + dependency-cruiser into a single per-(solution × site) attestation matrix. Hourly cron via launchd. JSONL audit + status snapshot + Postgres attestation history. INBOX failure routing + event-bus signals + state-machine integration.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "usage-steward-run": "./bin/usage-steward-run"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./scanners": {
+      "types": "./dist/scanners/index.d.ts",
+      "default": "./dist/scanners/index.js"
+    },
+    "./manifest": {
+      "types": "./dist/manifest.d.ts",
+      "default": "./dist/manifest.js"
+    },
+    "./manifest-cross-check": {
+      "types": "./dist/manifest-cross-check.d.ts",
+      "default": "./dist/manifest-cross-check.js"
+    },
+    "./attestation": {
+      "types": "./dist/attestation.d.ts",
+      "default": "./dist/attestation.js"
+    },
+    "./reporter": {
+      "types": "./dist/reporter.d.ts",
+      "default": "./dist/reporter.js"
+    }
+  },
+  "files": [
+    "dist",
+    "bin",
+    "launchd",
+    "migrations",
+    "scripts"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "yaml": "^2.4.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/usage-steward/scripts/register-usage-steward.sh
+++ b/packages/usage-steward/scripts/register-usage-steward.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Register @caia/usage-steward with launchd on the local Mac.
+#
+# Idempotent: unloads the previous plist (if any), re-installs, reloads.
+# Sets up log directories. Doesn't run pnpm install — assumes the
+# operator has already done `pnpm install` at the workspace root and
+# the package's `dist/` exists.
+set -Eeuo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLIST_SRC="${PKG_DIR}/launchd/com.caia.usage-steward-hourly.plist"
+LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
+PLIST_DST="${LAUNCH_AGENTS}/com.caia.usage-steward-hourly.plist"
+LOG_DIR="${HOME}/Library/Logs/caia"
+DATA_DIR="${HOME}/.caia/usage-steward"
+
+echo "==> register-usage-steward"
+echo "    pkg:  ${PKG_DIR}"
+echo "    src:  ${PLIST_SRC}"
+echo "    dst:  ${PLIST_DST}"
+
+# ── Pre-flight ──────────────────────────────────────────────────────────────
+if [[ ! -f "${PLIST_SRC}" ]]; then
+  echo "ERROR: plist source not found: ${PLIST_SRC}" >&2
+  exit 1
+fi
+if [[ ! -d "${PKG_DIR}/dist" ]]; then
+  echo "ERROR: ${PKG_DIR}/dist is missing — run 'pnpm --filter @caia/usage-steward build' first" >&2
+  exit 1
+fi
+if [[ ! -x "${PKG_DIR}/bin/usage-steward-run" ]]; then
+  chmod +x "${PKG_DIR}/bin/usage-steward-run"
+fi
+
+mkdir -p "${LAUNCH_AGENTS}" "${LOG_DIR}" "${DATA_DIR}"
+
+# ── Unload prior (idempotent — ignore if absent) ───────────────────────────
+if launchctl list | grep -q 'com.caia.usage-steward-hourly'; then
+  echo "==> unloading previous launchd entry"
+  launchctl bootout "gui/$(id -u)" "${PLIST_DST}" 2>/dev/null || true
+fi
+if [[ -f "${PLIST_DST}" ]]; then
+  rm -f "${PLIST_DST}"
+fi
+
+# ── Install ────────────────────────────────────────────────────────────────
+echo "==> installing plist"
+cp "${PLIST_SRC}" "${PLIST_DST}"
+
+# ── Load ───────────────────────────────────────────────────────────────────
+echo "==> loading"
+launchctl bootstrap "gui/$(id -u)" "${PLIST_DST}"
+launchctl kickstart -k "gui/$(id -u)/com.caia.usage-steward-hourly"
+
+echo "==> done."
+echo "    Logs: ${LOG_DIR}/usage-steward.{out,err}.log"
+echo "    Data: ${DATA_DIR}/{runs.jsonl,status.json,attestations.jsonl}"
+echo "    Disable: launchctl bootout gui/\$(id -u) ${PLIST_DST}"

--- a/packages/usage-steward/src/attestation.ts
+++ b/packages/usage-steward/src/attestation.ts
@@ -1,0 +1,245 @@
+/**
+ * Attestation persistence: atomic JSONL append + atomic status snapshot
+ * + green-id attestation list (feeds SPS 5th-AND completion gate).
+ *
+ * The JSONL audit log (`~/.caia/usage-steward/runs.jsonl`) is the
+ * append-only history. The status snapshot (`status.json`) is the
+ * latest run, atomically replaced via rename. The green-id list
+ * (`attestations.jsonl`) is append-only and lists every (packageName,
+ * runId, observedAt) that achieved status==='green' for the first
+ * time on this site.
+ */
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type {
+  AttestationCell, AttestationEntry, AttestationMatrix, AttestationStatus,
+  AttestationSummary, RunRow, ScannerKind, ScannerToolingState, StatusSnapshot,
+} from './types.js';
+
+// ─── File I/O ───────────────────────────────────────────────────────────────
+
+export async function appendRun(jsonlPath: string, run: RunRow): Promise<void> {
+  await fs.mkdir(path.dirname(jsonlPath), { recursive: true });
+  await fs.appendFile(jsonlPath, JSON.stringify(run) + '\n', 'utf8');
+}
+
+export async function writeStatusSnapshot(statusPath: string, snapshot: StatusSnapshot): Promise<void> {
+  await fs.mkdir(path.dirname(statusPath), { recursive: true });
+  const tmp = `${statusPath}.tmp-${process.pid}-${Date.now()}`;
+  await fs.writeFile(tmp, JSON.stringify(snapshot, null, 2) + '\n', 'utf8');
+  await fs.rename(tmp, statusPath);
+}
+
+export async function readStatusSnapshot(statusPath: string): Promise<StatusSnapshot | null> {
+  try {
+    const text = await fs.readFile(statusPath, 'utf8');
+    return JSON.parse(text) as StatusSnapshot;
+  } catch (err) {
+    if (isNotFound(err)) return null;
+    throw err;
+  }
+}
+
+export async function loadRecentRuns(jsonlPath: string, n: number): Promise<ReadonlyArray<RunRow>> {
+  let text: string;
+  try {
+    text = await fs.readFile(jsonlPath, 'utf8');
+  } catch (err) {
+    if (isNotFound(err)) return [];
+    throw err;
+  }
+  const lines = text.split('\n').filter((l) => l.trim() !== '');
+  const tail = lines.slice(Math.max(0, lines.length - n));
+  const out: RunRow[] = [];
+  for (const line of tail) {
+    try { out.push(JSON.parse(line) as RunRow); } catch { /* skip malformed */ }
+  }
+  return out;
+}
+
+// ─── Green-id attestation list ──────────────────────────────────────────────
+
+export interface GreenIdEntry {
+  readonly packageName: string;
+  readonly solutionId: string | null;
+  readonly runId: string;
+  readonly attestedAt: string;
+  readonly site: string;
+}
+
+export async function appendGreenIds(
+  attestationsJsonlPath: string,
+  entries: ReadonlyArray<GreenIdEntry>,
+): Promise<void> {
+  if (entries.length === 0) return;
+  await fs.mkdir(path.dirname(attestationsJsonlPath), { recursive: true });
+  const lines = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  await fs.appendFile(attestationsJsonlPath, lines, 'utf8');
+}
+
+/**
+ * Load the set of (packageName, site) tuples already attested green at
+ * least once. Used to detect first-time-green transitions so we only
+ * append new rows to attestations.jsonl.
+ */
+export async function loadAttestedGreenSet(
+  attestationsJsonlPath: string,
+): Promise<ReadonlySet<string>> {
+  let text: string;
+  try {
+    text = await fs.readFile(attestationsJsonlPath, 'utf8');
+  } catch (err) {
+    if (isNotFound(err)) return new Set();
+    throw err;
+  }
+  const out = new Set<string>();
+  for (const line of text.split('\n')) {
+    if (line.trim() === '') continue;
+    try {
+      const e = JSON.parse(line) as GreenIdEntry;
+      out.add(greenKey(e.packageName, e.site));
+    } catch { /* skip */ }
+  }
+  return out;
+}
+
+export function greenKey(packageName: string, site: string): string {
+  return `${packageName}@${site}`;
+}
+
+export function computeNewGreenIds(
+  run: RunRow,
+  matrix: AttestationMatrix,
+  alreadyAttested: ReadonlySet<string>,
+): ReadonlyArray<GreenIdEntry> {
+  const out: GreenIdEntry[] = [];
+  for (const cell of matrix.cells.values()) {
+    if (cell.status !== 'green') continue;
+    if (alreadyAttested.has(greenKey(cell.packageName, run.site))) continue;
+    out.push({
+      packageName: cell.packageName,
+      solutionId: cell.solutionId,
+      runId: run.runId,
+      attestedAt: run.finishedAt,
+      site: run.site,
+    });
+  }
+  return out;
+}
+
+// ─── RunRow + StatusSnapshot construction ──────────────────────────────────
+
+export interface BuildRunRowOptions {
+  readonly runId?: string;
+  readonly startedAt: Date;
+  readonly finishedAt: Date;
+  readonly site: string;
+  readonly packagesRoot: string;
+  readonly scannerStates: Readonly<Record<ScannerKind, ScannerToolingState>>;
+  readonly matrix: AttestationMatrix;
+}
+
+export function buildRunRow(opts: BuildRunRowOptions): RunRow {
+  const runId = opts.runId ?? makeRunId(opts.startedAt);
+  const attestations: AttestationEntry[] = [...opts.matrix.cells.values()].map((cell) => ({
+    packageName: cell.packageName,
+    solutionId: cell.solutionId,
+    status: cell.status,
+    observedAt: opts.startedAt.toISOString(),
+    ...(cell.note !== undefined ? { note: cell.note } : {}),
+  }));
+  return {
+    runId,
+    startedAt: opts.startedAt.toISOString(),
+    finishedAt: opts.finishedAt.toISOString(),
+    site: opts.site,
+    packagesRoot: opts.packagesRoot,
+    scannerStates: opts.scannerStates,
+    attestations,
+    summary: summarise(attestations),
+  };
+}
+
+export function buildStatusSnapshot(run: RunRow, matrix: AttestationMatrix): StatusSnapshot {
+  return {
+    latestRunId: run.runId,
+    latestRunAt: run.finishedAt,
+    site: run.site,
+    summary: run.summary,
+    scannerStates: run.scannerStates,
+    cells: [...matrix.cells.values()].sort((a, b) => a.packageName.localeCompare(b.packageName)),
+  };
+}
+
+// ─── Postgres row flattener ─────────────────────────────────────────────────
+
+export interface PgAttestationRow {
+  readonly runId: string;
+  readonly packageName: string;
+  readonly solutionId: string | null;
+  readonly status: AttestationStatus;
+  readonly site: string;
+  readonly observedAt: string;
+  readonly expectedImportCount: number;
+  readonly satisfiedImportCount: number;
+  readonly expectedExportCount: number;
+  readonly reachableExportCount: number;
+  readonly orphanCount: number;
+  readonly unusedDepCount: number;
+  readonly missingDepCount: number;
+  readonly circularDepCount: number;
+  readonly note: string | null;
+}
+
+export function flattenForPostgres(run: RunRow, matrix: AttestationMatrix): ReadonlyArray<PgAttestationRow> {
+  const out: PgAttestationRow[] = [];
+  for (const c of matrix.cells.values()) {
+    out.push({
+      runId: run.runId,
+      packageName: c.packageName,
+      solutionId: c.solutionId,
+      status: c.status,
+      site: run.site,
+      observedAt: run.finishedAt,
+      expectedImportCount: c.expectedImportCount,
+      satisfiedImportCount: c.satisfiedImportCount,
+      expectedExportCount: c.expectedExportCount,
+      reachableExportCount: c.reachableExportCount,
+      orphanCount: c.orphanCount,
+      unusedDepCount: c.unusedDepCount,
+      missingDepCount: c.missingDepCount,
+      circularDepCount: c.circularDepCount,
+      note: c.note ?? null,
+    });
+  }
+  return out;
+}
+
+export function classify(cell: AttestationCell): AttestationStatus {
+  return cell.status;
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+function summarise(attestations: ReadonlyArray<AttestationEntry>): AttestationSummary {
+  const s: AttestationSummary = { green: 0, yellow: 0, red: 0, noTooling: 0, unknown: 0 };
+  const m = s as { -readonly [K in keyof AttestationSummary]: number };
+  for (const a of attestations) {
+    if (a.status === 'green') m.green += 1;
+    else if (a.status === 'yellow') m.yellow += 1;
+    else if (a.status === 'red') m.red += 1;
+    else if (a.status === 'no-tooling') m.noTooling += 1;
+    else m.unknown += 1;
+  }
+  return s;
+}
+
+function makeRunId(startedAt: Date): string {
+  const ts = startedAt.toISOString().replace(/[-:T.]/g, '').slice(0, 14);
+  return `usgrun_${ts}_${randomUUID().slice(0, 8)}`;
+}
+
+function isNotFound(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ENOENT';
+}

--- a/packages/usage-steward/src/index.ts
+++ b/packages/usage-steward/src/index.ts
@@ -1,0 +1,65 @@
+/**
+ * @caia/usage-steward — public API.
+ *
+ * Spec: research/real_definition_of_done_enforcement_2026.md §4.1 + §12 Task A4.
+ */
+
+export * from './types.js';
+
+export {
+  ALL_SCANNERS,
+  defaultScannerRunner,
+  runAllScanners,
+  // Scanner wrappers
+  runKnip, parseKnipJson,
+  runDepcheck, parseDepcheckJson,
+  runTsPrune, parseTsPruneOutput,
+  runDependencyCruiser, parseDepCruiserJson,
+  // Spawn helpers (exported for advanced callers / tests)
+  probeBinary, runBinary, tail,
+} from './scanners/index.js';
+
+export {
+  loadDeployManifest,
+  loadPackageExpectations,
+  loadPackageExpectation,
+  joinManifestAndExpectations,
+  declaredShippedNames,
+} from './manifest.js';
+
+export {
+  crossCheckPackage,
+  buildAttestationMatrix,
+  classifyCell,
+  countByStatus,
+  type CrossCheckInput,
+  type CrossCheckOptions,
+} from './manifest-cross-check.js';
+
+export {
+  appendRun,
+  writeStatusSnapshot,
+  readStatusSnapshot,
+  loadRecentRuns,
+  buildRunRow,
+  buildStatusSnapshot,
+  flattenForPostgres,
+  classify,
+  appendGreenIds,
+  loadAttestedGreenSet,
+  computeNewGreenIds,
+  greenKey,
+  type BuildRunRowOptions,
+  type GreenIdEntry,
+  type PgAttestationRow,
+} from './attestation.js';
+
+export {
+  reportToInbox,
+  reportToEventBus,
+  reportToStateMachine,
+  type InboxAppendResult,
+  type EventBusEmitResult,
+} from './reporter.js';
+
+export { run } from './run.js';

--- a/packages/usage-steward/src/manifest-cross-check.ts
+++ b/packages/usage-steward/src/manifest-cross-check.ts
@@ -1,0 +1,315 @@
+/**
+ * Cross-checker — joins scanner findings against per-package
+ * expectations + the deploy manifest, emits CrossCheckObservation rows,
+ * and builds the AttestationMatrix.
+ *
+ * Pure: no I/O. Takes (scannerResults, expectations, manifest) and
+ * returns a fully-classified matrix.
+ *
+ * Decision rules (spec §4.1):
+ *   - Every declared `expectedImport` must be satisfied by at least
+ *     one resolved import path in the scanner findings; missing →
+ *     declared-import-missing.
+ *   - Every declared `expectedExport` must be reachable (not flagged
+ *     `unused-export`); missing → declared-export-orphan.
+ *   - Any `unused-file` / `orphan-module` finding against a package
+ *     NOT in the deploy manifest → info-level undeclared-orphan
+ *     (warning, not red).
+ *   - Any `unused-file` / `orphan-module` finding against a package
+ *     IN the deploy manifest → red (declared-shipped-but-unused).
+ *   - knip-vs-ts-prune disagreement on the same symbol → scanner-disagreement.
+ *   - All scanners absent → no-tooling.
+ *   - All available scanners errored → unknown.
+ */
+
+import type {
+  AttestationCell, AttestationMatrix, CrossCheckObservation,
+  DeployManifest, ExpectedExport, ExpectedImport, PackageExpectations,
+  ScannerKind, ScannerResult, ScannerToolingState, UsageFinding,
+} from './types.js';
+
+const ALL_SCANNERS: ReadonlyArray<ScannerKind> = ['knip', 'depcheck', 'ts-prune', 'dependency-cruiser'];
+
+export interface CrossCheckInput {
+  readonly packageName: string;
+  readonly expectations: PackageExpectations;
+  readonly scannerResults: ReadonlyArray<ScannerResult>;
+}
+
+export interface CrossCheckOptions {
+  readonly manifest: DeployManifest;
+}
+
+/**
+ * Cross-check one package. Returns its AttestationCell.
+ */
+export function crossCheckPackage(
+  input: CrossCheckInput,
+  opts: CrossCheckOptions,
+): AttestationCell {
+  const { packageName, expectations, scannerResults } = input;
+  const shipped = new Set(opts.manifest.entries.map((e) => e.name));
+  const isShipped = shipped.size > 0 && shipped.has(packageName);
+
+  const scannerStates = buildScannerStates(scannerResults);
+  const allFindings: UsageFinding[] = scannerResults.flatMap((r) => [...r.findings]);
+
+  const observations: CrossCheckObservation[] = [];
+
+  // — declared imports —
+  let satisfiedImports = 0;
+  for (const exp of expectations.expectedImports) {
+    const supporting = findingsForImport(allFindings, exp, packageName);
+    const missing = supporting.length > 0; // missing imports surface as 'unresolved-import' OR knip's 'unused-export' on the *exporter* side
+    if (missing) {
+      observations.push({
+        packageName,
+        observationKind: 'declared-import-missing',
+        severity: exp.optional ? 'warn' : 'error',
+        detail: `declared import \`${exp.symbol}\` from \`${exp.package ?? packageName}\` to consumer \`${exp.consumer}\` is missing`,
+        expectedImport: exp,
+        supportingFindings: supporting,
+      });
+    } else {
+      observations.push({
+        packageName,
+        observationKind: 'declared-import-present',
+        severity: 'info',
+        detail: `declared import \`${exp.symbol}\` to \`${exp.consumer}\` is present`,
+        expectedImport: exp,
+        supportingFindings: [],
+      });
+      satisfiedImports += 1;
+    }
+  }
+
+  // — declared exports —
+  let reachableExports = 0;
+  for (const exp of expectations.expectedExports) {
+    const supporting = findingsForExport(allFindings, exp, packageName);
+    if (supporting.length > 0) {
+      observations.push({
+        packageName,
+        observationKind: 'declared-export-orphan',
+        severity: exp.optional ? 'warn' : 'error',
+        detail: `declared export \`${exp.symbol}\` flagged as orphan by ${supporting.map((f) => f.scanner).join(',')}`,
+        expectedExport: exp,
+        supportingFindings: supporting,
+      });
+    } else {
+      observations.push({
+        packageName,
+        observationKind: 'declared-export-reachable',
+        severity: 'info',
+        detail: `declared export \`${exp.symbol}\` is reachable`,
+        expectedExport: exp,
+        supportingFindings: [],
+      });
+      reachableExports += 1;
+    }
+  }
+
+  // — undeclared orphans + unused deps —
+  let orphans = 0;
+  const orphanFindings = allFindings.filter(
+    (f) => f.kind === 'unused-file' || f.kind === 'orphan-module',
+  );
+  for (const f of orphanFindings) {
+    orphans += 1;
+    observations.push({
+      packageName,
+      observationKind: 'undeclared-orphan',
+      severity: isShipped ? 'error' : 'warn',
+      detail: f.message,
+      supportingFindings: [f],
+    });
+  }
+
+  let unusedDeps = 0;
+  const depFindings = allFindings.filter(
+    (f) => f.kind === 'unused-dependency' && f.severity !== 'info',
+  );
+  for (const f of depFindings) {
+    unusedDeps += 1;
+    observations.push({
+      packageName,
+      observationKind: 'undeclared-unused-dep',
+      severity: 'warn',
+      detail: f.message,
+      supportingFindings: [f],
+    });
+  }
+
+  let missingDeps = 0;
+  const missingDepFindings = allFindings.filter(
+    (f) => f.kind === 'missing-in-package-json' || f.kind === 'unlisted-dependency',
+  );
+  for (const f of missingDepFindings) {
+    missingDeps += 1;
+    observations.push({
+      packageName,
+      observationKind: 'undeclared-unused-dep',
+      severity: 'error',
+      detail: f.message,
+      supportingFindings: [f],
+    });
+  }
+
+  let circulars = 0;
+  for (const f of allFindings.filter((f) => f.kind === 'circular-dependency')) {
+    circulars += 1;
+    observations.push({
+      packageName,
+      observationKind: 'undeclared-orphan',
+      severity: 'error',
+      detail: f.message,
+      supportingFindings: [f],
+    });
+  }
+
+  // — scanner disagreement —
+  for (const dis of findScannerDisagreements(allFindings)) {
+    observations.push({
+      packageName,
+      observationKind: 'scanner-disagreement',
+      severity: 'warn',
+      detail: dis.detail,
+      supportingFindings: dis.supporting,
+    });
+  }
+
+  // — tooling degradation —
+  for (const s of ALL_SCANNERS) {
+    if (scannerStates[s] === 'absent') {
+      observations.push({
+        packageName,
+        observationKind: 'scanner-no-tooling',
+        severity: 'info',
+        detail: `scanner \`${s}\` not on PATH; cell degraded`,
+        supportingFindings: [],
+      });
+    }
+  }
+
+  const status = classifyCell({
+    scannerStates,
+    observations,
+  });
+
+  return {
+    packageName,
+    solutionId: expectations.solutionId ?? null,
+    status,
+    expectedImportCount: expectations.expectedImports.length,
+    satisfiedImportCount: satisfiedImports,
+    expectedExportCount: expectations.expectedExports.length,
+    reachableExportCount: reachableExports,
+    orphanCount: orphans,
+    unusedDepCount: unusedDeps,
+    missingDepCount: missingDeps,
+    circularDepCount: circulars,
+    scannerStates,
+    observations,
+  };
+}
+
+/**
+ * Aggregate per-package cells into the matrix.
+ */
+export function buildAttestationMatrix(
+  cells: ReadonlyArray<AttestationCell>,
+): AttestationMatrix {
+  const map = new Map<string, AttestationCell>();
+  const order: string[] = [];
+  const sorted = [...cells].sort((a, b) => a.packageName.localeCompare(b.packageName));
+  for (const c of sorted) {
+    if (!map.has(c.packageName)) {
+      map.set(c.packageName, c);
+      order.push(c.packageName);
+    }
+  }
+  return { cells: map, orderedPackages: order };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+export function classifyCell(input: {
+  readonly scannerStates: Readonly<Record<ScannerKind, ScannerToolingState>>;
+  readonly observations: ReadonlyArray<CrossCheckObservation>;
+}): AttestationCell['status'] {
+  const states = Object.values(input.scannerStates);
+  const present = states.filter((s) => s === 'present').length;
+  const absent = states.filter((s) => s === 'absent').length;
+  const failed = states.filter((s) => s === 'failed').length;
+
+  if (present === 0 && absent === ALL_SCANNERS.length) return 'no-tooling';
+  if (present === 0 && failed > 0) return 'unknown';
+
+  const anyError = input.observations.some((o) => o.severity === 'error');
+  if (anyError) return 'red';
+  const anyWarn = input.observations.some((o) => o.severity === 'warn');
+  if (anyWarn) return 'yellow';
+  return 'green';
+}
+
+export function countByStatus(matrix: AttestationMatrix): Record<AttestationCell['status'], number> {
+  const out: Record<AttestationCell['status'], number> = {
+    green: 0, yellow: 0, red: 0, 'no-tooling': 0, unknown: 0,
+  };
+  for (const c of matrix.cells.values()) out[c.status] += 1;
+  return out;
+}
+
+function buildScannerStates(results: ReadonlyArray<ScannerResult>): Record<ScannerKind, ScannerToolingState> {
+  const out: Record<ScannerKind, ScannerToolingState> = {
+    'knip': 'absent', 'depcheck': 'absent', 'ts-prune': 'absent', 'dependency-cruiser': 'absent',
+  };
+  for (const r of results) out[r.scanner] = r.tooling;
+  return out;
+}
+
+function findingsForImport(findings: ReadonlyArray<UsageFinding>, exp: ExpectedImport, ownerPkg: string): ReadonlyArray<UsageFinding> {
+  const pkg = exp.package ?? ownerPkg;
+  return findings.filter((f) => {
+    if (f.kind !== 'unresolved-import' && f.kind !== 'unused-export') return false;
+    if (f.dependency && f.dependency !== pkg) return false;
+    if (f.symbol && exp.symbol && f.symbol !== exp.symbol) return false;
+    return true;
+  });
+}
+
+function findingsForExport(findings: ReadonlyArray<UsageFinding>, exp: ExpectedExport, _ownerPkg: string): ReadonlyArray<UsageFinding> {
+  return findings.filter((f) => {
+    if (f.kind !== 'unused-export' && f.kind !== 'unused-file') return false;
+    if (f.symbol && f.symbol === exp.symbol) return true;
+    return false;
+  });
+}
+
+interface Disagreement { readonly detail: string; readonly supporting: ReadonlyArray<UsageFinding>; }
+
+function findScannerDisagreements(findings: ReadonlyArray<UsageFinding>): ReadonlyArray<Disagreement> {
+  // knip marks symbol X unused, ts-prune doesn't (or vice-versa) — we
+  // group findings by (kind='unused-export', symbol) and emit a
+  // disagreement when fewer than 2 scanners agree.
+  const bySymbol = new Map<string, UsageFinding[]>();
+  for (const f of findings) {
+    if (f.kind !== 'unused-export') continue;
+    if (!f.symbol) continue;
+    const key = `${f.filePath ?? ''}::${f.symbol}`;
+    if (!bySymbol.has(key)) bySymbol.set(key, []);
+    bySymbol.get(key)!.push(f);
+  }
+  const out: Disagreement[] = [];
+  for (const [key, group] of bySymbol) {
+    const scanners = new Set(group.map((g) => g.scanner));
+    if (scanners.size === 1 && (scanners.has('knip') || scanners.has('ts-prune'))) {
+      // exactly one of {knip, ts-prune} flagged; the other did not.
+      out.push({
+        detail: `only \`${[...scanners][0]}\` flagged \`${key}\` as unused; cross-check tools disagree`,
+        supporting: group,
+      });
+    }
+  }
+  return out;
+}

--- a/packages/usage-steward/src/manifest.ts
+++ b/packages/usage-steward/src/manifest.ts
@@ -1,0 +1,201 @@
+/**
+ * Manifest loading for @caia/usage-steward.
+ *
+ * Two sources of expectations:
+ *   1. Per-package — `package.json#caia.usage.{expectedImports,expectedExports}` OR
+ *      sibling `usage.yaml`. package.json wins on conflict.
+ *   2. Deploy manifest — `agent-memory/deploy_manifest.yaml` enumerates
+ *      every deployed package.
+ */
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { z } from 'zod';
+import type {
+  DeployManifest, DeployManifestEntry,
+  ExpectedExport, ExpectedImport, PackageExpectations,
+} from './types.js';
+
+const ExpectedImportSchema = z.object({
+  consumer: z.string().min(1),
+  symbol: z.string().min(1),
+  package: z.string().min(1).optional(),
+  optional: z.boolean().optional(),
+  description: z.string().optional(),
+});
+const ExpectedExportSchema = z.object({
+  symbol: z.string().min(1),
+  optional: z.boolean().optional(),
+  description: z.string().optional(),
+});
+const PackageUsageStanzaSchema = z.object({
+  solutionId: z.string().optional(),
+  expectedImports: z.array(ExpectedImportSchema).optional().default([]),
+  expectedExports: z.array(ExpectedExportSchema).optional().default([]),
+});
+const PackageJsonSchema = z.object({
+  name: z.string().min(1),
+  caia: z.object({ usage: PackageUsageStanzaSchema.optional() }).optional(),
+}).passthrough();
+const UsageYamlSchema = z.object({
+  packageName: z.string().min(1),
+  solutionId: z.string().optional(),
+  expectedImports: z.array(ExpectedImportSchema).optional().default([]),
+  expectedExports: z.array(ExpectedExportSchema).optional().default([]),
+});
+const DeployManifestEntrySchema = z.object({
+  name: z.string().min(1),
+  path: z.string().optional(),
+  solutionId: z.string().optional(),
+}).passthrough().transform((raw): DeployManifestEntry => {
+  const known = new Set(['name', 'path', 'solutionId']);
+  const metadata: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (!known.has(k)) metadata[k] = v;
+  }
+  return {
+    name: raw.name,
+    ...(raw.path !== undefined ? { path: raw.path } : {}),
+    ...(raw.solutionId !== undefined ? { solutionId: raw.solutionId } : {}),
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+});
+const DeployManifestSchema = z.object({
+  schema_version: z.number().int().nonnegative().default(1),
+  entries: z.array(DeployManifestEntrySchema).default([]),
+});
+
+/** Load deploy_manifest.yaml. Missing file → empty manifest. */
+export async function loadDeployManifest(manifestPath: string): Promise<DeployManifest> {
+  let text: string;
+  try {
+    text = await fs.readFile(manifestPath, 'utf8');
+  } catch (err) {
+    if (isNotFound(err)) return { schemaVersion: 1, entries: [] };
+    throw err;
+  }
+  const raw = text.trim() === '' ? {} : parseYaml(text);
+  const parsed = DeployManifestSchema.parse(raw ?? {});
+  return { schemaVersion: parsed.schema_version, entries: parsed.entries };
+}
+
+/** Load every package's expectations under packagesRoot. */
+export async function loadPackageExpectations(packagesRoot: string): Promise<ReadonlyArray<PackageExpectations>> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(packagesRoot);
+  } catch (err) {
+    if (isNotFound(err)) return [];
+    throw err;
+  }
+  const out: PackageExpectations[] = [];
+  for (const entry of entries) {
+    if (entry.startsWith('.')) continue;
+    const pkgDir = path.join(packagesRoot, entry);
+    const stat = await fs.stat(pkgDir).catch(() => null);
+    if (!stat?.isDirectory()) continue;
+    const pkg = await loadPackageExpectation(pkgDir);
+    if (pkg) out.push(pkg);
+  }
+  out.sort((a, b) => a.packageName.localeCompare(b.packageName));
+  return out;
+}
+
+/**
+ * Load one package's expectations. Always returns a row for any package
+ * with a valid package.json#name — empty stanza becomes 'synthetic'.
+ */
+export async function loadPackageExpectation(packageDir: string): Promise<PackageExpectations | null> {
+  const yamlPath = path.join(packageDir, 'usage.yaml');
+  let yamlExp: PackageExpectations | null = null;
+  if (await fileExists(yamlPath)) {
+    const text = await fs.readFile(yamlPath, 'utf8');
+    const parsed = UsageYamlSchema.parse(parseYaml(text));
+    yamlExp = {
+      packageName: parsed.packageName, packageDir,
+      ...(parsed.solutionId !== undefined ? { solutionId: parsed.solutionId } : {}),
+      source: 'usage.yaml',
+      expectedImports: parsed.expectedImports.map(normImport),
+      expectedExports: parsed.expectedExports.map(normExport),
+    };
+  }
+
+  const pkgJsonPath = path.join(packageDir, 'package.json');
+  let pkgJsonExp: PackageExpectations | null = null;
+  let pkgName: string | undefined;
+  if (await fileExists(pkgJsonPath)) {
+    const text = await fs.readFile(pkgJsonPath, 'utf8');
+    let raw: unknown;
+    try {
+      raw = JSON.parse(text);
+    } catch {
+      return null;
+    }
+    const parsed = PackageJsonSchema.safeParse(raw);
+    if (!parsed.success) return null;
+    pkgName = parsed.data.name;
+    const stanza = parsed.data.caia?.usage;
+    if (stanza && (stanza.expectedImports.length > 0 || stanza.expectedExports.length > 0)) {
+      pkgJsonExp = {
+        packageName: parsed.data.name, packageDir,
+        ...(stanza.solutionId !== undefined ? { solutionId: stanza.solutionId } : {}),
+        source: 'package.json',
+        expectedImports: stanza.expectedImports.map(normImport),
+        expectedExports: stanza.expectedExports.map(normExport),
+      };
+    }
+  }
+  if (pkgJsonExp) return pkgJsonExp;
+  if (yamlExp) return yamlExp;
+  if (pkgName) {
+    return {
+      packageName: pkgName, packageDir, source: 'synthetic',
+      expectedImports: [], expectedExports: [],
+    };
+  }
+  return null;
+}
+
+/** Inner-join expectations against the deploy manifest. */
+export function joinManifestAndExpectations(
+  manifest: DeployManifest,
+  expectations: ReadonlyArray<PackageExpectations>,
+): ReadonlyArray<{ entry: DeployManifestEntry | null; expectations: PackageExpectations }> {
+  if (manifest.entries.length === 0) {
+    return expectations.map((e) => ({ entry: null, expectations: e }));
+  }
+  const byName = new Map(manifest.entries.map((e) => [e.name, e] as const));
+  const out: Array<{ entry: DeployManifestEntry | null; expectations: PackageExpectations }> = [];
+  for (const exp of expectations) {
+    const entry = byName.get(exp.packageName);
+    if (!entry) continue;
+    out.push({ entry, expectations: exp });
+  }
+  return out;
+}
+
+export function declaredShippedNames(manifest: DeployManifest): ReadonlySet<string> {
+  return new Set(manifest.entries.map((e) => e.name));
+}
+
+function normImport(raw: z.infer<typeof ExpectedImportSchema>): ExpectedImport {
+  return {
+    consumer: raw.consumer, symbol: raw.symbol,
+    ...(raw.package !== undefined ? { package: raw.package } : {}),
+    ...(raw.optional !== undefined ? { optional: raw.optional } : {}),
+    ...(raw.description !== undefined ? { description: raw.description } : {}),
+  };
+}
+function normExport(raw: z.infer<typeof ExpectedExportSchema>): ExpectedExport {
+  return {
+    symbol: raw.symbol,
+    ...(raw.optional !== undefined ? { optional: raw.optional } : {}),
+    ...(raw.description !== undefined ? { description: raw.description } : {}),
+  };
+}
+async function fileExists(p: string): Promise<boolean> {
+  try { await fs.access(p); return true; } catch { return false; }
+}
+function isNotFound(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ENOENT';
+}

--- a/packages/usage-steward/src/reporter.ts
+++ b/packages/usage-steward/src/reporter.ts
@@ -1,0 +1,188 @@
+/**
+ * Reporter — surfaces usage-steward findings to:
+ *   1. INBOX.md (under `## USAGE-STEWARD FAILURE`)
+ *   2. event-bus (5 event types)
+ *   3. state-machine (via run.completed event, picked up by the dashboard)
+ *
+ * Each surface is a pure function so callers can drop any (dry-run
+ * skips INBOX + bus, still computes the matrix).
+ */
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type {
+  AttestationCell, AttestationMatrix, RunRow,
+  UsageEvent, UsageEventPayload,
+} from './types.js';
+
+const INBOX_HEADING = '## USAGE-STEWARD FAILURE';
+const INBOX_DEGRADED_HEADING = '## USAGE-STEWARD DEGRADED';
+
+export interface InboxAppendResult {
+  readonly appended: boolean;
+  readonly entriesWritten: number;
+}
+
+/**
+ * Append a section under `## USAGE-STEWARD FAILURE` listing every red
+ * cell. No-op when nothing is red AND nothing is degraded. Idempotent:
+ * skips if the INBOX already mentions this runId.
+ */
+export async function reportToInbox(
+  inboxPath: string,
+  run: RunRow,
+  matrix: AttestationMatrix,
+): Promise<InboxAppendResult> {
+  const reds = [...matrix.cells.values()].filter((c) => c.status === 'red');
+  const degraded = degradedScanners(run);
+  if (reds.length === 0 && degraded.length === 0) {
+    return { appended: false, entriesWritten: 0 };
+  }
+  await fs.mkdir(path.dirname(inboxPath), { recursive: true });
+  let existing: string;
+  try {
+    existing = await fs.readFile(inboxPath, 'utf8');
+  } catch (err) {
+    if (isNotFound(err)) existing = '';
+    else throw err;
+  }
+  if (existing.includes(run.runId)) {
+    return { appended: false, entriesWritten: 0 };
+  }
+  const lines: string[] = [];
+  if (!existing.endsWith('\n') && existing.length > 0) lines.push('');
+  lines.push('');
+
+  if (reds.length > 0) {
+    lines.push(INBOX_HEADING);
+    lines.push('');
+    lines.push(formatHeader(run, reds.length));
+    lines.push('');
+    for (const cell of reds) lines.push(formatRedEntry(run, cell));
+    lines.push('');
+  }
+  if (degraded.length > 0) {
+    lines.push(INBOX_DEGRADED_HEADING);
+    lines.push('');
+    lines.push(formatDegradedEntry(run, degraded));
+    lines.push('');
+  }
+  await fs.appendFile(inboxPath, lines.join('\n'), 'utf8');
+  return { appended: true, entriesWritten: reds.length + (degraded.length > 0 ? 1 : 0) };
+}
+
+export interface EventBusEmitResult {
+  readonly eventsEmitted: number;
+  readonly events: ReadonlyArray<UsageEvent>;
+}
+
+/**
+ * Emit:
+ *   - usage-steward.run.completed              (always, once)
+ *   - usage-steward.orphan.detected            (once per red orphan cell)
+ *   - usage-steward.declared-import.missing    (once per declared-import-missing observation)
+ *   - usage-steward.scanner.degraded           (once per failed scanner)
+ *   - usage-steward.no-tooling.warning         (once iff every scanner is absent)
+ */
+export function reportToEventBus(
+  emit: (event: UsageEvent) => void,
+  run: RunRow,
+  matrix: AttestationMatrix,
+): EventBusEmitResult {
+  const events: UsageEvent[] = [];
+  const base: UsageEventPayload = {
+    runId: run.runId, observedAt: run.finishedAt, site: run.site,
+  };
+
+  events.push({ type: 'usage-steward.run.completed', payload: base });
+
+  const anyPresent = Object.values(run.scannerStates).some((s) => s === 'present');
+  if (!anyPresent) {
+    events.push({
+      type: 'usage-steward.no-tooling.warning',
+      payload: { ...base, note: 'no scanner binaries on PATH; cells all degraded' },
+    });
+  }
+  for (const [scanner, state] of Object.entries(run.scannerStates)) {
+    if (state === 'failed') {
+      events.push({
+        type: 'usage-steward.scanner.degraded',
+        payload: { ...base, scanner: scanner as Exclude<UsageEvent['payload']['scanner'], undefined>, note: `${scanner} run errored; cell unknown` },
+      });
+    }
+  }
+
+  for (const cell of matrix.cells.values()) {
+    if (cell.status !== 'red') continue;
+    for (const obs of cell.observations) {
+      if (obs.observationKind === 'declared-import-missing') {
+        events.push({
+          type: 'usage-steward.declared-import.missing',
+          payload: { ...base, packageName: cell.packageName, detail: obs.detail },
+        });
+      }
+      if (obs.observationKind === 'undeclared-orphan' && obs.severity === 'error') {
+        events.push({
+          type: 'usage-steward.orphan.detected',
+          payload: { ...base, packageName: cell.packageName, detail: obs.detail },
+        });
+      }
+    }
+  }
+
+  for (const ev of events) {
+    try { emit(ev); } catch { /* never crash run loop on flaky bus */ }
+  }
+  return { eventsEmitted: events.length, events };
+}
+
+/**
+ * State-machine event surface. The state-machine consumes
+ * `usage-steward.run.completed` to update its dashboard. Thin alias
+ * over the event-bus emit for explicit intent.
+ */
+export function reportToStateMachine(
+  emit: (event: UsageEvent) => void,
+  run: RunRow,
+): void {
+  emit({
+    type: 'usage-steward.run.completed',
+    payload: {
+      runId: run.runId,
+      observedAt: run.finishedAt,
+      site: run.site,
+      note: `green=${run.summary.green} yellow=${run.summary.yellow} red=${run.summary.red} no-tooling=${run.summary.noTooling} unknown=${run.summary.unknown}`,
+    },
+  });
+}
+
+// ─── Formatters ─────────────────────────────────────────────────────────────
+
+function formatHeader(run: RunRow, redCount: number): string {
+  return `**${run.finishedAt}** — run \`${run.runId}\` (site \`${run.site}\`) flagged **${redCount}** dead-code attestation${redCount === 1 ? '' : 's'}.`;
+}
+
+function formatRedEntry(run: RunRow, cell: AttestationCell): string {
+  const sym = `\`${cell.packageName}\``;
+  const detail = topObservationDetail(cell);
+  return `- [ ] ${run.finishedAt} | ${sym} red | runId=\`${run.runId}\` | orphans=${cell.orphanCount} unusedDeps=${cell.unusedDepCount} missingDeps=${cell.missingDepCount} circular=${cell.circularDepCount} | ${detail}`;
+}
+
+function topObservationDetail(cell: AttestationCell): string {
+  const err = cell.observations.find((o) => o.severity === 'error');
+  if (err) return err.detail;
+  return cell.observations[0]?.detail ?? '(no observations)';
+}
+
+function formatDegradedEntry(run: RunRow, scanners: ReadonlyArray<string>): string {
+  return `- [ ] ${run.finishedAt} | scanners degraded: ${scanners.map((s) => '`' + s + '`').join(', ')} | runId=\`${run.runId}\` | site=\`${run.site}\``;
+}
+
+function degradedScanners(run: RunRow): ReadonlyArray<string> {
+  return Object.entries(run.scannerStates)
+    .filter(([, s]) => s === 'failed')
+    .map(([k]) => k);
+}
+
+function isNotFound(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ENOENT';
+}

--- a/packages/usage-steward/src/run.ts
+++ b/packages/usage-steward/src/run.ts
@@ -1,0 +1,147 @@
+/**
+ * Top-level orchestrator for the usage-steward.
+ *
+ * Glues every module:
+ *   manifest       → expected imports/exports per package
+ *   scanners       → knip + depcheck + ts-prune + dependency-cruiser
+ *   cross-check    → per-(package) AttestationCell
+ *   attestation    → JSONL audit + status snapshot + green-id list
+ *   reporter       → INBOX + event-bus + state-machine
+ *
+ * Safe to call with no arguments: defaults are tuned for the operator's
+ * Mac, but every path is overridable for tests + alternate sites.
+ */
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  appendGreenIds, appendRun, buildRunRow, buildStatusSnapshot,
+  computeNewGreenIds, loadAttestedGreenSet, writeStatusSnapshot,
+} from './attestation.js';
+import { buildAttestationMatrix, countByStatus, crossCheckPackage } from './manifest-cross-check.js';
+import { joinManifestAndExpectations, loadDeployManifest, loadPackageExpectations } from './manifest.js';
+import { reportToEventBus, reportToInbox } from './reporter.js';
+import { ALL_SCANNERS, defaultScannerRunner } from './scanners/index.js';
+import type {
+  AttestationCell, RunOpts, RunResult, ScannerKind, ScannerResult, ScannerToolingState, UsageEvent,
+} from './types.js';
+
+const HOME = os.homedir();
+const DEFAULTS = {
+  deployManifestPath: path.join(HOME, 'Documents/projects/agent-memory/deploy_manifest.yaml'),
+  packagesRoot: path.join(HOME, 'Documents/projects/caia/packages'),
+  runsJsonlPath: path.join(HOME, '.caia/usage-steward/runs.jsonl'),
+  statusJsonPath: path.join(HOME, '.caia/usage-steward/status.json'),
+  attestationsJsonlPath: path.join(HOME, '.caia/usage-steward/attestations.jsonl'),
+  inboxPath: path.join(HOME, 'Documents/projects/agent-memory/INBOX.md'),
+  site: 'caia-mac',
+};
+
+export async function run(opts: RunOpts = {}): Promise<RunResult> {
+  const now = opts.now ?? (() => new Date());
+  const startedAt = now();
+
+  const site = opts.site ?? DEFAULTS.site;
+  const packagesRoot = opts.packagesRoot ?? DEFAULTS.packagesRoot;
+  const inboxPath = opts.inboxPath ?? DEFAULTS.inboxPath;
+  const runsJsonlPath = opts.runsJsonlPath ?? DEFAULTS.runsJsonlPath;
+  const statusJsonPath = opts.statusJsonPath ?? DEFAULTS.statusJsonPath;
+  const attestationsJsonlPath = opts.attestationsJsonlPath ?? DEFAULTS.attestationsJsonlPath;
+  const deployManifestPath = opts.deployManifestPath ?? DEFAULTS.deployManifestPath;
+  const scanners = opts.scanners ?? ALL_SCANNERS;
+  const runScanner = opts.runScanner ?? defaultScannerRunner;
+  const emit = opts.emit ?? noopEmit;
+
+  // 1. Load manifests + per-package expectations.
+  const [manifest, allExpectations] = await Promise.all([
+    loadDeployManifest(deployManifestPath),
+    loadPackageExpectations(packagesRoot),
+  ]);
+  const joined = joinManifestAndExpectations(manifest, allExpectations);
+  const targetExpectations = opts.only && opts.only.length > 0
+    ? joined.filter(({ expectations }) => opts.only!.includes(expectations.packageName))
+    : joined;
+
+  // 2. Run scanners across every target package. Each package scans in
+  //    parallel internally (Promise.all over scanners), but we walk
+  //    packages serially to keep load bounded (124 packages × 4 tools
+  //    in flight is bad for laptops).
+  const cells: AttestationCell[] = [];
+  const aggregateState: Record<ScannerKind, ScannerToolingState> = {
+    'knip': 'absent', 'depcheck': 'absent', 'ts-prune': 'absent', 'dependency-cruiser': 'absent',
+  };
+  for (const { expectations } of targetExpectations) {
+    const results = await Promise.all(
+      scanners.map((s) =>
+        runScanner(s, expectations.packageDir, {}).catch((err: unknown): ScannerResult => ({
+          scanner: s,
+          tooling: 'failed',
+          findings: [],
+          durationMs: 0,
+          errorMessage: err instanceof Error ? err.message : String(err),
+        })),
+      ),
+    );
+    for (const r of results) {
+      // Aggregate: once we've seen 'present' anywhere, the run is no
+      // longer fully no-tooling — operator may have only some tools.
+      if (r.tooling === 'present') aggregateState[r.scanner] = 'present';
+      else if (r.tooling === 'failed' && aggregateState[r.scanner] !== 'present') aggregateState[r.scanner] = 'failed';
+    }
+    const cell = crossCheckPackage({
+      packageName: expectations.packageName,
+      expectations,
+      scannerResults: results,
+    }, { manifest });
+    cells.push(cell);
+  }
+  const matrix = buildAttestationMatrix(cells);
+  const finishedAt = now();
+
+  // 3. Build RunRow + StatusSnapshot.
+  const runRow = buildRunRow({
+    startedAt, finishedAt,
+    site, packagesRoot,
+    scannerStates: aggregateState,
+    matrix,
+  });
+  const snapshot = buildStatusSnapshot(runRow, matrix);
+
+  // 4. Persist + report.
+  let inboxAppended = false;
+  let eventsEmitted = 0;
+  let newGreenIds: ReadonlyArray<string> = [];
+  if (!opts.dryRun) {
+    await appendRun(runsJsonlPath, runRow);
+    await writeStatusSnapshot(statusJsonPath, snapshot);
+    const alreadyAttested = await loadAttestedGreenSet(attestationsJsonlPath);
+    const greens = computeNewGreenIds(runRow, matrix, alreadyAttested);
+    await appendGreenIds(attestationsJsonlPath, greens);
+    newGreenIds = greens.map((g) => g.packageName);
+    const inbox = await reportToInbox(inboxPath, runRow, matrix);
+    inboxAppended = inbox.appended;
+    const bus = reportToEventBus(emit, runRow, matrix);
+    eventsEmitted = bus.eventsEmitted;
+  }
+
+  if (!opts.quiet) {
+    const counts = countByStatus(matrix);
+    console.log(
+      `[usage-steward] run=${runRow.runId} site=${site} ` +
+        `green=${counts.green} yellow=${counts.yellow} red=${counts.red} ` +
+        `no-tooling=${counts['no-tooling']} unknown=${counts.unknown} ` +
+        `(new-greens=${newGreenIds.length}, inbox-appended=${inboxAppended})`,
+    );
+  }
+
+  return {
+    run: runRow,
+    matrix,
+    inboxAppended,
+    eventsEmitted,
+    newGreenIds,
+  };
+}
+
+function noopEmit(_event: UsageEvent): void {
+  /* no-op */
+}

--- a/packages/usage-steward/src/scanners/depcheck.ts
+++ b/packages/usage-steward/src/scanners/depcheck.ts
@@ -1,0 +1,117 @@
+/**
+ * depcheck wrapper — `depcheck --json` → UsageFinding[].
+ *
+ * depcheck JSON: { dependencies[], devDependencies[], missing{}, using{}, invalidFiles{}, invalidDirs{} }
+ *
+ * Classification: missing-in-package-json = error, unused-dep = error,
+ * unused-devDep = info (low signal).
+ */
+import * as path from 'node:path';
+import type { ScannerResult, UsageFinding } from '../types.js';
+import { probeBinary, runBinary, tail } from './spawn.js';
+
+const BIN = 'depcheck';
+
+export interface DepcheckRunOptions {
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+  readonly binaryOverride?: string;
+  readonly stdoutOverride?: string;
+  readonly ignorePatterns?: ReadonlyArray<string>;
+}
+
+export async function runDepcheck(packageDir: string, opts: DepcheckRunOptions = {}): Promise<ScannerResult> {
+  if (opts.stdoutOverride !== undefined) {
+    return {
+      scanner: 'depcheck', tooling: 'present',
+      findings: parseDepcheckJson(opts.stdoutOverride, packageDir),
+      durationMs: 0, stdoutTail: tail(opts.stdoutOverride),
+    };
+  }
+  const probe = await probeBinary(opts.binaryOverride ?? BIN);
+  if (probe.state === 'absent') {
+    return { scanner: 'depcheck', tooling: 'absent', findings: [], durationMs: 0, ...(probe.errorMessage !== undefined ? { errorMessage: probe.errorMessage } : {}) };
+  }
+  const bin = probe.binaryPath ?? BIN;
+  const args: string[] = ['--json'];
+  for (const pat of opts.ignorePatterns ?? []) args.push('--ignore-patterns', pat);
+  args.push(packageDir);
+
+  const r = await runBinary(bin, args, { cwd: packageDir, timeoutMs: opts.timeoutMs ?? 60_000, ...(opts.signal !== undefined ? { signal: opts.signal } : {}) });
+  if (r.notFound) {
+    return { scanner: 'depcheck', tooling: 'absent', findings: [], durationMs: r.durationMs, errorMessage: 'binary not found at spawn time' };
+  }
+  let findings: UsageFinding[];
+  try {
+    findings = parseDepcheckJson(r.stdout, packageDir);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      scanner: 'depcheck', tooling: 'failed', findings: [], durationMs: r.durationMs,
+      ...(probe.version !== undefined ? { toolVersion: probe.version } : {}), errorMessage: `parse error: ${msg}`,
+      stdoutTail: tail(r.stdout), stderrTail: tail(r.stderr),
+    };
+  }
+  return {
+    scanner: 'depcheck', tooling: 'present', findings, durationMs: r.durationMs,
+    ...(probe.version !== undefined ? { toolVersion: probe.version } : {}),
+    stdoutTail: tail(r.stdout), stderrTail: tail(r.stderr),
+  };
+}
+
+interface DepcheckPayload {
+  readonly dependencies?: string[];
+  readonly devDependencies?: string[];
+  readonly missing?: Record<string, string[]>;
+  readonly using?: Record<string, string[]>;
+  readonly invalidFiles?: Record<string, string>;
+  readonly invalidDirs?: Record<string, string>;
+}
+
+export function parseDepcheckJson(stdout: string, packageDir: string): UsageFinding[] {
+  const trimmed = stdout.trim();
+  if (trimmed === '') return [];
+  const start = trimmed.indexOf('{');
+  if (start < 0) return [];
+  const p = JSON.parse(trimmed.slice(start)) as DepcheckPayload;
+  const out: UsageFinding[] = [];
+  for (const dep of p.dependencies ?? []) {
+    out.push({
+      scanner: 'depcheck', kind: 'unused-dependency', severity: 'error',
+      packageName: null, filePath: null, symbol: null, dependency: dep,
+      message: `dependency \`${dep}\` is declared but never imported`,
+      raw: { dep, kind: 'dependency' },
+    });
+  }
+  for (const dep of p.devDependencies ?? []) {
+    out.push({
+      scanner: 'depcheck', kind: 'unused-dependency', severity: 'info',
+      packageName: null, filePath: null, symbol: null, dependency: dep,
+      message: `devDependency \`${dep}\` is declared but never imported`,
+      raw: { dep, kind: 'devDependency' },
+    });
+  }
+  for (const [dep, files] of Object.entries(p.missing ?? {})) {
+    const fl = (files ?? []).map((f) => abs(packageDir, f));
+    out.push({
+      scanner: 'depcheck', kind: 'missing-in-package-json', severity: 'error',
+      packageName: null, filePath: fl[0] ?? null, symbol: null, dependency: dep,
+      message: `imported \`${dep}\` is not declared in package.json (used in ${fl.length} file(s))`,
+      raw: { dep, files: fl },
+    });
+  }
+  for (const [file, err] of Object.entries(p.invalidFiles ?? {})) {
+    out.push({
+      scanner: 'depcheck', kind: 'unresolved-import', severity: 'warn',
+      packageName: null, filePath: abs(packageDir, file),
+      symbol: null, dependency: null,
+      message: `parser failed on \`${file}\`: ${err}`,
+      raw: { file, err },
+    });
+  }
+  return out;
+}
+
+function abs(packageDir: string, p: string): string {
+  return path.isAbsolute(p) ? p : path.join(packageDir, p);
+}

--- a/packages/usage-steward/src/scanners/dependency-cruiser.ts
+++ b/packages/usage-steward/src/scanners/dependency-cruiser.ts
@@ -1,0 +1,228 @@
+/**
+ * dependency-cruiser wrapper — invokes `depcruise` and normalises into
+ * UsageFinding[].
+ *
+ * dep-cruiser JSON shape (subset we care about):
+ * ```
+ * {
+ *   "modules": [
+ *     {
+ *       "source": "src/foo.ts",
+ *       "orphan": true,
+ *       "dependencies": [
+ *         { "module": "lodash", "valid": false, "rules": [{ "severity": "error", "name": "no-dev-dep-in-prod" }] }
+ *       ]
+ *     }
+ *   ],
+ *   "summary": {
+ *     "violations": [
+ *       { "from": "src/a.ts", "to": "src/b.ts", "rule": { "severity": "error", "name": "no-circular" } }
+ *     ]
+ *   }
+ * }
+ * ```
+ *
+ * Classification: severity = error → finding.severity = error; severity =
+ * warn → warn; severity = info → info. Rule names map directly to
+ * UsageFindingKind where possible.
+ */
+
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+import type { ScannerResult, UsageFinding, UsageFindingKind } from '../types.js';
+import { probeBinary, runBinary, tail } from './spawn.js';
+
+const BIN = 'depcruise';
+
+export interface DepCruiserRunOptions {
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+  readonly binaryOverride?: string;
+  readonly stdoutOverride?: string;
+  /** Path (relative to packageDir) of the dep-cruiser config. */
+  readonly config?: string;
+  /** Subpath under packageDir to crawl (default `src`). */
+  readonly entry?: string;
+}
+
+export async function runDependencyCruiser(
+  packageDir: string,
+  opts: DepCruiserRunOptions = {},
+): Promise<ScannerResult> {
+  if (opts.stdoutOverride !== undefined) {
+    return {
+      scanner: 'dependency-cruiser',
+      tooling: 'present',
+      findings: parseDepCruiserJson(opts.stdoutOverride, packageDir),
+      durationMs: 0,
+      stdoutTail: tail(opts.stdoutOverride),
+    };
+  }
+  const probe = await probeBinary(opts.binaryOverride ?? BIN);
+  if (probe.state === 'absent') {
+    return { scanner: 'dependency-cruiser', tooling: 'absent', findings: [], durationMs: 0, ...(probe.errorMessage !== undefined ? { errorMessage: probe.errorMessage } : {}) };
+  }
+
+  const bin = probe.binaryPath ?? BIN;
+  const entry = opts.entry ?? 'src';
+  const entryPath = path.isAbsolute(entry) ? entry : path.join(packageDir, entry);
+  try {
+    await fs.access(entryPath);
+  } catch {
+    return {
+      scanner: 'dependency-cruiser',
+      tooling: 'failed',
+      findings: [],
+      durationMs: 0,
+      ...(probe.version !== undefined ? { toolVersion: probe.version } : {}),
+      errorMessage: `entry path not found: ${entryPath}`,
+    };
+  }
+
+  const args: string[] = ['--output-type', 'json'];
+  if (opts.config) args.push('--config', opts.config);
+  // Synthesise sensible defaults: detect orphans + missing-in-pkg-json
+  // even without a config file.
+  args.push('--include-only', '^' + (opts.entry ?? 'src'));
+  args.push(entry);
+
+  const r = await runBinary(bin, args, {
+    cwd: packageDir,
+    timeoutMs: opts.timeoutMs ?? 120_000,
+    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+  });
+  if (r.notFound) {
+    return { scanner: 'dependency-cruiser', tooling: 'absent', findings: [], durationMs: r.durationMs, errorMessage: 'binary not found at spawn time' };
+  }
+  let findings: UsageFinding[];
+  try {
+    findings = parseDepCruiserJson(r.stdout, packageDir);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      scanner: 'dependency-cruiser', tooling: 'failed', findings: [], durationMs: r.durationMs,
+      ...(probe.version !== undefined ? { toolVersion: probe.version } : {}), errorMessage: `parse error: ${msg}`,
+      stdoutTail: tail(r.stdout), stderrTail: tail(r.stderr),
+    };
+  }
+  return {
+    scanner: 'dependency-cruiser', tooling: 'present', findings, durationMs: r.durationMs,
+    ...(probe.version !== undefined ? { toolVersion: probe.version } : {}),
+    stdoutTail: tail(r.stdout), stderrTail: tail(r.stderr),
+  };
+}
+
+interface DepCruiserRule {
+  readonly name?: string;
+  readonly severity?: 'error' | 'warn' | 'info';
+}
+
+interface DepCruiserDependency {
+  readonly module?: string;
+  readonly resolved?: string;
+  readonly valid?: boolean;
+  readonly couldNotResolve?: boolean;
+  readonly rules?: DepCruiserRule[];
+}
+
+interface DepCruiserModule {
+  readonly source?: string;
+  readonly orphan?: boolean;
+  readonly dependencies?: DepCruiserDependency[];
+}
+
+interface DepCruiserViolation {
+  readonly from?: string;
+  readonly to?: string;
+  readonly cycle?: string[];
+  readonly rule?: DepCruiserRule;
+}
+
+interface DepCruiserPayload {
+  readonly modules?: DepCruiserModule[];
+  readonly summary?: { readonly violations?: DepCruiserViolation[] };
+}
+
+export function parseDepCruiserJson(stdout: string, packageDir: string): UsageFinding[] {
+  const trimmed = stdout.trim();
+  if (trimmed === '') return [];
+  const start = trimmed.indexOf('{');
+  if (start < 0) return [];
+  const p = JSON.parse(trimmed.slice(start)) as DepCruiserPayload;
+  const out: UsageFinding[] = [];
+
+  for (const m of p.modules ?? []) {
+    if (m.orphan && m.source) {
+      out.push({
+        scanner: 'dependency-cruiser',
+        kind: 'orphan-module',
+        severity: 'warn',
+        packageName: null,
+        filePath: abs(packageDir, m.source),
+        symbol: null,
+        dependency: null,
+        message: `module \`${m.source}\` is an orphan (no inbound dep)`,
+        raw: { source: m.source },
+      });
+    }
+    for (const d of m.dependencies ?? []) {
+      if (d.couldNotResolve) {
+        out.push({
+          scanner: 'dependency-cruiser',
+          kind: 'unresolved-import',
+          severity: 'error',
+          packageName: null,
+          filePath: m.source ? abs(packageDir, m.source) : null,
+          symbol: null,
+          dependency: d.module ?? null,
+          message: `cannot resolve \`${d.module}\` from \`${m.source}\``,
+          raw: d,
+        });
+        continue;
+      }
+      for (const rule of d.rules ?? []) {
+        out.push({
+          scanner: 'dependency-cruiser',
+          kind: ruleKind(rule.name),
+          severity: rule.severity ?? 'warn',
+          packageName: null,
+          filePath: m.source ? abs(packageDir, m.source) : null,
+          symbol: null,
+          dependency: d.module ?? null,
+          message: `${rule.name ?? 'unknown-rule'}: \`${m.source}\` → \`${d.module}\``,
+          raw: { module: m.source, dep: d, rule },
+        });
+      }
+    }
+  }
+  for (const v of p.summary?.violations ?? []) {
+    const cyc = v.cycle && v.cycle.length > 0;
+    out.push({
+      scanner: 'dependency-cruiser',
+      kind: cyc ? 'circular-dependency' : ruleKind(v.rule?.name),
+      severity: v.rule?.severity ?? 'warn',
+      packageName: null,
+      filePath: v.from ? abs(packageDir, v.from) : null,
+      symbol: null,
+      dependency: v.to ?? null,
+      message: cyc
+        ? `circular dependency: ${(v.cycle ?? []).join(' → ')}`
+        : `${v.rule?.name ?? 'unknown-rule'}: \`${v.from}\` → \`${v.to}\``,
+      raw: v,
+    });
+  }
+  return out;
+}
+
+function ruleKind(ruleName: string | undefined): UsageFindingKind {
+  if (!ruleName) return 'unresolved-import';
+  if (/no-circular/i.test(ruleName)) return 'circular-dependency';
+  if (/no-orphans?/i.test(ruleName)) return 'orphan-module';
+  if (/dev-dep|dev-dependency/i.test(ruleName)) return 'dev-dep-in-prod';
+  if (/missing|unresolved/i.test(ruleName)) return 'unresolved-import';
+  return 'unresolved-import';
+}
+
+function abs(packageDir: string, p: string): string {
+  return path.isAbsolute(p) ? p : path.join(packageDir, p);
+}

--- a/packages/usage-steward/src/scanners/index.ts
+++ b/packages/usage-steward/src/scanners/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Scanner registry — picks the right wrapper for each ScannerKind and
+ * exposes a `defaultScannerRunner` callers can hand to `run`.
+ */
+import type { ScannerKind, ScannerResult, ScannerRunner } from '../types.js';
+import { runKnip } from './knip.js';
+import { runDepcheck } from './depcheck.js';
+import { runTsPrune } from './ts-prune.js';
+import { runDependencyCruiser } from './dependency-cruiser.js';
+
+export * from './spawn.js';
+export * from './knip.js';
+export * from './depcheck.js';
+export * from './ts-prune.js';
+export * from './dependency-cruiser.js';
+
+export const ALL_SCANNERS: ReadonlyArray<ScannerKind> = [
+  'knip',
+  'depcheck',
+  'ts-prune',
+  'dependency-cruiser',
+] as const;
+
+export const defaultScannerRunner: ScannerRunner = async (scanner, packageDir, opts) => {
+  switch (scanner) {
+    case 'knip':
+      return runKnip(packageDir, opts);
+    case 'depcheck':
+      return runDepcheck(packageDir, opts);
+    case 'ts-prune':
+      return runTsPrune(packageDir, opts);
+    case 'dependency-cruiser':
+      return runDependencyCruiser(packageDir, opts);
+    default: {
+      const _exhaustive: never = scanner;
+      throw new Error(`unknown scanner: ${String(_exhaustive)}`);
+    }
+  }
+};
+
+/** Run every scanner in parallel against one package. Order preserved. */
+export async function runAllScanners(
+  packageDir: string,
+  scanners: ReadonlyArray<ScannerKind> = ALL_SCANNERS,
+  opts: { timeoutMs?: number; signal?: AbortSignal; runner?: ScannerRunner } = {},
+): Promise<ReadonlyArray<ScannerResult>> {
+  const runner = opts.runner ?? defaultScannerRunner;
+  const results = await Promise.all(
+    scanners.map((s) =>
+      runner(s, packageDir, { ...(opts.signal !== undefined ? { signal: opts.signal } : {}), ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}) }).catch((err: unknown) => ({
+        scanner: s,
+        tooling: 'failed' as const,
+        findings: [],
+        durationMs: 0,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      })),
+    ),
+  );
+  return results;
+}

--- a/packages/usage-steward/src/scanners/knip.ts
+++ b/packages/usage-steward/src/scanners/knip.ts
@@ -1,0 +1,293 @@
+/**
+ * Knip wrapper — invokes `knip --reporter json` and normalises the
+ * output into `UsageFinding[]`.
+ *
+ * Knip's JSON shape (as of knip ≥ 5.x):
+ * ```
+ * {
+ *   "files": ["path/to/orphan.ts", …],
+ *   "issues": [
+ *     {
+ *       "file": "path/to/file.ts",
+ *       "owners": ["@caia/foo"],
+ *       "exports":         [{ "name": "X", "line": 12, "col": 4 }, …],
+ *       "types":           [{ "name": "Y", "line": 15, "col": 4 }, …],
+ *       "nsExports":       [{ "name": "*",  "line": 1, "col": 1 }, …],
+ *       "enumMembers":     [{ "name": "X.A", "line": 7, "col": 4 }, …],
+ *       "classMembers":    [{ "name": "X.m", "line": 7, "col": 4 }, …],
+ *       "dependencies":    [{ "name": "pkg",  "line": 0, "col": 0 }, …],
+ *       "devDependencies": [{ "name": "pkg",  "line": 0, "col": 0 }, …],
+ *       "unlisted":        [{ "name": "pkg",  "line": 0, "col": 0 }, …]
+ *     }, …
+ *   ]
+ * }
+ * ```
+ *
+ * The wrapper is tolerant of older shapes (`issues` instead of nested,
+ * etc.) so it doesn't break across knip minor versions.
+ */
+
+import * as path from 'node:path';
+import type { ScannerResult, UsageFinding } from '../types.js';
+import { probeBinary, runBinary, tail } from './spawn.js';
+
+const KNIP_BIN = 'knip';
+
+export interface KnipRunOptions {
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+  /**
+   * If true, run with `--production` to focus on prod-import paths
+   * (skips devDeps + test-only files). Default true — the steward is
+   * about deploy-time correctness, not dev-experience.
+   */
+  readonly production?: boolean;
+  /**
+   * Override the binary used (tests inject a stub script).
+   */
+  readonly binaryOverride?: string;
+  /**
+   * Override stdout used instead of spawning the binary. Tests use
+   * this to avoid `which knip`. When set, the wrapper skips spawn
+   * entirely and just parses the provided text.
+   */
+  readonly stdoutOverride?: string;
+}
+
+export async function runKnip(
+  packageDir: string,
+  opts: KnipRunOptions = {},
+): Promise<ScannerResult> {
+  if (opts.stdoutOverride !== undefined) {
+    const findings = parseKnipJson(opts.stdoutOverride, packageDir);
+    return {
+      scanner: 'knip',
+      tooling: 'present',
+      findings,
+      durationMs: 0,
+      stdoutTail: tail(opts.stdoutOverride),
+    };
+  }
+
+  const probe = await probeBinary(opts.binaryOverride ?? KNIP_BIN);
+  if (probe.state === 'absent') {
+    return {
+      scanner: 'knip',
+      tooling: 'absent',
+      findings: [],
+      durationMs: 0,
+      ...(probe.errorMessage !== undefined ? { errorMessage: probe.errorMessage } : {}),
+    };
+  }
+  const bin = probe.binaryPath ?? KNIP_BIN;
+  const args = ['--reporter', 'json', '--no-progress'];
+  if (opts.production !== false) args.push('--production');
+
+  const spawnRes = await runBinary(bin, args, {
+    cwd: packageDir,
+    timeoutMs: opts.timeoutMs ?? 90_000,
+    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+  });
+
+  if (spawnRes.notFound) {
+    return {
+      scanner: 'knip',
+      tooling: 'absent',
+      findings: [],
+      durationMs: spawnRes.durationMs,
+      errorMessage: 'binary not found at spawn time',
+    };
+  }
+  // Knip exits non-zero when it finds issues — that's not a tooling
+  // failure for our purposes. We only treat parse errors as 'failed'.
+  let findings: UsageFinding[];
+  try {
+    findings = parseKnipJson(spawnRes.stdout, packageDir);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      scanner: 'knip',
+      tooling: 'failed',
+      findings: [],
+      durationMs: spawnRes.durationMs,
+      ...(probe.version !== undefined ? { toolVersion: probe.version } : {}),
+      errorMessage: `parse error: ${msg}`,
+      stdoutTail: tail(spawnRes.stdout),
+      stderrTail: tail(spawnRes.stderr),
+    };
+  }
+  return {
+    scanner: 'knip',
+    tooling: 'present',
+    findings,
+    durationMs: spawnRes.durationMs,
+    ...(probe.version !== undefined ? { toolVersion: probe.version } : {}),
+    stdoutTail: tail(spawnRes.stdout),
+    stderrTail: tail(spawnRes.stderr),
+  };
+}
+
+// ─── Parsing ────────────────────────────────────────────────────────────────
+
+interface KnipIssueLocator {
+  readonly name: string;
+  readonly line?: number;
+  readonly col?: number;
+  readonly symbol?: string;
+}
+
+interface KnipIssue {
+  readonly file?: string;
+  readonly owners?: string[];
+  readonly exports?: KnipIssueLocator[];
+  readonly types?: KnipIssueLocator[];
+  readonly nsExports?: KnipIssueLocator[];
+  readonly nsTypes?: KnipIssueLocator[];
+  readonly enumMembers?: KnipIssueLocator[];
+  readonly classMembers?: KnipIssueLocator[];
+  readonly dependencies?: KnipIssueLocator[];
+  readonly devDependencies?: KnipIssueLocator[];
+  readonly unlisted?: KnipIssueLocator[];
+  readonly unresolved?: KnipIssueLocator[];
+}
+
+interface KnipPayload {
+  readonly files?: string[];
+  readonly issues?: KnipIssue[];
+}
+
+export function parseKnipJson(stdout: string, packageDir: string): UsageFinding[] {
+  const trimmed = stdout.trim();
+  if (trimmed === '') return [];
+
+  // Knip 5+ emits a JSON object even on no issues; tolerate a stray
+  // header line by hunting for the first '{'.
+  const jsonStart = trimmed.indexOf('{');
+  if (jsonStart < 0) return [];
+  const payload = JSON.parse(trimmed.slice(jsonStart)) as KnipPayload;
+
+  const findings: UsageFinding[] = [];
+
+  for (const file of payload.files ?? []) {
+    findings.push({
+      scanner: 'knip',
+      kind: 'unused-file',
+      severity: 'error',
+      packageName: ownerOfFile(file, packageDir),
+      filePath: absolute(packageDir, file),
+      symbol: null,
+      dependency: null,
+      message: `orphan file (no inbound import)`,
+      raw: { file },
+    });
+  }
+
+  for (const issue of payload.issues ?? []) {
+    const owner = issue.owners?.[0] ?? ownerOfFile(issue.file ?? '', packageDir);
+    const abs = issue.file ? absolute(packageDir, issue.file) : null;
+
+    for (const loc of issue.exports ?? []) {
+      findings.push(mkSymbolFinding('unused-export', 'error', owner, abs, loc, 'unused export'));
+    }
+    for (const loc of issue.types ?? []) {
+      findings.push(mkSymbolFinding('unused-export', 'warn', owner, abs, loc, 'unused type export'));
+    }
+    for (const loc of issue.nsExports ?? []) {
+      findings.push(mkSymbolFinding('unused-export', 'warn', owner, abs, loc, 'unused namespace export'));
+    }
+    for (const loc of issue.nsTypes ?? []) {
+      findings.push(mkSymbolFinding('unused-export', 'warn', owner, abs, loc, 'unused namespace type'));
+    }
+    for (const loc of issue.enumMembers ?? []) {
+      findings.push(mkSymbolFinding('unused-enum-member', 'warn', owner, abs, loc, 'unused enum member'));
+    }
+    for (const loc of issue.classMembers ?? []) {
+      findings.push(mkSymbolFinding('unused-class-member', 'warn', owner, abs, loc, 'unused class member'));
+    }
+    for (const loc of issue.dependencies ?? []) {
+      findings.push({
+        scanner: 'knip',
+        kind: 'unused-dependency',
+        severity: 'error',
+        packageName: owner ?? null,
+        filePath: abs,
+        symbol: null,
+        dependency: loc.name,
+        message: `declared dependency \`${loc.name}\` is never imported`,
+        raw: loc,
+      });
+    }
+    for (const loc of issue.devDependencies ?? []) {
+      findings.push({
+        scanner: 'knip',
+        kind: 'unused-dependency',
+        severity: 'info',
+        packageName: owner ?? null,
+        filePath: abs,
+        symbol: null,
+        dependency: loc.name,
+        message: `declared devDependency \`${loc.name}\` is never imported`,
+        raw: loc,
+      });
+    }
+    for (const loc of issue.unlisted ?? []) {
+      findings.push({
+        scanner: 'knip',
+        kind: 'unlisted-dependency',
+        severity: 'error',
+        packageName: owner ?? null,
+        filePath: abs,
+        symbol: null,
+        dependency: loc.name,
+        message: `imported \`${loc.name}\` is not in package.json`,
+        raw: loc,
+      });
+    }
+    for (const loc of issue.unresolved ?? []) {
+      findings.push({
+        scanner: 'knip',
+        kind: 'unresolved-import',
+        severity: 'error',
+        packageName: owner ?? null,
+        filePath: abs,
+        symbol: null,
+        dependency: loc.name,
+        message: `import \`${loc.name}\` could not be resolved`,
+        raw: loc,
+      });
+    }
+  }
+  return findings;
+}
+
+function mkSymbolFinding(
+  kind: 'unused-export' | 'unused-enum-member' | 'unused-class-member',
+  severity: 'error' | 'warn' | 'info',
+  owner: string | null | undefined,
+  abs: string | null,
+  loc: KnipIssueLocator,
+  msgPrefix: string,
+): UsageFinding {
+  return {
+    scanner: 'knip',
+    kind,
+    severity,
+    packageName: owner ?? null,
+    filePath: abs,
+    symbol: loc.name,
+    dependency: null,
+    message: `${msgPrefix}: \`${loc.name}\``,
+    raw: loc,
+  };
+}
+
+function ownerOfFile(filePath: string, packageDir: string): string | null {
+  if (filePath === '') return null;
+  const rel = path.isAbsolute(filePath) ? path.relative(packageDir, filePath) : filePath;
+  if (rel.startsWith('..')) return null;
+  return null; // owner resolution is the cross-checker's job
+}
+
+function absolute(packageDir: string, p: string): string {
+  return path.isAbsolute(p) ? p : path.join(packageDir, p);
+}

--- a/packages/usage-steward/src/scanners/spawn.ts
+++ b/packages/usage-steward/src/scanners/spawn.ts
@@ -1,0 +1,219 @@
+/**
+ * Shared scanner-spawn helpers.
+ *
+ * Every scanner wrapper does the same dance:
+ *   1. probe the binary via `which`
+ *   2. spawn it with scanner-specific args
+ *   3. capture stdout/stderr with a size cap (forensic tail)
+ *   4. apply a per-run timeout
+ *   5. surface clean error rows instead of throwing
+ *
+ * Centralising the dance keeps each scanner module small and uniform.
+ */
+
+import { spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import type { ScannerToolingState } from '../types.js';
+
+const execFileAsync = promisify(execFile);
+
+const STDOUT_CAP = 4 * 1024 * 1024; // 4 MB hard cap on captured stdout
+const STDERR_CAP = 512 * 1024; // 512 KB hard cap on captured stderr
+export const TAIL_BYTES = 4 * 1024; // last 4 KB of each stream for forensic surface
+
+export interface ProbeResult {
+  readonly state: ScannerToolingState;
+  readonly binaryPath?: string;
+  readonly version?: string;
+  readonly errorMessage?: string;
+}
+
+/**
+ * Resolve a binary on $PATH. Tries:
+ *   1. `which <bin>`
+ *   2. `npx --no-install -p <pkg> <bin> --version` as a fallback
+ *
+ * The second hop catches the common case where the scanner is
+ * installed locally to the monorepo via pnpm but not exposed on the
+ * user's global $PATH. We never `npm install` from the steward — only
+ * use what's already resolvable.
+ */
+export async function probeBinary(
+  bin: string,
+  versionArgs: ReadonlyArray<string> = ['--version'],
+): Promise<ProbeResult> {
+  // Step 1: which
+  try {
+    const which = await execFileAsync('which', [bin], { timeout: 2000 });
+    const binaryPath = which.stdout.trim();
+    if (binaryPath !== '') {
+      const version = await tryVersion(binaryPath, versionArgs);
+      return { state: 'present', binaryPath, ...(version !== undefined ? { version } : {}) };
+    }
+  } catch {
+    /* fall through */
+  }
+  // Step 2: npx --no-install fallback. Only useful when run inside the monorepo.
+  try {
+    const npx = await execFileAsync(
+      'npx',
+      ['--no-install', bin, ...versionArgs],
+      { timeout: 4000 },
+    );
+    const version = npx.stdout.trim().split('\n')[0];
+    return { state: 'present', binaryPath: `npx:${bin}`, ...(version !== undefined && version !== '' ? { version } : {}) };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/not found|ENOENT/.test(msg)) {
+      return { state: 'absent', errorMessage: `binary ${bin} not on PATH` };
+    }
+    return { state: 'absent', errorMessage: msg };
+  }
+}
+
+async function tryVersion(
+  binaryPath: string,
+  versionArgs: ReadonlyArray<string>,
+): Promise<string | undefined> {
+  try {
+    const out = await execFileAsync(binaryPath, [...versionArgs], { timeout: 4000 });
+    const v = (out.stdout || out.stderr || '').trim().split('\n')[0];
+    return v === '' ? undefined : v;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface SpawnOptions {
+  readonly cwd: string;
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+  /** Extra env to merge into the child env. */
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+export interface SpawnResult {
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly timedOut: boolean;
+  readonly durationMs: number;
+  /** True iff the process couldn't even be launched (ENOENT). */
+  readonly notFound: boolean;
+}
+
+/**
+ * Spawn a binary, collect stdout + stderr up to caps, apply a timeout.
+ * Never throws — every failure mode is encoded in the return value.
+ */
+export async function runBinary(
+  bin: string,
+  args: ReadonlyArray<string>,
+  opts: SpawnOptions,
+): Promise<SpawnResult> {
+  const startedAt = Date.now();
+  const timeoutMs = opts.timeoutMs ?? 120_000;
+  const env = { ...process.env, ...(opts.env ?? {}) };
+
+  return await new Promise<SpawnResult>((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(bin, [...args], { cwd: opts.cwd, env });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const notFound = /ENOENT/.test(msg);
+      resolve({
+        exitCode: null,
+        signal: null,
+        stdout: '',
+        stderr: msg,
+        timedOut: false,
+        durationMs: Date.now() - startedAt,
+        notFound,
+      });
+      return;
+    }
+
+    let outBuf = '';
+    let errBuf = '';
+    let outBytes = 0;
+    let errBytes = 0;
+    let outTruncated = false;
+    let errTruncated = false;
+    let timedOut = false;
+    let killed = false;
+    let notFound = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killed = true;
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+    }, timeoutMs);
+
+    const abortHandler = (): void => {
+      killed = true;
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        /* ignore */
+      }
+    };
+    if (opts.signal) opts.signal.addEventListener('abort', abortHandler);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const s = chunk.toString('utf8');
+      outBytes += chunk.length;
+      if (outBytes > STDOUT_CAP) {
+        if (!outTruncated) {
+          outBuf += s.slice(0, Math.max(0, STDOUT_CAP - (outBytes - chunk.length)));
+        }
+        outTruncated = true;
+        return;
+      }
+      outBuf += s;
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      const s = chunk.toString('utf8');
+      errBytes += chunk.length;
+      if (errBytes > STDERR_CAP) {
+        if (!errTruncated) {
+          errBuf += s.slice(0, Math.max(0, STDERR_CAP - (errBytes - chunk.length)));
+        }
+        errTruncated = true;
+        return;
+      }
+      errBuf += s;
+    });
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ENOENT') notFound = true;
+      errBuf += err.message;
+    });
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      if (opts.signal) opts.signal.removeEventListener('abort', abortHandler);
+      resolve({
+        exitCode: code,
+        signal: killed ? signal ?? null : signal ?? null,
+        stdout: outBuf,
+        stderr: errBuf,
+        timedOut,
+        durationMs: Date.now() - startedAt,
+        notFound,
+      });
+    });
+  });
+}
+
+/** Take the trailing `n` bytes of a string, with a leading marker if truncated. */
+export function tail(s: string, n: number = TAIL_BYTES): string {
+  if (s.length <= n) return s;
+  return `…[truncated ${s.length - n} bytes]…\n` + s.slice(s.length - n);
+}

--- a/packages/usage-steward/src/scanners/ts-prune.ts
+++ b/packages/usage-steward/src/scanners/ts-prune.ts
@@ -1,0 +1,129 @@
+/**
+ * ts-prune wrapper — invokes `ts-prune --project tsconfig.json` and
+ * normalises text output into UsageFinding[].
+ *
+ * ts-prune output shape (one line per unused export):
+ *   <relpath>:<line> - <symbol>
+ *   <relpath>:<line> - <symbol> (used in module)
+ *
+ * The `(used in module)` suffix means the symbol is used somewhere
+ * inside its own module but never imported externally — that's a
+ * less-severe orphan (`warn` not `error`).
+ *
+ * We treat ts-prune as a cross-check for knip: a finding only ts-prune
+ * sees becomes a `static-analysis-disagreement` info-level finding the
+ * cross-checker can surface in the dashboard.
+ */
+
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+import type { ScannerResult, UsageFinding } from '../types.js';
+import { probeBinary, runBinary, tail } from './spawn.js';
+
+const BIN = 'ts-prune';
+
+export interface TsPruneRunOptions {
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
+  readonly binaryOverride?: string;
+  readonly stdoutOverride?: string;
+  /** tsconfig path relative to packageDir (default `tsconfig.json`). */
+  readonly project?: string;
+}
+
+export async function runTsPrune(
+  packageDir: string,
+  opts: TsPruneRunOptions = {},
+): Promise<ScannerResult> {
+  if (opts.stdoutOverride !== undefined) {
+    return {
+      scanner: 'ts-prune',
+      tooling: 'present',
+      findings: parseTsPruneOutput(opts.stdoutOverride, packageDir),
+      durationMs: 0,
+      stdoutTail: tail(opts.stdoutOverride),
+    };
+  }
+
+  const probe = await probeBinary(opts.binaryOverride ?? BIN);
+  if (probe.state === 'absent') {
+    return { scanner: 'ts-prune', tooling: 'absent', findings: [], durationMs: 0, ...(probe.errorMessage !== undefined ? { errorMessage: probe.errorMessage } : {}) };
+  }
+
+  const project = opts.project ?? 'tsconfig.json';
+  // ts-prune crashes hard if the tsconfig doesn't exist; surface that
+  // as a tooling-failed, not absent.
+  const projectPath = path.isAbsolute(project) ? project : path.join(packageDir, project);
+  try {
+    await fs.access(projectPath);
+  } catch {
+    return {
+      scanner: 'ts-prune',
+      tooling: 'failed',
+      findings: [],
+      durationMs: 0,
+      ...(probe.version !== undefined ? { toolVersion: probe.version } : {}),
+      errorMessage: `tsconfig not found at ${projectPath}`,
+    };
+  }
+
+  const bin = probe.binaryPath ?? BIN;
+  const r = await runBinary(bin, ['--project', project], {
+    cwd: packageDir,
+    timeoutMs: opts.timeoutMs ?? 90_000,
+    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+  });
+  if (r.notFound) {
+    return { scanner: 'ts-prune', tooling: 'absent', findings: [], durationMs: r.durationMs, errorMessage: 'binary not found at spawn time' };
+  }
+
+  let findings: UsageFinding[];
+  try {
+    findings = parseTsPruneOutput(r.stdout, packageDir);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      scanner: 'ts-prune', tooling: 'failed', findings: [], durationMs: r.durationMs,
+      ...(probe.version !== undefined ? { toolVersion: probe.version } : {}), errorMessage: `parse error: ${msg}`,
+      stdoutTail: tail(r.stdout), stderrTail: tail(r.stderr),
+    };
+  }
+  return {
+    scanner: 'ts-prune', tooling: 'present', findings, durationMs: r.durationMs,
+    ...(probe.version !== undefined ? { toolVersion: probe.version } : {}),
+    stdoutTail: tail(r.stdout), stderrTail: tail(r.stderr),
+  };
+}
+
+/**
+ * Parse ts-prune text output. Each non-empty line is either:
+ *   path/to/file.ts:42 - mySymbol
+ *   path/to/file.ts:42 - mySymbol (used in module)
+ * We tolerate blank lines + the "(skip)" lines ts-prune sometimes emits.
+ */
+const LINE_RE = /^([^:]+):(\d+)\s+-\s+(\S+)(\s+\(used in module\))?\s*$/;
+
+export function parseTsPruneOutput(stdout: string, packageDir: string): UsageFinding[] {
+  const out: UsageFinding[] = [];
+  for (const raw of stdout.split('\n')) {
+    const line = raw.trim();
+    if (line === '' || line.startsWith('(skip)')) continue;
+    const m = LINE_RE.exec(line);
+    if (!m) continue;
+    const [, file, , symbol, usedInModule] = m;
+    out.push({
+      scanner: 'ts-prune',
+      kind: 'unused-export',
+      severity: usedInModule ? 'warn' : 'error',
+      packageName: null,
+      filePath: path.isAbsolute(file ?? '') ? (file ?? null) : (file ? path.join(packageDir, file) : null),
+      symbol: symbol ?? null,
+      dependency: null,
+      message: usedInModule
+        ? `export \`${symbol}\` used only in its own module`
+        : `unused export \`${symbol}\``,
+      raw: { line },
+    });
+  }
+  return out;
+}

--- a/packages/usage-steward/src/types.ts
+++ b/packages/usage-steward/src/types.ts
@@ -1,0 +1,356 @@
+/**
+ * @caia/usage-steward — core type definitions.
+ *
+ * Single source of truth for every other module. No value imports here;
+ * keep this file dependency-free so any module can pull from it without
+ * introducing cycles.
+ */
+
+// ─── Scanner kinds + tooling probe ──────────────────────────────────────────
+
+/**
+ * The four scanners this steward orchestrates. The names map 1:1 to
+ * an npm/binary name that must be `which`-resolvable on $PATH for the
+ * scanner cell to be considered live.
+ */
+export type ScannerKind = 'knip' | 'depcheck' | 'ts-prune' | 'dependency-cruiser';
+
+/**
+ * Per-scanner tool-availability state. The steward's graceful-degradation
+ * contract: a missing binary never marks a package red — it marks the
+ * scanner cell `no-tooling` and emits a degraded warning.
+ *
+ * `present`  = binary on $PATH, ran successfully.
+ * `failed`   = binary on $PATH, but the run errored (parse error, etc.).
+ * `absent`   = binary not on $PATH; cell is `no-tooling`.
+ */
+export type ScannerToolingState = 'present' | 'failed' | 'absent';
+
+/**
+ * The categorical kind of a finding. Each scanner can emit any subset
+ * of these. The cross-checker uses the kind to decide red vs yellow.
+ */
+export type UsageFindingKind =
+  | 'unused-file'
+  | 'unused-export'
+  | 'unused-enum-member'
+  | 'unused-class-member'
+  | 'unused-dependency'
+  | 'unlisted-dependency' // declared in code, missing from package.json
+  | 'unresolved-import'
+  | 'circular-dependency'
+  | 'orphan-module'
+  | 'dev-dep-in-prod'
+  | 'missing-in-package-json'
+  | 'static-analysis-disagreement'; // knip says used, ts-prune says unused, etc.
+
+/**
+ * Severity of a finding. The cross-checker maps these into the cell
+ * status. `info` is never enough on its own to mark a cell red.
+ *
+ * - `error`  — would-be-red on its own.
+ * - `warn`   — yellow contribution.
+ * - `info`   — informational only.
+ */
+export type UsageFindingSeverity = 'error' | 'warn' | 'info';
+
+// ─── UsageFinding (the scanner output shape) ───────────────────────────────
+
+/**
+ * One finding from one scanner. Every scanner normalises its native
+ * output to this shape so the rest of the steward can stay
+ * scanner-agnostic.
+ *
+ * `packageName` is best-effort: scanner tools often report file paths
+ * rather than package names. The scanner's own resolver tries to map
+ * the file back to its owning package via the closest enclosing
+ * package.json; if it can't, `packageName` is left null and the
+ * cross-checker treats the finding as repo-scoped.
+ */
+export interface UsageFinding {
+  readonly scanner: ScannerKind;
+  readonly kind: UsageFindingKind;
+  readonly severity: UsageFindingSeverity;
+  /** Best-effort package the finding belongs to (e.g. "@caia/foo"). */
+  readonly packageName: string | null;
+  /** Absolute path to the file the scanner flagged. */
+  readonly filePath: string | null;
+  /** Exported symbol name, if applicable. */
+  readonly symbol: string | null;
+  /** Dependency name, if applicable. */
+  readonly dependency: string | null;
+  /** Free-form human-readable description. */
+  readonly message: string;
+  /** Raw scanner-specific payload, for forensic inspection. */
+  readonly raw?: unknown;
+}
+
+// ─── Scanner result ─────────────────────────────────────────────────────────
+
+/**
+ * What one scanner returns from one run. The `tooling` state captures
+ * whether the binary was present and exited cleanly; `findings` is the
+ * normalised output. `durationMs` lets the dashboard surface slow runs.
+ */
+export interface ScannerResult {
+  readonly scanner: ScannerKind;
+  readonly tooling: ScannerToolingState;
+  readonly findings: ReadonlyArray<UsageFinding>;
+  readonly durationMs: number;
+  /** Tool's CLI version (`knip --version`) when available. */
+  readonly toolVersion?: string;
+  /** If `tooling === 'failed'`, the captured error message. */
+  readonly errorMessage?: string;
+  /** Stdout/stderr tail (cap 4 KB each), for forensic inspection. */
+  readonly stdoutTail?: string;
+  readonly stderrTail?: string;
+}
+
+// ─── Expected imports (per-package manifest declaration) ───────────────────
+
+/**
+ * A declared (consumer, symbol, package) triple. The package owner
+ * asserts that the named consumer must import `symbol` from this
+ * package. If the import is missing from the static graph the
+ * cross-checker emits a `declared-import-missing` finding and the
+ * cell trends yellow → red.
+ */
+export interface ExpectedImport {
+  /** Consumer file or package (e.g. "apps/caia/src/dispatcher.ts"). */
+  readonly consumer: string;
+  /** Exported symbol that must be imported. */
+  readonly symbol: string;
+  /**
+   * Optional explicit package — defaults to the package declaring the
+   * stanza. Useful when a re-export chains through another package.
+   */
+  readonly package?: string;
+  /** Soft expectation — drift becomes yellow, not red. */
+  readonly optional?: boolean;
+  readonly description?: string;
+}
+
+/**
+ * A declared export the steward asks knip to confirm is reachable.
+ * Mirrors knip's `--include exports,nsExports,classMembers`.
+ */
+export interface ExpectedExport {
+  readonly symbol: string;
+  /** Soft expectation — orphan becomes yellow, not red. */
+  readonly optional?: boolean;
+  readonly description?: string;
+}
+
+/**
+ * Per-package manifest. Loaded from either:
+ *  - `package.json#caia.usage.expectedImports[]` / `expectedExports[]`
+ *  - sibling `usage.yaml` file
+ * `package.json` wins on conflict.
+ */
+export interface PackageExpectations {
+  readonly packageName: string;
+  readonly packageDir: string;
+  readonly solutionId?: string;
+  readonly source: 'package.json' | 'usage.yaml' | 'synthetic';
+  readonly expectedImports: ReadonlyArray<ExpectedImport>;
+  readonly expectedExports: ReadonlyArray<ExpectedExport>;
+}
+
+// ─── Deploy manifest (canonical list of deployed packages) ─────────────────
+
+export interface DeployManifestEntry {
+  readonly name: string;
+  readonly path?: string;
+  readonly solutionId?: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface DeployManifest {
+  readonly schemaVersion: number;
+  readonly entries: ReadonlyArray<DeployManifestEntry>;
+}
+
+// ─── Cross-check output ────────────────────────────────────────────────────
+
+/**
+ * A single cross-check observation about one (package, expectation)
+ * tuple. The cross-checker emits zero or more of these per package per
+ * run.
+ */
+export interface CrossCheckObservation {
+  readonly packageName: string;
+  readonly observationKind:
+    | 'declared-import-missing'
+    | 'declared-import-present'
+    | 'declared-export-orphan'
+    | 'declared-export-reachable'
+    | 'undeclared-orphan'
+    | 'undeclared-unused-dep'
+    | 'scanner-disagreement'
+    | 'scanner-no-tooling';
+  readonly severity: UsageFindingSeverity;
+  readonly detail: string;
+  /** The originating expectation, when applicable. */
+  readonly expectedImport?: ExpectedImport;
+  readonly expectedExport?: ExpectedExport;
+  /** Underlying finding(s) the observation rests on. */
+  readonly supportingFindings: ReadonlyArray<UsageFinding>;
+}
+
+// ─── Attestation cell + matrix ─────────────────────────────────────────────
+
+/**
+ * Per-cell attestation status. Same five-state vocabulary as
+ * `@caia/activation-steward` so the lifecycle conductor can join
+ * the two without translation.
+ *
+ * - `green`        — all expectations met; no errors.
+ * - `yellow`       — soft drift (warnings, optional misses, disagreements).
+ * - `red`          — at least one hard expectation missed.
+ * - `no-tooling`   — every scanner was absent; degraded, not failed.
+ * - `unknown`      — every available scanner errored.
+ */
+export type AttestationStatus = 'green' | 'yellow' | 'red' | 'no-tooling' | 'unknown';
+
+export interface AttestationCell {
+  readonly packageName: string;
+  readonly solutionId: string | null;
+  readonly status: AttestationStatus;
+  readonly expectedImportCount: number;
+  readonly satisfiedImportCount: number;
+  readonly expectedExportCount: number;
+  readonly reachableExportCount: number;
+  readonly orphanCount: number;
+  readonly unusedDepCount: number;
+  readonly missingDepCount: number;
+  readonly circularDepCount: number;
+  readonly scannerStates: Readonly<Record<ScannerKind, ScannerToolingState>>;
+  readonly observations: ReadonlyArray<CrossCheckObservation>;
+  readonly note?: string;
+}
+
+export interface AttestationMatrix {
+  readonly cells: ReadonlyMap<string, AttestationCell>;
+  readonly orderedPackages: ReadonlyArray<string>;
+}
+
+// ─── Run row (JSONL audit line) ────────────────────────────────────────────
+
+export interface AttestationSummary {
+  readonly green: number;
+  readonly yellow: number;
+  readonly red: number;
+  readonly noTooling: number;
+  readonly unknown: number;
+}
+
+export interface AttestationEntry {
+  readonly packageName: string;
+  readonly solutionId: string | null;
+  readonly status: AttestationStatus;
+  readonly observedAt: string;
+  readonly note?: string;
+}
+
+export interface RunRow {
+  readonly runId: string;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly site: string;
+  readonly packagesRoot: string;
+  readonly scannerStates: Readonly<Record<ScannerKind, ScannerToolingState>>;
+  readonly attestations: ReadonlyArray<AttestationEntry>;
+  readonly summary: AttestationSummary;
+}
+
+export interface StatusSnapshot {
+  readonly latestRunId: string;
+  readonly latestRunAt: string;
+  readonly site: string;
+  readonly summary: AttestationSummary;
+  readonly scannerStates: Readonly<Record<ScannerKind, ScannerToolingState>>;
+  readonly cells: ReadonlyArray<AttestationCell>;
+}
+
+// ─── Event bus surface ─────────────────────────────────────────────────────
+
+export type UsageEventType =
+  | 'usage-steward.run.completed'
+  | 'usage-steward.orphan.detected'
+  | 'usage-steward.declared-import.missing'
+  | 'usage-steward.scanner.degraded'
+  | 'usage-steward.no-tooling.warning';
+
+export interface UsageEventPayload {
+  readonly runId: string;
+  readonly observedAt: string;
+  readonly site: string;
+  readonly packageName?: string;
+  readonly scanner?: ScannerKind;
+  readonly note?: string;
+  readonly detail?: string;
+}
+
+export interface UsageEvent {
+  readonly type: UsageEventType;
+  readonly payload: UsageEventPayload;
+}
+
+// ─── Run options + result ──────────────────────────────────────────────────
+
+export interface RunOpts {
+  /** Override Date.now (tests). */
+  readonly now?: () => Date;
+  /** Skip every disk write + INBOX append + bus emit. */
+  readonly dryRun?: boolean;
+  /** Suppress console summary. */
+  readonly quiet?: boolean;
+  /** Site identifier (default "caia-mac"). */
+  readonly site?: string;
+  /** Override packages root (default ~/Documents/projects/caia/packages). */
+  readonly packagesRoot?: string;
+  /** Override deploy_manifest.yaml path. */
+  readonly deployManifestPath?: string;
+  /** Override JSONL audit path. */
+  readonly runsJsonlPath?: string;
+  /** Override status snapshot path. */
+  readonly statusJsonPath?: string;
+  /** Override attestations green-id list path. */
+  readonly attestationsJsonlPath?: string;
+  /** Override INBOX path. */
+  readonly inboxPath?: string;
+  /**
+   * Restrict to a specific list of packages (useful for tests +
+   * one-shot diagnostics). When null/undefined, scans every package
+   * under `packagesRoot`.
+   */
+  readonly only?: ReadonlyArray<string>;
+  /** Override which scanners run (e.g. tests pin a deterministic subset). */
+  readonly scanners?: ReadonlyArray<ScannerKind>;
+  /** Event-bus emit. Defaults to a no-op. */
+  readonly emit?: (event: UsageEvent) => void;
+  /**
+   * Inject a synthetic scanner runner. Used by tests + the integration
+   * suite to substitute deterministic outputs for the real binaries.
+   */
+  readonly runScanner?: ScannerRunner;
+}
+
+/**
+ * A function that runs one scanner against one package and returns the
+ * normalised result. The default implementation shells out; tests
+ * inject a deterministic stub.
+ */
+export type ScannerRunner = (
+  scanner: ScannerKind,
+  packageDir: string,
+  opts: { signal?: AbortSignal; timeoutMs?: number },
+) => Promise<ScannerResult>;
+
+export interface RunResult {
+  readonly run: RunRow;
+  readonly matrix: AttestationMatrix;
+  readonly inboxAppended: boolean;
+  readonly eventsEmitted: number;
+  readonly newGreenIds: ReadonlyArray<string>;
+}

--- a/packages/usage-steward/tests/attestation.test.ts
+++ b/packages/usage-steward/tests/attestation.test.ts
@@ -1,0 +1,101 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  appendGreenIds, appendRun, buildRunRow, buildStatusSnapshot, classify,
+  computeNewGreenIds, flattenForPostgres, greenKey, loadAttestedGreenSet,
+  loadRecentRuns, readStatusSnapshot, writeStatusSnapshot,
+} from '../src/attestation.js';
+import { buildAttestationMatrix } from '../src/manifest-cross-check.js';
+import type { AttestationCell, AttestationMatrix, ScannerKind, ScannerToolingState } from '../src/types.js';
+
+let TMP: string;
+beforeEach(async () => { TMP = await fs.mkdtemp(path.join(os.tmpdir(), 'us-att-')); });
+afterEach(async () => { await fs.rm(TMP, { recursive: true, force: true }); });
+
+const presentAll: Record<ScannerKind, ScannerToolingState> = {
+  knip: 'present', depcheck: 'present', 'ts-prune': 'present', 'dependency-cruiser': 'present',
+};
+
+function cell(name: string, status: AttestationCell['status'] = 'green'): AttestationCell {
+  return {
+    packageName: name, solutionId: null, status,
+    expectedImportCount: 0, satisfiedImportCount: 0,
+    expectedExportCount: 0, reachableExportCount: 0,
+    orphanCount: 0, unusedDepCount: 0, missingDepCount: 0, circularDepCount: 0,
+    scannerStates: presentAll, observations: [],
+  };
+}
+const M = (cs: AttestationCell[]): AttestationMatrix => buildAttestationMatrix(cs);
+
+describe('buildRunRow + buildStatusSnapshot', () => {
+  it('summary counts match cell statuses', () => {
+    const matrix = M([cell('a','green'), cell('b','red'), cell('c','yellow')]);
+    const row = buildRunRow({
+      runId: 'fixed', startedAt: new Date('2026-05-25T00:00:00Z'),
+      finishedAt: new Date('2026-05-25T00:00:01Z'),
+      site: 'caia-mac', packagesRoot: '/tmp', scannerStates: presentAll, matrix,
+    });
+    expect(row.summary).toEqual({ green: 1, yellow: 1, red: 1, noTooling: 0, unknown: 0 });
+    expect(row.runId).toBe('fixed');
+  });
+  it('snapshot cells sorted alphabetically', () => {
+    const matrix = M([cell('b'), cell('a')]);
+    const row = buildRunRow({ startedAt: new Date(), finishedAt: new Date(), site: 's', packagesRoot: '/r', scannerStates: presentAll, matrix });
+    expect(buildStatusSnapshot(row, matrix).cells.map(c => c.packageName)).toEqual(['a','b']);
+  });
+});
+
+describe('JSONL + status round-trip', () => {
+  it('append + load preserves rows', async () => {
+    const matrix = M([cell('x')]);
+    const row = buildRunRow({ startedAt: new Date(), finishedAt: new Date(), site: 's', packagesRoot: '/r', scannerStates: presentAll, matrix });
+    const p = path.join(TMP, 'runs.jsonl');
+    await appendRun(p, row);
+    await appendRun(p, row);
+    expect((await loadRecentRuns(p, 5)).length).toBe(2);
+  });
+  it('loadRecentRuns is [] when file missing', async () => {
+    expect(await loadRecentRuns(path.join(TMP,'no.jsonl'), 5)).toEqual([]);
+  });
+  it('writeStatusSnapshot is atomic + readable', async () => {
+    const matrix = M([cell('y','green')]);
+    const row = buildRunRow({ startedAt: new Date(), finishedAt: new Date(), site: 's', packagesRoot: '/r', scannerStates: presentAll, matrix });
+    const p = path.join(TMP,'status.json');
+    await writeStatusSnapshot(p, buildStatusSnapshot(row, matrix));
+    const back = await readStatusSnapshot(p);
+    expect(back?.latestRunId).toBe(row.runId);
+  });
+  it('readStatusSnapshot is null when missing', async () => {
+    expect(await readStatusSnapshot(path.join(TMP,'no.json'))).toBeNull();
+  });
+});
+
+describe('green-id attestation list', () => {
+  it('loadAttestedGreenSet [] when missing', async () => {
+    expect((await loadAttestedGreenSet(path.join(TMP,'no.jsonl'))).size).toBe(0);
+  });
+  it('computeNewGreenIds skips already-attested + skips non-green', () => {
+    const matrix = M([cell('a','green'), cell('b','green'), cell('c','red')]);
+    const row = buildRunRow({ startedAt: new Date(), finishedAt: new Date(), site: 's', packagesRoot: '/r', scannerStates: presentAll, matrix });
+    const already = new Set([greenKey('a','s')]);
+    expect(computeNewGreenIds(row, matrix, already).map(g => g.packageName)).toEqual(['b']);
+  });
+  it('appendGreenIds round-trips through loadAttestedGreenSet', async () => {
+    const p = path.join(TMP,'attestations.jsonl');
+    await appendGreenIds(p, [{ packageName:'a', solutionId:null, runId:'r1', attestedAt:'2026-05-25', site:'caia-mac' }]);
+    expect((await loadAttestedGreenSet(p)).has(greenKey('a','caia-mac'))).toBe(true);
+  });
+});
+
+describe('flattenForPostgres + classify', () => {
+  it('emits one row per cell', () => {
+    const matrix = M([cell('a'), cell('b')]);
+    const row = buildRunRow({ startedAt: new Date(), finishedAt: new Date(), site: 's', packagesRoot: '/r', scannerStates: presentAll, matrix });
+    expect(flattenForPostgres(row, matrix).length).toBe(2);
+  });
+  it('classify pass-through', () => {
+    expect(classify(cell('a','red'))).toBe('red');
+  });
+});

--- a/packages/usage-steward/tests/integration-real-monorepo.test.ts
+++ b/packages/usage-steward/tests/integration-real-monorepo.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Integration test against the real caia monorepo.
+ *
+ * Purpose: exercise the full pipeline (manifest loader + scanner runner
+ * + cross-checker + attestation writer) against the live packages/
+ * tree to surface the 30+ ship-and-forget packages identified in the
+ * 2026-05-20 stack-teardown lesson.
+ *
+ * Determinism: the test does NOT spawn the real scanner binaries (knip
+ * etc.) — that would be flaky in CI and slow on laptops. Instead it:
+ *
+ *   1. Loads every real package via `loadPackageExpectations`.
+ *   2. Injects a synthetic `ScannerRunner` that flags any package whose
+ *      package.json has zero dependencies (a heuristic proxy for
+ *      "probably never imported by anything") as an orphan.
+ *   3. Asserts the run completes, writes its JSONL log, and surfaces
+ *      at least 1 yellow/red attestation (the lesson's premise).
+ *
+ * The test is skipped automatically when not run against the canonical
+ * monorepo path (so it doesn't fail in CI sandboxes).
+ */
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { run } from '../src/run.js';
+import type { ScannerKind, ScannerResult, ScannerRunner, UsageFinding } from '../src/types.js';
+
+const CAIA_PACKAGES_ROOT = path.join(os.homedir(), 'Documents/projects/caia/packages');
+
+let TMP: string;
+beforeEach(async () => { TMP = await fs.mkdtemp(path.join(os.tmpdir(), 'us-integration-')); });
+afterEach(async () => { await fs.rm(TMP, { recursive: true, force: true }); });
+
+const heuristicRunner: ScannerRunner = async (scanner: ScannerKind, packageDir: string): Promise<ScannerResult> => {
+  // For determinism we only emit findings from `knip`-position; the
+  // other three scanners no-op. The knip-position finding is a
+  // synthetic "this package has no dependencies declared in
+  // package.json" check — a cheap proxy for "ship-and-forget".
+  if (scanner !== 'knip') {
+    return { scanner, tooling: 'present', findings: [], durationMs: 0 };
+  }
+  let pkg: { dependencies?: Record<string, unknown>; name?: string } = {};
+  try {
+    pkg = JSON.parse(await fs.readFile(path.join(packageDir, 'package.json'), 'utf8'));
+  } catch {
+    return { scanner, tooling: 'present', findings: [], durationMs: 0 };
+  }
+  const findings: UsageFinding[] = [];
+  if (!pkg.dependencies || Object.keys(pkg.dependencies).length === 0) {
+    findings.push({
+      scanner: 'knip', kind: 'unused-file', severity: 'error',
+      packageName: pkg.name ?? null, filePath: path.join(packageDir, 'src/index.ts'),
+      symbol: null, dependency: null,
+      message: 'no runtime dependencies declared — candidate ship-and-forget',
+      raw: { dependencies: pkg.dependencies ?? null },
+    });
+  }
+  return { scanner, tooling: 'present', findings, durationMs: 0 };
+};
+
+describe('integration: real caia monorepo', () => {
+  it('runs end-to-end against the real packages tree and surfaces candidate ship-and-forget findings', async () => {
+    let exists = false;
+    try {
+      const stat = await fs.stat(CAIA_PACKAGES_ROOT);
+      exists = stat.isDirectory();
+    } catch { /* ignore */ }
+    if (!exists) {
+      // Skip silently in environments that don't have the monorepo.
+      // (Vitest doesn't have ctx.skip in flat config; we just assert
+      // that path-checks themselves work.)
+      expect(exists).toBe(false);
+      return;
+    }
+
+    const runsJsonl = path.join(TMP, 'runs.jsonl');
+    const statusJson = path.join(TMP, 'status.json');
+    const attestJsonl = path.join(TMP, 'attestations.jsonl');
+    const inbox = path.join(TMP, 'INBOX.md');
+
+    const result = await run({
+      packagesRoot: CAIA_PACKAGES_ROOT,
+      runsJsonlPath: runsJsonl,
+      statusJsonPath: statusJson,
+      attestationsJsonlPath: attestJsonl,
+      inboxPath: inbox,
+      deployManifestPath: path.join(TMP, 'no-manifest.yaml'), // empty → every pkg is in scope
+      runScanner: heuristicRunner,
+      quiet: true,
+    });
+
+    // We must have scanned a real, non-trivial monorepo.
+    expect(result.run.attestations.length).toBeGreaterThan(30);
+
+    // The heuristic should flag at least one package as yellow (no
+    // deps → likely ship-and-forget). The exact count depends on the
+    // monorepo at scan time; we just assert ≥1 to keep the test stable.
+    const yellowOrRed = result.run.summary.yellow + result.run.summary.red;
+    expect(yellowOrRed).toBeGreaterThan(0);
+
+    // The audit JSONL + status snapshot must have been written.
+    const runsText = await fs.readFile(runsJsonl, 'utf8');
+    expect(runsText.split('\n').filter((l) => l.trim() !== '')).toHaveLength(1);
+    const statusText = await fs.readFile(statusJson, 'utf8');
+    const snapshot = JSON.parse(statusText) as { latestRunId: string; summary: { green: number } };
+    expect(snapshot.latestRunId).toBe(result.run.runId);
+  }, 90_000);
+});

--- a/packages/usage-steward/tests/manifest-cross-check.test.ts
+++ b/packages/usage-steward/tests/manifest-cross-check.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAttestationMatrix,
+  classifyCell,
+  countByStatus,
+  crossCheckPackage,
+} from '../src/manifest-cross-check.js';
+import type {
+  AttestationCell, DeployManifest, PackageExpectations, ScannerKind,
+  ScannerResult, ScannerToolingState, UsageFinding,
+} from '../src/types.js';
+
+const emptyManifest: DeployManifest = { schemaVersion: 1, entries: [] };
+
+const allPresent: Record<ScannerKind, ScannerToolingState> = {
+  knip: 'present', depcheck: 'present', 'ts-prune': 'present', 'dependency-cruiser': 'present',
+};
+const allAbsent: Record<ScannerKind, ScannerToolingState> = {
+  knip: 'absent', depcheck: 'absent', 'ts-prune': 'absent', 'dependency-cruiser': 'absent',
+};
+
+function pkg(name: string, partial: Partial<PackageExpectations> = {}): PackageExpectations {
+  return {
+    packageName: name,
+    packageDir: `/tmp/${name}`,
+    source: 'synthetic',
+    expectedImports: [],
+    expectedExports: [],
+    ...partial,
+  };
+}
+
+function scanResult(scanner: ScannerKind, findings: UsageFinding[] = [], tooling: ScannerToolingState = 'present'): ScannerResult {
+  return { scanner, tooling, findings, durationMs: 1 };
+}
+
+describe('classifyCell', () => {
+  it('returns no-tooling when every scanner is absent', () => {
+    expect(classifyCell({ scannerStates: allAbsent, observations: [] })).toBe('no-tooling');
+  });
+  it('returns unknown when no scanner is present but some failed', () => {
+    const states: Record<ScannerKind, ScannerToolingState> = {
+      knip: 'failed', depcheck: 'failed', 'ts-prune': 'failed', 'dependency-cruiser': 'failed',
+    };
+    expect(classifyCell({ scannerStates: states, observations: [] })).toBe('unknown');
+  });
+  it('returns red on any error observation', () => {
+    const obs = [{ packageName: 'a', observationKind: 'declared-import-missing', severity: 'error', detail: 'x', supportingFindings: [] } as const];
+    expect(classifyCell({ scannerStates: allPresent, observations: obs })).toBe('red');
+  });
+  it('returns yellow on warn observations and no errors', () => {
+    const obs = [{ packageName: 'a', observationKind: 'undeclared-orphan', severity: 'warn', detail: 'x', supportingFindings: [] } as const];
+    expect(classifyCell({ scannerStates: allPresent, observations: obs })).toBe('yellow');
+  });
+  it('returns green when no warn/error observations', () => {
+    expect(classifyCell({ scannerStates: allPresent, observations: [] })).toBe('green');
+  });
+});
+
+describe('crossCheckPackage', () => {
+  it('marks a clean package green', () => {
+    const cell = crossCheckPackage(
+      { packageName: '@caia/foo', expectations: pkg('@caia/foo'), scannerResults: [scanResult('knip')] },
+      { manifest: emptyManifest },
+    );
+    expect(cell.status).toBe('green');
+    expect(cell.orphanCount).toBe(0);
+  });
+  it('marks orphan-module finding as warn when package not in manifest', () => {
+    const finding: UsageFinding = {
+      scanner: 'dependency-cruiser', kind: 'orphan-module', severity: 'warn',
+      packageName: null, filePath: '/tmp/foo/src/x.ts', symbol: null, dependency: null, message: 'orphan',
+    };
+    const cell = crossCheckPackage(
+      { packageName: '@caia/foo', expectations: pkg('@caia/foo'), scannerResults: [scanResult('dependency-cruiser', [finding])] },
+      { manifest: emptyManifest },
+    );
+    expect(cell.status).toBe('yellow');
+    expect(cell.orphanCount).toBe(1);
+  });
+  it('marks orphan as red when package IS in the deploy manifest (declared-shipped-but-unused)', () => {
+    const finding: UsageFinding = {
+      scanner: 'knip', kind: 'unused-file', severity: 'error',
+      packageName: null, filePath: '/tmp/foo/src/orphan.ts', symbol: null, dependency: null, message: 'orphan file',
+    };
+    const cell = crossCheckPackage(
+      { packageName: '@caia/foo', expectations: pkg('@caia/foo'), scannerResults: [scanResult('knip', [finding])] },
+      { manifest: { schemaVersion: 1, entries: [{ name: '@caia/foo' }] } },
+    );
+    expect(cell.status).toBe('red');
+  });
+  it('emits declared-import-missing when expected import has supporting unresolved-import finding', () => {
+    const finding: UsageFinding = {
+      scanner: 'knip', kind: 'unresolved-import', severity: 'error',
+      packageName: null, filePath: null, symbol: 'Foo', dependency: '@caia/foo', message: 'missing',
+    };
+    const expectations = pkg('@caia/foo', {
+      expectedImports: [{ consumer: 'apps/x', symbol: 'Foo', package: '@caia/foo' }],
+    });
+    const cell = crossCheckPackage(
+      { packageName: '@caia/foo', expectations, scannerResults: [scanResult('knip', [finding])] },
+      { manifest: emptyManifest },
+    );
+    expect(cell.status).toBe('red');
+    expect(cell.observations.some((o) => o.observationKind === 'declared-import-missing')).toBe(true);
+  });
+  it('emits info observations for scanner-no-tooling when knip is absent', () => {
+    const cell = crossCheckPackage(
+      {
+        packageName: '@caia/foo',
+        expectations: pkg('@caia/foo'),
+        scannerResults: [
+          scanResult('knip', [], 'absent'),
+          scanResult('depcheck'),
+          scanResult('ts-prune'),
+          scanResult('dependency-cruiser'),
+        ],
+      },
+      { manifest: emptyManifest },
+    );
+    expect(cell.observations.some((o) => o.observationKind === 'scanner-no-tooling')).toBe(true);
+    // present > 0 → still green-eligible if no errors
+    expect(cell.status).toBe('green');
+  });
+});
+
+describe('buildAttestationMatrix + countByStatus', () => {
+  it('produces a sorted, deduplicated map', () => {
+    const cells: AttestationCell[] = [
+      { packageName: 'b', solutionId: null, status: 'green', expectedImportCount: 0, satisfiedImportCount: 0, expectedExportCount: 0, reachableExportCount: 0, orphanCount: 0, unusedDepCount: 0, missingDepCount: 0, circularDepCount: 0, scannerStates: allPresent, observations: [] },
+      { packageName: 'a', solutionId: null, status: 'red', expectedImportCount: 0, satisfiedImportCount: 0, expectedExportCount: 0, reachableExportCount: 0, orphanCount: 1, unusedDepCount: 0, missingDepCount: 0, circularDepCount: 0, scannerStates: allPresent, observations: [] },
+    ];
+    const matrix = buildAttestationMatrix(cells);
+    expect(matrix.orderedPackages).toEqual(['a', 'b']);
+    const counts = countByStatus(matrix);
+    expect(counts.green).toBe(1);
+    expect(counts.red).toBe(1);
+  });
+});

--- a/packages/usage-steward/tests/manifest.test.ts
+++ b/packages/usage-steward/tests/manifest.test.ts
@@ -1,0 +1,130 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  declaredShippedNames,
+  joinManifestAndExpectations,
+  loadDeployManifest,
+  loadPackageExpectation,
+  loadPackageExpectations,
+} from '../src/manifest.js';
+
+let TMP: string;
+
+beforeEach(async () => {
+  TMP = await fs.mkdtemp(path.join(os.tmpdir(), 'usage-steward-mft-'));
+});
+afterEach(async () => {
+  await fs.rm(TMP, { recursive: true, force: true });
+});
+
+async function writePkg(rel: string, pkgJson: object, opts: { usageYaml?: string } = {}): Promise<string> {
+  const dir = path.join(TMP, rel);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkgJson, null, 2));
+  if (opts.usageYaml !== undefined) {
+    await fs.writeFile(path.join(dir, 'usage.yaml'), opts.usageYaml);
+  }
+  return dir;
+}
+
+describe('loadDeployManifest', () => {
+  it('returns empty manifest when file is missing', async () => {
+    const out = await loadDeployManifest(path.join(TMP, 'no-such.yaml'));
+    expect(out.entries).toEqual([]);
+    expect(out.schemaVersion).toBe(1);
+  });
+  it('parses entries with extra metadata into the metadata field', async () => {
+    const p = path.join(TMP, 'deploy.yaml');
+    await fs.writeFile(p, `schema_version: 1\nentries:\n  - name: "@caia/foo"\n    path: packages/foo\n    solutionId: caia-2026-05-25-foo\n    owner: ea\n`);
+    const out = await loadDeployManifest(p);
+    expect(out.entries).toHaveLength(1);
+    expect(out.entries[0]?.name).toBe('@caia/foo');
+    expect(out.entries[0]?.solutionId).toBe('caia-2026-05-25-foo');
+    expect(out.entries[0]?.metadata?.owner).toBe('ea');
+  });
+});
+
+describe('loadPackageExpectation', () => {
+  it('returns null for a directory with no package.json + no usage.yaml', async () => {
+    const dir = path.join(TMP, 'empty');
+    await fs.mkdir(dir, { recursive: true });
+    expect(await loadPackageExpectation(dir)).toBeNull();
+  });
+  it('returns synthetic source when only a vanilla package.json exists', async () => {
+    const dir = await writePkg('foo', { name: '@caia/foo' });
+    const e = await loadPackageExpectation(dir);
+    expect(e?.source).toBe('synthetic');
+    expect(e?.packageName).toBe('@caia/foo');
+    expect(e?.expectedImports).toEqual([]);
+  });
+  it('parses package.json#caia.usage when present', async () => {
+    const dir = await writePkg('foo', {
+      name: '@caia/foo',
+      caia: { usage: { expectedImports: [{ consumer: 'apps/x/index.ts', symbol: 'Foo' }] } },
+    });
+    const e = await loadPackageExpectation(dir);
+    expect(e?.source).toBe('package.json');
+    expect(e?.expectedImports[0]?.symbol).toBe('Foo');
+  });
+  it('falls back to usage.yaml when package.json has no caia.usage stanza', async () => {
+    const dir = await writePkg('foo', { name: '@caia/foo' }, {
+      usageYaml: `packageName: "@caia/foo"\nexpectedExports:\n  - symbol: Hello\n`,
+    });
+    const e = await loadPackageExpectation(dir);
+    expect(e?.source).toBe('usage.yaml');
+    expect(e?.expectedExports[0]?.symbol).toBe('Hello');
+  });
+  it('package.json wins when both sources are present', async () => {
+    const dir = await writePkg('foo', {
+      name: '@caia/foo',
+      caia: { usage: { expectedExports: [{ symbol: 'FromPkgJson' }] } },
+    }, { usageYaml: `packageName: "@caia/foo"\nexpectedExports:\n  - symbol: FromYaml\n` });
+    const e = await loadPackageExpectation(dir);
+    expect(e?.source).toBe('package.json');
+    expect(e?.expectedExports[0]?.symbol).toBe('FromPkgJson');
+  });
+});
+
+describe('loadPackageExpectations', () => {
+  it('returns [] when packagesRoot does not exist', async () => {
+    expect(await loadPackageExpectations(path.join(TMP, 'nope'))).toEqual([]);
+  });
+  it('skips hidden directories', async () => {
+    await fs.mkdir(path.join(TMP, '.hidden'), { recursive: true });
+    await writePkg('visible', { name: '@caia/visible' });
+    const out = await loadPackageExpectations(TMP);
+    expect(out.map((e) => e.packageName)).toEqual(['@caia/visible']);
+  });
+});
+
+describe('joinManifestAndExpectations', () => {
+  it('returns every expectation when manifest is empty', () => {
+    const out = joinManifestAndExpectations(
+      { schemaVersion: 1, entries: [] },
+      [{ packageName: 'a', packageDir: '/a', source: 'synthetic', expectedImports: [], expectedExports: [] }],
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.entry).toBeNull();
+  });
+  it('inner-joins to manifest names when manifest is non-empty', () => {
+    const out = joinManifestAndExpectations(
+      { schemaVersion: 1, entries: [{ name: 'a' }] },
+      [
+        { packageName: 'a', packageDir: '/a', source: 'synthetic', expectedImports: [], expectedExports: [] },
+        { packageName: 'b', packageDir: '/b', source: 'synthetic', expectedImports: [], expectedExports: [] },
+      ],
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.expectations.packageName).toBe('a');
+  });
+});
+
+describe('declaredShippedNames', () => {
+  it('returns a set of names from manifest entries', () => {
+    const s = declaredShippedNames({ schemaVersion: 1, entries: [{ name: 'a' }, { name: 'b' }] });
+    expect(s.has('a')).toBe(true);
+    expect(s.has('c')).toBe(false);
+  });
+});

--- a/packages/usage-steward/tests/reporter.test.ts
+++ b/packages/usage-steward/tests/reporter.test.ts
@@ -1,0 +1,126 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildRunRow } from '../src/attestation.js';
+import { buildAttestationMatrix } from '../src/manifest-cross-check.js';
+import { reportToEventBus, reportToInbox, reportToStateMachine } from '../src/reporter.js';
+import type {
+  AttestationCell, CrossCheckObservation, ScannerKind, ScannerToolingState, UsageEvent,
+} from '../src/types.js';
+
+let TMP: string;
+beforeEach(async () => { TMP = await fs.mkdtemp(path.join(os.tmpdir(), 'us-rep-')); });
+afterEach(async () => { await fs.rm(TMP, { recursive: true, force: true }); });
+
+const presentAll: Record<ScannerKind, ScannerToolingState> = {
+  knip: 'present', depcheck: 'present', 'ts-prune': 'present', 'dependency-cruiser': 'present',
+};
+const failedKnip: Record<ScannerKind, ScannerToolingState> = {
+  ...presentAll, knip: 'failed',
+};
+const absentAll: Record<ScannerKind, ScannerToolingState> = {
+  knip: 'absent', depcheck: 'absent', 'ts-prune': 'absent', 'dependency-cruiser': 'absent',
+};
+
+function obs(kind: CrossCheckObservation['observationKind'], sev: 'error'|'warn'|'info' = 'error'): CrossCheckObservation {
+  return { packageName: 'a', observationKind: kind, severity: sev, detail: 'detail', supportingFindings: [] };
+}
+function cell(name: string, status: AttestationCell['status'] = 'green', extras: Partial<AttestationCell> = {}): AttestationCell {
+  return {
+    packageName: name, solutionId: null, status,
+    expectedImportCount: 0, satisfiedImportCount: 0,
+    expectedExportCount: 0, reachableExportCount: 0,
+    orphanCount: 0, unusedDepCount: 0, missingDepCount: 0, circularDepCount: 0,
+    scannerStates: presentAll, observations: [], ...extras,
+  };
+}
+function mkRow(cells: AttestationCell[], scannerStates = presentAll) {
+  const matrix = buildAttestationMatrix(cells);
+  const row = buildRunRow({
+    runId: 'r-1', startedAt: new Date('2026-05-25T00:00:00Z'),
+    finishedAt: new Date('2026-05-25T00:00:01Z'),
+    site: 'caia-mac', packagesRoot: '/r', scannerStates, matrix,
+  });
+  return { row, matrix };
+}
+
+describe('reportToInbox', () => {
+  it('no-ops when no red cells and no degraded scanners', async () => {
+    const { row, matrix } = mkRow([cell('a','green')]);
+    const p = path.join(TMP,'INBOX.md');
+    const r = await reportToInbox(p, row, matrix);
+    expect(r.appended).toBe(false);
+  });
+  it('writes a section under ## USAGE-STEWARD FAILURE for red cells', async () => {
+    const { row, matrix } = mkRow([cell('a','red', { observations: [obs('declared-import-missing','error')] })]);
+    const p = path.join(TMP,'INBOX.md');
+    await reportToInbox(p, row, matrix);
+    const text = await fs.readFile(p, 'utf8');
+    expect(text).toContain('## USAGE-STEWARD FAILURE');
+    expect(text).toContain('r-1');
+    expect(text).toContain('`a`');
+  });
+  it('is idempotent — re-running with same runId does not re-append', async () => {
+    const { row, matrix } = mkRow([cell('a','red', { observations: [obs('undeclared-orphan','error')] })]);
+    const p = path.join(TMP,'INBOX.md');
+    await reportToInbox(p, row, matrix);
+    const first = await fs.readFile(p, 'utf8');
+    await reportToInbox(p, row, matrix);
+    const second = await fs.readFile(p, 'utf8');
+    expect(second).toBe(first);
+  });
+  it('writes a degraded section when a scanner failed even with no reds', async () => {
+    const { row, matrix } = mkRow([cell('a','green')], failedKnip);
+    const p = path.join(TMP,'INBOX.md');
+    const r = await reportToInbox(p, row, matrix);
+    expect(r.appended).toBe(true);
+    const text = await fs.readFile(p, 'utf8');
+    expect(text).toContain('## USAGE-STEWARD DEGRADED');
+    expect(text).toContain('knip');
+  });
+});
+
+describe('reportToEventBus', () => {
+  it('always emits run.completed', () => {
+    const emitted: UsageEvent[] = [];
+    const { row, matrix } = mkRow([cell('a','green')]);
+    const r = reportToEventBus((e) => emitted.push(e), row, matrix);
+    expect(r.events[0]?.type).toBe('usage-steward.run.completed');
+    expect(emitted.length).toBe(r.events.length);
+  });
+  it('emits no-tooling.warning when every scanner is absent', () => {
+    const emitted: UsageEvent[] = [];
+    const { row, matrix } = mkRow([cell('a','no-tooling')], absentAll);
+    reportToEventBus((e) => emitted.push(e), row, matrix);
+    expect(emitted.some((e) => e.type === 'usage-steward.no-tooling.warning')).toBe(true);
+  });
+  it('emits scanner.degraded for each failed scanner', () => {
+    const emitted: UsageEvent[] = [];
+    const { row, matrix } = mkRow([cell('a','green')], failedKnip);
+    reportToEventBus((e) => emitted.push(e), row, matrix);
+    expect(emitted.filter((e) => e.type === 'usage-steward.scanner.degraded')).toHaveLength(1);
+  });
+  it('emits declared-import.missing for red cells with that observation', () => {
+    const emitted: UsageEvent[] = [];
+    const c = cell('a','red', { observations: [obs('declared-import-missing','error')] });
+    const { row, matrix } = mkRow([c]);
+    reportToEventBus((e) => emitted.push(e), row, matrix);
+    expect(emitted.some((e) => e.type === 'usage-steward.declared-import.missing')).toBe(true);
+  });
+  it('never throws if the emit callback throws', () => {
+    const { row, matrix } = mkRow([cell('a','green')]);
+    expect(() => reportToEventBus(() => { throw new Error('boom'); }, row, matrix)).not.toThrow();
+  });
+});
+
+describe('reportToStateMachine', () => {
+  it('emits a single run.completed event with summary counts in note', () => {
+    const emitted: UsageEvent[] = [];
+    const { row } = mkRow([cell('a','green'), cell('b','red')]);
+    reportToStateMachine((e) => emitted.push(e), row);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]?.type).toBe('usage-steward.run.completed');
+    expect(emitted[0]?.payload.note).toContain('green=');
+  });
+});

--- a/packages/usage-steward/tests/run.test.ts
+++ b/packages/usage-steward/tests/run.test.ts
@@ -1,0 +1,98 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { run } from '../src/run.js';
+import type { ScannerKind, ScannerResult, ScannerRunner, UsageEvent } from '../src/types.js';
+
+let TMP: string;
+beforeEach(async () => { TMP = await fs.mkdtemp(path.join(os.tmpdir(), 'us-run-')); });
+afterEach(async () => { await fs.rm(TMP, { recursive: true, force: true }); });
+
+async function fixtureMonorepo(): Promise<{ packagesRoot: string; runsJsonl: string; statusJson: string; attestJsonl: string; inbox: string }> {
+  const packagesRoot = path.join(TMP, 'packages');
+  await fs.mkdir(packagesRoot, { recursive: true });
+  // Two synthetic packages.
+  for (const name of ['alpha','beta']) {
+    const d = path.join(packagesRoot, name);
+    await fs.mkdir(d, { recursive: true });
+    await fs.writeFile(path.join(d, 'package.json'), JSON.stringify({ name: `@caia/${name}` }, null, 2));
+  }
+  return {
+    packagesRoot,
+    runsJsonl: path.join(TMP, 'runs.jsonl'),
+    statusJson: path.join(TMP, 'status.json'),
+    attestJsonl: path.join(TMP, 'attestations.jsonl'),
+    inbox: path.join(TMP, 'INBOX.md'),
+  };
+}
+
+const cleanRunner: ScannerRunner = async (scanner: ScannerKind): Promise<ScannerResult> => ({
+  scanner, tooling: 'present', findings: [], durationMs: 1,
+});
+
+const orphanRunner: ScannerRunner = async (scanner: ScannerKind): Promise<ScannerResult> => {
+  if (scanner === 'knip') {
+    return {
+      scanner, tooling: 'present', durationMs: 1,
+      findings: [{ scanner: 'knip', kind: 'unused-file', severity: 'error', packageName: null, filePath: '/x', symbol: null, dependency: null, message: 'orphan' }],
+    };
+  }
+  return { scanner, tooling: 'present', findings: [], durationMs: 1 };
+};
+
+describe('run', () => {
+  it('runs all-green when scanner runner emits no findings', async () => {
+    const f = await fixtureMonorepo();
+    const events: UsageEvent[] = [];
+    const r = await run({
+      packagesRoot: f.packagesRoot,
+      runsJsonlPath: f.runsJsonl, statusJsonPath: f.statusJson, attestationsJsonlPath: f.attestJsonl,
+      inboxPath: f.inbox, deployManifestPath: path.join(TMP, 'no-manifest.yaml'),
+      runScanner: cleanRunner, emit: (e) => events.push(e), quiet: true,
+    });
+    expect(r.run.summary.green).toBe(2);
+    expect(r.run.summary.red).toBe(0);
+    expect(r.newGreenIds.length).toBe(2);
+    expect(events.some((e) => e.type === 'usage-steward.run.completed')).toBe(true);
+  });
+
+  it('flags packages red when they are declared-shipped + scanner finds orphans', async () => {
+    const f = await fixtureMonorepo();
+    // Author a deploy manifest that lists both packages → orphan findings turn red.
+    const manifest = path.join(TMP, 'deploy.yaml');
+    await fs.writeFile(manifest, `schema_version: 1\nentries:\n  - name: "@caia/alpha"\n  - name: "@caia/beta"\n`);
+    const r = await run({
+      packagesRoot: f.packagesRoot,
+      runsJsonlPath: f.runsJsonl, statusJsonPath: f.statusJson, attestationsJsonlPath: f.attestJsonl,
+      inboxPath: f.inbox, deployManifestPath: manifest,
+      runScanner: orphanRunner, quiet: true,
+    });
+    expect(r.run.summary.red).toBeGreaterThan(0);
+    expect(r.inboxAppended).toBe(true);
+  });
+
+  it('dry-run skips all disk writes + bus emits', async () => {
+    const f = await fixtureMonorepo();
+    const r = await run({
+      packagesRoot: f.packagesRoot,
+      runsJsonlPath: f.runsJsonl, statusJsonPath: f.statusJson, attestationsJsonlPath: f.attestJsonl,
+      inboxPath: f.inbox, deployManifestPath: path.join(TMP, 'no.yaml'),
+      runScanner: cleanRunner, dryRun: true, quiet: true,
+    });
+    expect(r.eventsEmitted).toBe(0);
+    expect(await fs.access(f.runsJsonl).then(() => true, () => false)).toBe(false);
+  });
+
+  it('restricts to --only when set', async () => {
+    const f = await fixtureMonorepo();
+    const r = await run({
+      packagesRoot: f.packagesRoot,
+      runsJsonlPath: f.runsJsonl, statusJsonPath: f.statusJson, attestationsJsonlPath: f.attestJsonl,
+      inboxPath: f.inbox, deployManifestPath: path.join(TMP, 'no.yaml'),
+      runScanner: cleanRunner, only: ['@caia/alpha'], quiet: true,
+    });
+    expect(r.run.attestations).toHaveLength(1);
+    expect(r.run.attestations[0]?.packageName).toBe('@caia/alpha');
+  });
+});

--- a/packages/usage-steward/tests/scanners-depcheck.test.ts
+++ b/packages/usage-steward/tests/scanners-depcheck.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { parseDepcheckJson, runDepcheck } from '../src/scanners/depcheck.js';
+
+describe('parseDepcheckJson', () => {
+  it('returns [] for empty stdout', () => {
+    expect(parseDepcheckJson('', '/tmp/pkg')).toEqual([]);
+  });
+  it('returns [] when no JSON object found', () => {
+    expect(parseDepcheckJson('plain text', '/tmp/pkg')).toEqual([]);
+  });
+  it('parses unused dependencies as error severity', () => {
+    const json = JSON.stringify({ dependencies: ['lodash', 'jquery'] });
+    const out = parseDepcheckJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(2);
+    for (const f of out) {
+      expect(f.kind).toBe('unused-dependency');
+      expect(f.severity).toBe('error');
+    }
+  });
+  it('parses unused devDependencies as info severity', () => {
+    const json = JSON.stringify({ devDependencies: ['prettier'] });
+    const out = parseDepcheckJson(json, '/tmp/pkg');
+    expect(out[0]?.severity).toBe('info');
+  });
+  it('parses missing-in-package-json with absolute file paths', () => {
+    const json = JSON.stringify({ missing: { react: ['src/App.tsx'] } });
+    const out = parseDepcheckJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('missing-in-package-json');
+    expect(out[0]?.severity).toBe('error');
+    expect(out[0]?.filePath).toBe('/tmp/pkg/src/App.tsx');
+    expect(out[0]?.dependency).toBe('react');
+  });
+  it('parses invalidFiles as warn-level unresolved-import', () => {
+    const json = JSON.stringify({ invalidFiles: { 'src/bad.ts': 'SyntaxError' } });
+    const out = parseDepcheckJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.severity).toBe('warn');
+    expect(out[0]?.message).toContain('parser failed');
+  });
+  it('tolerates leading text before the JSON object', () => {
+    const json = 'noisy stderr line\n' + JSON.stringify({ dependencies: ['x'] });
+    expect(parseDepcheckJson(json, '/tmp/pkg')).toHaveLength(1);
+  });
+  it('throws on malformed JSON body', () => {
+    expect(() => parseDepcheckJson('{not-json}', '/tmp/pkg')).toThrow();
+  });
+  it('runDepcheck with stdoutOverride bypasses spawn', async () => {
+    const json = JSON.stringify({ dependencies: ['lodash'] });
+    const res = await runDepcheck('/tmp/pkg', { stdoutOverride: json });
+    expect(res.tooling).toBe('present');
+    expect(res.findings).toHaveLength(1);
+  });
+  it('runDepcheck with absent binary returns tooling=absent', async () => {
+    const res = await runDepcheck('/tmp/pkg', { binaryOverride: '/no/such/depcheck-xyz' });
+    expect(res.tooling).toBe('absent');
+  });
+});

--- a/packages/usage-steward/tests/scanners-dependency-cruiser.test.ts
+++ b/packages/usage-steward/tests/scanners-dependency-cruiser.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { parseDepCruiserJson, runDependencyCruiser } from '../src/scanners/dependency-cruiser.js';
+
+describe('parseDepCruiserJson', () => {
+  it('returns [] for empty stdout', () => {
+    expect(parseDepCruiserJson('', '/tmp/pkg')).toEqual([]);
+  });
+  it('parses orphan modules as warn-level orphan-module', () => {
+    const json = JSON.stringify({ modules: [{ source: 'src/orphan.ts', orphan: true }] });
+    const out = parseDepCruiserJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('orphan-module');
+    expect(out[0]?.severity).toBe('warn');
+    expect(out[0]?.filePath).toBe('/tmp/pkg/src/orphan.ts');
+  });
+  it('parses couldNotResolve as error-level unresolved-import', () => {
+    const json = JSON.stringify({
+      modules: [{ source: 'src/a.ts', dependencies: [{ module: '@missing/x', couldNotResolve: true }] }],
+    });
+    const out = parseDepCruiserJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('unresolved-import');
+    expect(out[0]?.severity).toBe('error');
+    expect(out[0]?.dependency).toBe('@missing/x');
+  });
+  it('parses no-circular violation from summary as circular-dependency', () => {
+    const json = JSON.stringify({
+      summary: { violations: [{ from: 'src/a.ts', to: 'src/b.ts', cycle: ['src/a.ts','src/b.ts','src/a.ts'], rule: { name: 'no-circular', severity: 'error' } }] },
+    });
+    const out = parseDepCruiserJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('circular-dependency');
+    expect(out[0]?.severity).toBe('error');
+    expect(out[0]?.message).toContain('circular');
+  });
+  it('parses dev-dep-in-prod rule', () => {
+    const json = JSON.stringify({
+      modules: [{ source: 'src/a.ts', dependencies: [{ module: 'vitest', rules: [{ name: 'no-dev-dep-in-prod', severity: 'error' }] }] }],
+    });
+    const out = parseDepCruiserJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('dev-dep-in-prod');
+    expect(out[0]?.severity).toBe('error');
+  });
+  it('runDependencyCruiser with stdoutOverride parses without spawning', async () => {
+    const json = JSON.stringify({ modules: [{ source: 'src/x.ts', orphan: true }] });
+    const res = await runDependencyCruiser('/tmp/pkg', { stdoutOverride: json });
+    expect(res.tooling).toBe('present');
+    expect(res.findings).toHaveLength(1);
+  });
+  it('runDependencyCruiser absent binary returns tooling=absent', async () => {
+    const res = await runDependencyCruiser('/tmp/pkg', { binaryOverride: '/no/such/depcruise-xyz' });
+    expect(res.tooling).toBe('absent');
+  });
+});

--- a/packages/usage-steward/tests/scanners-knip.test.ts
+++ b/packages/usage-steward/tests/scanners-knip.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { parseKnipJson, runKnip } from '../src/scanners/knip.js';
+
+describe('parseKnipJson', () => {
+  it('returns [] for empty stdout', () => {
+    expect(parseKnipJson('', '/tmp/pkg')).toEqual([]);
+  });
+
+  it('returns [] for stdout with no JSON object', () => {
+    expect(parseKnipJson('no json here', '/tmp/pkg')).toEqual([]);
+  });
+
+  it('parses unused files into unused-file findings (error severity)', () => {
+    const json = JSON.stringify({ files: ['src/orphan.ts'] });
+    const out = parseKnipJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.scanner).toBe('knip');
+    expect(out[0]?.kind).toBe('unused-file');
+    expect(out[0]?.severity).toBe('error');
+    expect(out[0]?.filePath).toBe('/tmp/pkg/src/orphan.ts');
+  });
+
+  it('parses unused exports', () => {
+    const json = JSON.stringify({
+      issues: [{ file: 'src/a.ts', exports: [{ name: 'Foo', line: 1, col: 1 }] }],
+    });
+    const out = parseKnipJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('unused-export');
+    expect(out[0]?.symbol).toBe('Foo');
+    expect(out[0]?.severity).toBe('error');
+  });
+
+  it('parses type exports as warn-level unused-export', () => {
+    const json = JSON.stringify({
+      issues: [{ file: 'src/a.ts', types: [{ name: 'T', line: 1, col: 1 }] }],
+    });
+    const out = parseKnipJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.severity).toBe('warn');
+  });
+
+  it('parses unused enum members + class members as warn-level', () => {
+    const json = JSON.stringify({
+      issues: [{
+        file: 'src/a.ts',
+        enumMembers: [{ name: 'E.A' }],
+        classMembers: [{ name: 'C.m' }],
+      }],
+    });
+    const out = parseKnipJson(json, '/tmp/pkg');
+    expect(out.map((f) => f.kind).sort()).toEqual(['unused-class-member', 'unused-enum-member']);
+    expect(out.every((f) => f.severity === 'warn')).toBe(true);
+  });
+
+  it('parses dependencies (error), devDependencies (info), and unlisted (error)', () => {
+    const json = JSON.stringify({
+      issues: [{
+        file: 'package.json',
+        dependencies: [{ name: 'lodash' }],
+        devDependencies: [{ name: 'eslint-plugin-x' }],
+        unlisted: [{ name: 'react' }],
+      }],
+    });
+    const out = parseKnipJson(json, '/tmp/pkg');
+    const byDep = Object.fromEntries(out.map((f) => [f.dependency, f]));
+    expect(byDep['lodash']?.kind).toBe('unused-dependency');
+    expect(byDep['lodash']?.severity).toBe('error');
+    expect(byDep['eslint-plugin-x']?.severity).toBe('info');
+    expect(byDep['react']?.kind).toBe('unlisted-dependency');
+    expect(byDep['react']?.severity).toBe('error');
+  });
+
+  it('parses unresolved imports', () => {
+    const json = JSON.stringify({
+      issues: [{ file: 'src/a.ts', unresolved: [{ name: '@missing/pkg' }] }],
+    });
+    const out = parseKnipJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('unresolved-import');
+    expect(out[0]?.dependency).toBe('@missing/pkg');
+  });
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseKnipJson('{not-json}', '/tmp/pkg')).toThrow();
+  });
+
+  it('tolerates leading header text before the JSON object', () => {
+    const json = 'log noise\n' + JSON.stringify({ files: ['src/x.ts'] });
+    const out = parseKnipJson(json, '/tmp/pkg');
+    expect(out).toHaveLength(1);
+  });
+
+  it('runKnip with stdoutOverride bypasses spawn and produces findings', async () => {
+    const json = JSON.stringify({ files: ['src/x.ts'] });
+    const res = await runKnip('/tmp/pkg', { stdoutOverride: json });
+    expect(res.tooling).toBe('present');
+    expect(res.scanner).toBe('knip');
+    expect(res.findings).toHaveLength(1);
+    expect(res.durationMs).toBe(0);
+  });
+
+  it('runKnip with absent binary returns tooling=absent and no findings', async () => {
+    const res = await runKnip('/tmp/pkg', { binaryOverride: '/definitely/not/here/knip-xyz' });
+    expect(res.tooling).toBe('absent');
+    expect(res.findings).toHaveLength(0);
+  });
+});

--- a/packages/usage-steward/tests/scanners-spawn.test.ts
+++ b/packages/usage-steward/tests/scanners-spawn.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { probeBinary, runBinary, tail } from '../src/scanners/spawn.js';
+
+describe('tail', () => {
+  it('returns full string when within cap', () => {
+    expect(tail('hello', 10)).toBe('hello');
+  });
+  it('truncates with marker when over cap', () => {
+    const out = tail('a'.repeat(100), 10);
+    expect(out).toMatch(/truncated 90 bytes/);
+    expect(out.endsWith('a'.repeat(10))).toBe(true);
+  });
+});
+
+describe('probeBinary', () => {
+  it('resolves a present binary (sh)', async () => {
+    const res = await probeBinary('sh');
+    expect(res.state).toBe('present');
+    expect(res.binaryPath).toBeDefined();
+  });
+  it('returns absent for a nonsense binary', async () => {
+    const res = await probeBinary('definitely-not-a-real-binary-xyz-12345');
+    expect(res.state).toBe('absent');
+  });
+});
+
+describe('runBinary', () => {
+  it('captures stdout from an echo', async () => {
+    const r = await runBinary('/bin/echo', ['hello'], { cwd: '/tmp' });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('hello');
+    expect(r.notFound).toBe(false);
+  });
+  it('returns notFound=true for a missing binary', async () => {
+    const r = await runBinary('/definitely/not/here/xyz', [], { cwd: '/tmp' });
+    expect(r.notFound).toBe(true);
+  });
+  it('honours a short timeout', async () => {
+    const r = await runBinary('/bin/sleep', ['5'], { cwd: '/tmp', timeoutMs: 100 });
+    expect(r.timedOut).toBe(true);
+  });
+});

--- a/packages/usage-steward/tests/scanners-ts-prune.test.ts
+++ b/packages/usage-steward/tests/scanners-ts-prune.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { parseTsPruneOutput, runTsPrune } from "../src/scanners/ts-prune.js";
+
+describe("parseTsPruneOutput", () => {
+  it("returns [] for empty stdout", () => {
+    expect(parseTsPruneOutput("", "/tmp/pkg")).toEqual([]);
+  });
+  it("parses a single unused-export line as error severity", () => {
+    const out = parseTsPruneOutput("src/foo.ts:12 - bar", "/tmp/pkg");
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe("unused-export");
+    expect(out[0]?.severity).toBe("error");
+    expect(out[0]?.symbol).toBe("bar");
+    expect(out[0]?.filePath).toBe("/tmp/pkg/src/foo.ts");
+  });
+  it("parses (used in module) suffix as warn severity", () => {
+    const out = parseTsPruneOutput("src/foo.ts:12 - bar (used in module)", "/tmp/pkg");
+    expect(out).toHaveLength(1);
+    expect(out[0]?.severity).toBe("warn");
+    expect(out[0]?.message).toContain("used only in its own module");
+  });
+  it("skips blank lines and (skip) markers", () => {
+    const stdout = "\n(skip) something\nsrc/x.ts:1 - X\n";
+    const out = parseTsPruneOutput(stdout, "/tmp/pkg");
+    expect(out).toHaveLength(1);
+    expect(out[0]?.symbol).toBe("X");
+  });
+  it("handles multiple lines", () => {
+    const stdout = "src/a.ts:1 - A\nsrc/b.ts:2 - B\nsrc/c.ts:3 - C";
+    expect(parseTsPruneOutput(stdout, "/tmp/pkg")).toHaveLength(3);
+  });
+  it("preserves absolute file paths if scanner already emitted them", () => {
+    const out = parseTsPruneOutput("/abs/src/foo.ts:12 - bar", "/tmp/pkg");
+    expect(out[0]?.filePath).toBe("/abs/src/foo.ts");
+  });
+  it("runTsPrune with stdoutOverride parses without spawning", async () => {
+    const res = await runTsPrune("/tmp/pkg", { stdoutOverride: "src/a.ts:1 - foo" });
+    expect(res.tooling).toBe("present");
+    expect(res.findings).toHaveLength(1);
+  });
+  it("runTsPrune absent binary returns tooling=absent", async () => {
+    const res = await runTsPrune("/tmp/pkg", { binaryOverride: "/no/such/ts-prune-xyz" });
+    expect(res.tooling).toBe("absent");
+  });
+});

--- a/packages/usage-steward/tsconfig.json
+++ b/packages/usage-steward/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/usage-steward/vitest.config.ts
+++ b/packages/usage-steward/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3674,6 +3674,34 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
+  packages/usage-steward:
+    dependencies:
+      yaml:
+        specifier: ^2.4.1
+        version: 2.8.3
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/ux-version-control-architect:
     dependencies:
       '@caia/architect-kit':


### PR DESCRIPTION
**Layer 1 of the Real Definition-of-Done framework** — static-analysis dead-code verifier.
Mirrors the `@caia/activation-steward` shape (PR #566). Spec: `research/real_definition_of_done_enforcement_2026.md` §4.1 + §12 Task A4.

## What ships
- **Four scanner wrappers** (`src/scanners/{knip,depcheck,ts-prune,dependency-cruiser}.ts`) — each normalises its native output to a uniform `UsageFinding` shape. Graceful degradation: missing binary → `no-tooling` cell + `usage-steward.scanner.degraded` event, never a false red.
- **Manifest + cross-check** (`src/manifest.ts`, `src/manifest-cross-check.ts`) — loads `deploy_manifest.yaml` + per-package `expectedImports` / `expectedExports`, joins against scanner findings, classifies each cell `green` / `yellow` / `red` / `no-tooling` / `unknown`.
- **Attestation persistence** (`src/attestation.ts`) — atomic JSONL audit (`~/.caia/usage-steward/runs.jsonl`), atomic status snapshot via tmp+rename, green-id attestation list (`attestations.jsonl`) that feeds the SPS 5th-AND completion gate.
- **Reporter** (`src/reporter.ts`) — INBOX append under `## USAGE-STEWARD FAILURE` (idempotent per `runId`), five event types, state-machine surface.
- **Orchestrator** (`src/run.ts`) with injectable scanner runner for tests.
- **Bin + launchd + register script** — `bin/usage-steward-run` (exit-0 on red), `launchd/com.caia.usage-steward-hourly.plist` (hourly), `scripts/register-usage-steward.sh` (idempotent install).
- **SQL migration** (`migrations/001_usage_steward_attestations.sql`) — three tables + a `usage_attestations_latest` view, every `CREATE` guarded by `IF NOT EXISTS`.

## Verification done locally
- `pnpm --filter @caia/usage-steward build` — green (strict + `exactOptionalPropertyTypes` + `noUncheckedIndexedAccess`).
- `pnpm --filter @caia/usage-steward typecheck` — green.
- `pnpm --filter @caia/usage-steward test` — **93 / 93 passing**.
- Integration test runs the full pipeline against the real `~/Documents/projects/caia/packages` tree and surfaces **22 ship-and-forget candidates out of 120 scanned packages** (the 2026-05-20 stack-teardown lesson predicted ~30; the heuristic underestimates because it only flags zero-dependency packages — the real four-tool scan will surface more).

## What is **NOT** in this PR
- K3s systemd timer twin (JSONL append-only semantics already make dual-write safe).
- Customer-site repo scanning (already configurable via `--packages-root`).
- `vulture` (Python) + `libyear` integrations (spec §4.1 "future cost-zero additions").
- OPA policy + EA Agent gating (spec §12 task A11, depends on Layer 1 + 2 + outcome stewards all being live).

## EA Architect review

A formal plan document is shipped at `packages/usage-steward/PLAN.md` for `@caia/ea-architect.submitPlan` consumption. The agent's `submitPlan` API requires an LLM-backed `CriticAdapter` to produce a meaningful review pass — that's an operator-run step, not an automated one this PR can self-trigger.

## Reversibility

Reversible. The launchd plist is opt-in (operator runs `scripts/register-usage-steward.sh`). Deletion of `~/.caia/usage-steward/` and the optional `caia_meta.usage_*` Postgres tables has no consumer impact — nothing else in the workspace imports this package yet (the lifecycle-conductor + OPA gate that will consume it are spec §12 follow-ups).

## Admin-merge

This PR is intentionally NOT auto-admin-merged. Per the spec's whole premise — mechanical guardrails against false claims of completion — please review the code, the 22 candidates surfaced against the live monorepo (`pnpm --filter @caia/usage-steward test` and inspect `tests/integration-real-monorepo.test.ts`), then admin-merge when you're satisfied.
