### PR TITLE
feat(@caia/knowledge-graph-dispatch-hook): Layer 3 pre-dispatch context injection

### DIFF
--- a/packages/knowledge-graph-dispatch-hook/README.md
+++ b/packages/knowledge-graph-dispatch-hook/README.md
@@ -1,0 +1,142 @@
+# @caia/knowledge-graph-dispatch-hook
+
+**Layer 3** of the AI-First Continuous-Discipline framework
+(`research/ai_first_continuous_discipline_2026.md`).
+
+Activates the already-built but underused Architecture Knowledge Graph
+(`@chiefaia/architecture-registry` — nomic-embed-text + sqlite-vec) for
+**pre-dispatch context injection**. Every fresh subagent dispatch gets the
+most-relevant ADRs / principles / lessons / feedback memories
+auto-prepended to its brief based on semantic similarity to the task
+topic.
+
+## Where it sits
+
+Mirrors the higher-order dispatch-wrapper pattern in `@caia/policy-linter`
+(Layer 1, validating) and `@chiefaia/llm-cache`'s `withCache` (HOF
+wrapper around route-style functions). Together they compose the
+preflight in spec order:
+
+```
+brief → Layer 3 (this)  → Layer 2 (EA Architect)  → Layer 1 (policy-linter) → spawn
+        mutate, enrich    mutate, rewrite plan      validate, refuse
+```
+
+## Quick start
+
+```ts
+import { createKgDispatchHook } from '@caia/knowledge-graph-dispatch-hook';
+import { createEventBus } from '@chiefaia/events';
+import {
+  bootstrapVectorTables,
+  OllamaEmbeddingClient,
+} from '@chiefaia/architecture-registry';
+import Database from 'better-sqlite3';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const db = new Database(join(homedir(), '.caia/akg.sqlite'));
+bootstrapVectorTables(db);
+const embedder = new OllamaEmbeddingClient({ model: 'nomic-embed-text' });
+const eventBus = createEventBus();
+
+const hook = createKgDispatchHook({ db, embedder, eventBus });
+
+const wrappedDispatch = hook(async (brief) => {
+  // brief.briefMd now arrives with the "Architecture Context" preamble
+  // prepended. Your inner dispatch sees the enriched brief.
+  return await myInnerDispatch(brief);
+});
+
+const result = await wrappedDispatch({
+  callerAgentId: 'researcher-001',
+  briefMd: 'Investigate event-sourcing options for the leaderboard...',
+  intent: 'research',
+});
+```
+
+## The preamble shape (verbatim from spec lines 651-672)
+
+```markdown
+## Architecture Context (auto-injected by AKG)
+
+The following decisions, principles, and lessons may be relevant to this
+task. Read them before proceeding. If any seem to constrain the requested
+action, surface that to the caller via your output.
+
+### ADRs
+- [ADR-011] Event-first state with database as projection
+- [ADR-028] Architecture Knowledge Graph via sqlite-vec + nomic-embed
+- [ADR-038] EA Reviewer vs EA Architect scope
+
+### Principles
+- [P3] No timelines, ever
+
+### Lessons
+- [L01] Pixel-perfect calibration (85%/95% diff thresholds)
+
+### Recent feedback memories
+- [feedback-continuous-discipline-problem] (2026-05-24)
+```
+
+Empty sections are omitted. When every section is empty, the preamble is
+the empty string and the original brief passes through unchanged.
+
+## API
+
+### `injectContext(brief, deps, opts?) → EnrichedBrief`
+
+Pure function. Returns `{ brief, preamble, retrieved, stats,
+callerAgentId }`. Never throws — failures fall through to a no-op with
+`stats.fallbackUsed` set to one of `'disabled' | 'embedder-down' |
+'sparse-only' | 'empty-kg' | 'none'`.
+
+### `createKgDispatchHook(deps, opts?) → withKgContext`
+
+Factory returning the HOF wrapper. Bind the deps once, wrap many
+dispatch fns.
+
+### `withKgContext(deps, inner, opts?) → wrappedDispatch`
+
+One-shot convenience for callers that don't need a factory handle.
+
+### Knobs (`KgInjectionOpts`)
+
+- `topK` — total hits surfaced (default sum of kindMix = 6)
+- `threshold` — sqlite-vec cosine floor (default 0.6, spec line 676)
+- `kindMix` — per-kind slot allocation; underflow rolls forward
+  (default `{adr:3, principle:1, lesson:1, feedback:1, other:0}`)
+- `disabled` — when true the hook is a no-op (default false)
+- `sparseOnly` / `denseOnly` — pin one retriever
+- `queryOverride` — override the embedding-query text
+- `briefSummaryMaxChars` — cap for auto-derived query string (default 1200)
+- `preambleOnly` — return preamble but DON'T mutate `brief`
+
+## Failure modes
+
+Per the spec (lines 282-285), this package degrades to a no-op
+gracefully — never throws, never blocks the wrapped dispatch.
+
+- **Empty AKG** (T06 not yet run): `fallbackUsed: 'empty-kg'`. Preamble
+  is empty. Brief passes through.
+- **Ollama down / model not pulled**: caught at the embedder layer →
+  retries sparse-only. `fallbackUsed: 'sparse-only'`.
+- **DB error / corrupt index**: caught at the hook layer.
+  `fallbackUsed: 'embedder-down'`. Brief passes through unchanged.
+- **Caller-requested disable**: `opts.disabled === true` →
+  `fallbackUsed: 'disabled'`. Instant return.
+
+## Cost discipline
+
+Zero outbound network. All retrieval + embedding is local
+(Ollama + sqlite). Aligns with P1 (subscription-only) and P14
+(no-paid-API per ADR-001).
+
+## Forward compatibility note (spec task T06)
+
+The AKG schema today exposes `ArtifactKind = 'adr' | ...` but not yet
+`'principle' | 'lesson' | 'feedback'`. Until T06 lands first-class
+kinds, principle/lesson/feedback rows are indexed as `kind='adr'` with
+a discriminating `tags[]` entry — this package recognises both shapes
+in `embedder.normaliseHit()` so the preamble renders correctly today
+AND after T06 with no code change.

--- a/packages/knowledge-graph-dispatch-hook/package.json
+++ b/packages/knowledge-graph-dispatch-hook/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@caia/knowledge-graph-dispatch-hook",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Layer 3 of the AI-First Continuous-Discipline framework. Pre-dispatch context injection: activates the Architecture Knowledge Graph (@chiefaia/architecture-registry, nomic-embed-text + sqlite-vec) so every fresh subagent dispatch receives relevant ADRs / principles / lessons / feedback memories auto-prepended to its brief based on semantic similarity to the task topic. Mirrors @caia/policy-linter's dispatch-hook pattern (HOF wrapper around any dispatch fn).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./hook": {
+      "import": "./dist/hook.js",
+      "types": "./dist/hook.d.ts"
+    },
+    "./embedder": {
+      "import": "./dist/embedder.js",
+      "types": "./dist/embedder.d.ts"
+    },
+    "./context-builder": {
+      "import": "./dist/context-builder.js",
+      "types": "./dist/context-builder.d.ts"
+    },
+    "./api": {
+      "import": "./dist/api.js",
+      "types": "./dist/api.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "echo \"(lint via root)\""
+  },
+  "dependencies": {
+    "@chiefaia/architecture-registry": "workspace:*",
+    "@chiefaia/events": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20",
+    "better-sqlite3": "^12.6.2",
+    "sqlite-vec": "^0.1.9",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  }
+}

--- a/packages/knowledge-graph-dispatch-hook/src/api.ts
+++ b/packages/knowledge-graph-dispatch-hook/src/api.ts
@@ -1,0 +1,196 @@
+/**
+ * @caia/knowledge-graph-dispatch-hook — `injectContext` core API.
+ *
+ * Pure composition of `retrieveContext` (embedder.ts) + `buildPreamble`
+ * (context-builder.ts) into a single `injectContext(brief, deps, opts?)`
+ * call returning an `EnrichedBrief`.
+ *
+ * Failure semantics:
+ *   - If `opts.disabled === true`: instant no-op. Returns original brief
+ *     with `fallbackUsed: 'disabled'`.
+ *   - If the AKG returns zero hits: returns original brief with
+ *     `fallbackUsed: 'empty-kg'`. Does NOT throw.
+ *   - If the embedder throws something other than EmbedderUnavailable
+ *     (which is caught at the embedder layer): caught here and treated
+ *     as `fallbackUsed: 'embedder-down'`. Returns original brief.
+ *   - If `retrieveContext` falls back to sparse-only:
+ *     `fallbackUsed: 'sparse-only'`. The retrieved artifacts are still
+ *     used.
+ *
+ * The hook layer (hook.ts) wraps this with HOF + event emission.
+ * Callers that want a synchronous pipeline can also call this directly.
+ */
+
+import type Database from 'better-sqlite3';
+import type { EmbeddingClient } from '@chiefaia/architecture-registry';
+
+import {
+  retrieveContext,
+  mergeKindMix,
+  sumMix,
+  type RetrieveOpts,
+} from './embedder.js';
+import { buildPreamble, prependPreamble } from './context-builder.js';
+import type {
+  DispatchBrief,
+  EnrichedBrief,
+  KgInjectionOpts,
+  KgInjectionStats,
+  RetrievedArtifact,
+} from './types.js';
+
+export interface InjectContextDeps {
+  db: Database.Database;
+  embedder: EmbeddingClient;
+}
+
+const DEFAULT_BRIEF_SUMMARY_MAX_CHARS = 1200;
+
+/**
+ * Inject AKG-derived context into a dispatch brief.
+ *
+ * Pure-ish function: only side effects are the DB read + embedder call
+ * inside `retrieveContext`. Never throws (except for genuinely
+ * unrecoverable programmer errors — bad arg types, etc.).
+ */
+export async function injectContext(
+  brief: DispatchBrief,
+  deps: InjectContextDeps,
+  opts: KgInjectionOpts = {},
+): Promise<EnrichedBrief> {
+  const t0 = Date.now();
+  const mix = mergeKindMix(opts.kindMix);
+  const topK = opts.topK ?? sumMix(mix);
+  const threshold = opts.threshold ?? 0.6;
+
+  // Short-circuit: disabled.
+  if (opts.disabled === true) {
+    return noopResult(brief, {
+      topK,
+      threshold,
+      embedderTokens: 0,
+      latencyMs: Date.now() - t0,
+      retrievedCount: 0,
+      sourcesByKind: emptySources(),
+      fallbackUsed: 'disabled',
+    });
+  }
+
+  const query = deriveQuery(brief, opts);
+  if (query.trim().length === 0) {
+    return noopResult(brief, {
+      topK,
+      threshold,
+      embedderTokens: 0,
+      latencyMs: Date.now() - t0,
+      retrievedCount: 0,
+      sourcesByKind: emptySources(),
+      fallbackUsed: 'empty-kg',
+    });
+  }
+
+  const retrieveOpts: RetrieveOpts = {
+    topK,
+    threshold,
+    kindMix: opts.kindMix ?? mix,
+  };
+  if (opts.sparseOnly) retrieveOpts.sparseOnly = true;
+  if (opts.denseOnly) retrieveOpts.denseOnly = true;
+  if (brief.targetRepos && brief.targetRepos.length > 0) {
+    retrieveOpts.projects = brief.targetRepos;
+  }
+
+  let artifacts: ReadonlyArray<RetrievedArtifact> = [];
+  let embedderTokens = 0;
+  let fallbackUsedSparseOnly = false;
+  let embedderDown = false;
+
+  try {
+    const result = await retrieveContext(query, deps, retrieveOpts);
+    artifacts = result.artifacts;
+    embedderTokens = result.embedderTokens;
+    fallbackUsedSparseOnly = result.fallbackUsedSparseOnly;
+  } catch (err) {
+    // EmbedderUnavailable is already caught inside retrieveContext.
+    // Anything else here is a DB error, malformed AKG, etc. — never
+    // block the dispatch.
+    embedderDown = true;
+    void err;
+  }
+
+  const preamble = buildPreamble(artifacts);
+  const finalBrief = opts.preambleOnly
+    ? brief.briefMd
+    : prependPreamble(brief.briefMd, preamble);
+
+  const sourcesByKind = countByKind(artifacts);
+  const stats: KgInjectionStats = {
+    topK,
+    threshold,
+    embedderTokens,
+    latencyMs: Date.now() - t0,
+    retrievedCount: artifacts.length,
+    sourcesByKind,
+    fallbackUsed: embedderDown
+      ? 'embedder-down'
+      : artifacts.length === 0
+        ? 'empty-kg'
+        : fallbackUsedSparseOnly
+          ? 'sparse-only'
+          : 'none',
+  };
+
+  return {
+    brief: finalBrief,
+    preamble,
+    retrieved: artifacts,
+    stats,
+    callerAgentId: brief.callerAgentId,
+  };
+}
+
+/**
+ * Build a query string for the embedder from a `DispatchBrief`.
+ *
+ * Preference order:
+ *   1. `opts.queryOverride` — caller knows best.
+ *   2. `brief.briefSummary` — caller pre-summarised.
+ *   3. Head of `brief.briefMd` capped at `briefSummaryMaxChars` (default
+ *      1200) — good enough; the embedder normalises anyway.
+ */
+export function deriveQuery(
+  brief: DispatchBrief,
+  opts: KgInjectionOpts = {},
+): string {
+  if (opts.queryOverride !== undefined) return opts.queryOverride;
+  if (brief.briefSummary !== undefined) return brief.briefSummary;
+  const cap = opts.briefSummaryMaxChars ?? DEFAULT_BRIEF_SUMMARY_MAX_CHARS;
+  return brief.briefMd.slice(0, cap);
+}
+
+function noopResult(
+  brief: DispatchBrief,
+  stats: KgInjectionStats,
+): EnrichedBrief {
+  return {
+    brief: brief.briefMd,
+    preamble: '',
+    retrieved: [],
+    stats,
+    callerAgentId: brief.callerAgentId,
+  };
+}
+
+function emptySources(): KgInjectionStats['sourcesByKind'] {
+  return { adr: 0, principle: 0, lesson: 0, feedback: 0, other: 0 };
+}
+
+function countByKind(
+  artifacts: ReadonlyArray<RetrievedArtifact>,
+): KgInjectionStats['sourcesByKind'] {
+  const acc = emptySources();
+  for (const a of artifacts) {
+    acc[a.kind] += 1;
+  }
+  return acc;
+}

--- a/packages/knowledge-graph-dispatch-hook/src/context-builder.ts
+++ b/packages/knowledge-graph-dispatch-hook/src/context-builder.ts
@@ -1,0 +1,170 @@
+/**
+ * @caia/knowledge-graph-dispatch-hook — markdown preamble renderer.
+ *
+ * Renders the "Architecture Context (auto-injected by AKG)" markdown
+ * block defined in the Layer 3 spec
+ * (`research/ai_first_continuous_discipline_2026.md`, lines 651-672).
+ *
+ * Shape (verbatim from spec):
+ *
+ *   ## Architecture Context (auto-injected by AKG)
+ *
+ *   The following decisions, principles, and lessons may be relevant to
+ *   this task. Read them before proceeding. If any seem to constrain the
+ *   requested action, surface that to the caller via your output.
+ *
+ *   ### ADRs
+ *   - [ADR-011] Event-first state with database as projection
+ *   …
+ *   ### Principles
+ *   - [P3] No timelines, ever
+ *   …
+ *   ### Lessons
+ *   - [L01] Pixel-perfect calibration (85%/95% diff thresholds)
+ *   …
+ *   ### Recent feedback memories
+ *   - [feedback-continuous-discipline-problem] (2026-05-24)
+ *
+ * Rules:
+ *   - Empty sections are OMITTED (no headers for empty kinds).
+ *   - When ALL sections are empty, the whole preamble is the empty
+ *     string — the api layer skips prepending in that case.
+ *   - Order is fixed: ADRs → Principles → Lessons → Recent feedback
+ *     memories → Other. Within a section, rank order from the embedder
+ *     is preserved.
+ *   - Titles are trimmed and markdown-character-escaped lightly
+ *     (closing brackets only, to keep the `[ID] Title` shape parseable).
+ *   - Feedback memories include a `(YYYY-MM-DD)` suffix when a date is
+ *     known; omitted otherwise.
+ *
+ * Pure: no I/O, no deps beyond the types module.
+ */
+
+import type { RetrievedArtifact } from './types.js';
+
+export const PREAMBLE_HEADER = '## Architecture Context (auto-injected by AKG)';
+
+export const PREAMBLE_INTRO = [
+  'The following decisions, principles, and lessons may be relevant to',
+  'this task. Read them before proceeding. If any seem to constrain the',
+  'requested action, surface that to the caller via your output.',
+].join(' ');
+
+const SECTION_ORDER: ReadonlyArray<{
+  kind: RetrievedArtifact['kind'];
+  heading: string;
+}> = [
+  { kind: 'adr', heading: '### ADRs' },
+  { kind: 'principle', heading: '### Principles' },
+  { kind: 'lesson', heading: '### Lessons' },
+  { kind: 'feedback', heading: '### Recent feedback memories' },
+  { kind: 'other', heading: '### Other' },
+];
+
+/**
+ * Build the preamble markdown block from a list of retrieved artifacts.
+ *
+ * @param artifacts Ranked artifact list (from embedder.retrieveContext).
+ * @returns Markdown string. Empty string when `artifacts` is empty or
+ *          contains only empty/invalid entries.
+ */
+export function buildPreamble(
+  artifacts: ReadonlyArray<RetrievedArtifact>,
+): string {
+  if (artifacts.length === 0) return '';
+
+  const grouped = groupByKind(artifacts);
+  const sections: string[] = [];
+
+  for (const { kind, heading } of SECTION_ORDER) {
+    const items = grouped[kind];
+    if (!items || items.length === 0) continue;
+    const lines = items.map((a) => renderArtifactLine(a, kind));
+    sections.push(`${heading}\n${lines.join('\n')}`);
+  }
+
+  if (sections.length === 0) return '';
+
+  return [
+    PREAMBLE_HEADER,
+    '',
+    PREAMBLE_INTRO,
+    '',
+    sections.join('\n\n'),
+  ].join('\n');
+}
+
+/**
+ * Prepend the preamble to a brief, with two trailing newlines so the
+ * original brief's heading rendering is preserved. If `preamble` is
+ * empty, returns `brief` unchanged.
+ */
+export function prependPreamble(brief: string, preamble: string): string {
+  if (preamble.length === 0) return brief;
+  return `${preamble}\n\n${brief}`;
+}
+
+/**
+ * Group artifacts by kind, preserving rank order within each kind.
+ */
+export function groupByKind(
+  artifacts: ReadonlyArray<RetrievedArtifact>,
+): Record<RetrievedArtifact['kind'], RetrievedArtifact[]> {
+  const acc: Record<RetrievedArtifact['kind'], RetrievedArtifact[]> = {
+    adr: [],
+    principle: [],
+    lesson: [],
+    feedback: [],
+    other: [],
+  };
+  for (const a of artifacts) {
+    acc[a.kind].push(a);
+  }
+  return acc;
+}
+
+/**
+ * Render one bullet for the preamble.
+ *
+ *   ADR-style:        - [ADR-011] Event-first state with database as projection
+ *   Principle-style:  - [P3] No timelines, ever
+ *   Lesson-style:     - [L01] Pixel-perfect calibration (85%/95% diff thresholds)
+ *   Feedback-style:   - [feedback-continuous-discipline-problem] (2026-05-24)
+ *   Other-style:      - [<id>] <title>
+ *
+ * For feedback memories specifically: the title is dropped when the id
+ * already encodes intent ("feedback-no-timelines" reads cleanly on its
+ * own) and a date suffix is appended when available.
+ */
+export function renderArtifactLine(
+  artifact: RetrievedArtifact,
+  kind: RetrievedArtifact['kind'],
+): string {
+  const id = sanitiseId(artifact.id);
+  if (kind === 'feedback') {
+    const datePart = artifact.date ? ` (${artifact.date})` : '';
+    return `- [${id}]${datePart}`;
+  }
+  const title = sanitiseTitle(artifact.title);
+  return title.length > 0 ? `- [${id}] ${title}` : `- [${id}]`;
+}
+
+/**
+ * Strip closing brackets from the id so the [id] shape stays parseable.
+ * Caps at 80 chars.
+ */
+function sanitiseId(id: string): string {
+  const cleaned = id.replace(/[\[\]]/g, '').trim();
+  return cleaned.length > 80 ? cleaned.slice(0, 80) : cleaned;
+}
+
+/**
+ * Strip line breaks, collapse whitespace, trim, cap at 200 chars.
+ * Closing brackets in titles are escaped with a backslash so consumers
+ * eyeballing the markdown still see them.
+ */
+function sanitiseTitle(title: string): string {
+  const collapsed = title.replace(/\s+/g, ' ').trim();
+  const escaped = collapsed.replace(/\]/g, '\\]');
+  return escaped.length > 200 ? `${escaped.slice(0, 197).trim()}…` : escaped;
+}

--- a/packages/knowledge-graph-dispatch-hook/src/embedder.ts
+++ b/packages/knowledge-graph-dispatch-hook/src/embedder.ts
@@ -1,0 +1,372 @@
+/**
+ * @caia/knowledge-graph-dispatch-hook — KG semantic search wrapper.
+ *
+ * Thin, opinionated adapter over `@chiefaia/architecture-registry`'s
+ * `archSearch`. Adds three things on top of the raw archSearch:
+ *
+ *   1. **Kind normalisation** — collapses the AKG's 12 ArtifactKinds into
+ *      the 5 logical buckets the preamble understands: adr / principle /
+ *      lesson / feedback / other. Principle/lesson/feedback are
+ *      recognised either by `kind=adr` + tag (until the AKG schema gains
+ *      first-class kinds in spec task T06) OR by future first-class
+ *      kinds when they ship. Forward-compatible.
+ *
+ *   2. **Slot-rolling kind mix** — caller asks for a {adr:3, principle:1,
+ *      lesson:1, feedback:1} mix; if a kind underflows, the slot rolls
+ *      into the next kind in priority order so total `topK` is
+ *      preserved. Avoids holes in the preamble.
+ *
+ *   3. **Fallback path** — if the embedder is unavailable (Ollama down,
+ *      model not pulled), retries as sparse-only and annotates
+ *      `fallbackUsed: 'sparse-only'` on the result. Spec line 282-283:
+ *      "Embedder unavailable: caught + falls through to sparse-only".
+ *
+ * The DB handle + embedder are owned by the caller. This module is pure
+ * and easily testable; the integration test passes a real
+ * better-sqlite3 + StubEmbeddingClient pair.
+ */
+
+import {
+  archSearch,
+  type ArchSearchHit,
+  type ArchSearchOpts,
+  type ArchSearchResult,
+  type ArtifactKind,
+  EmbedderUnavailableError,
+  type EmbeddingClient,
+} from '@chiefaia/architecture-registry';
+import type Database from 'better-sqlite3';
+
+import type {
+  KindMix,
+  RetrievedArtifact,
+} from './types.js';
+
+/**
+ * The kind-normalisation table. Keys are AKG `ArtifactKind` values;
+ * values are the bucket the preamble lives in.
+ *
+ * The AKG today exposes `'adr'` but not `'principle'|'lesson'|'feedback'`.
+ * Until spec task T06 adds them, principle/lesson/feedback rows are
+ * stored as `kind='adr'` with a discriminating tag in `tags[]`. We honour
+ * both: a hit whose `kind` lookup returns 'other' is reclassified into
+ * 'principle'|'lesson'|'feedback' if its tags include the matching tag.
+ *
+ * Note: the AKG ArtifactKind enum may add new kinds in future PRs. Any
+ * unknown kind falls through to 'other' — never throws.
+ */
+const KIND_BUCKETS: Readonly<Record<ArtifactKind | string, RetrievedArtifact['kind']>> = {
+  adr: 'adr',
+  // First-class kinds promoted by T06 — declared here as strings so a
+  // future ArtifactKind extension is recognised without touching this file.
+  principle: 'principle',
+  lesson: 'lesson',
+  feedback: 'feedback',
+};
+
+const TAG_BUCKETS: ReadonlyArray<readonly [string, RetrievedArtifact['kind']]> = [
+  ['feedback', 'feedback'],
+  ['lesson', 'lesson'],
+  ['principle', 'principle'],
+];
+
+/**
+ * Default per-kind mix. Spec line 676:
+ *   "result mix = 3 ADRs + 1 principle + 1 lesson by default"
+ * We also reserve a feedback slot (Layer 3 preamble has "Recent
+ * feedback memories" as the fourth section, line 670). topK defaults to
+ * 6 to fit the mix; callers passing topK=5 (spec default) drop the
+ * feedback slot.
+ */
+export const DEFAULT_KIND_MIX: Required<KindMix> = Object.freeze({
+  adr: 3,
+  principle: 1,
+  lesson: 1,
+  feedback: 1,
+  other: 0,
+});
+
+/** Priority order used by the slot-rolling allocator. */
+const KIND_PRIORITY: ReadonlyArray<RetrievedArtifact['kind']> = [
+  'adr',
+  'principle',
+  'lesson',
+  'feedback',
+  'other',
+];
+
+/**
+ * Inputs to `retrieveContext`. The caller owns the DB and embedder
+ * lifecycle.
+ */
+export interface RetrieveDeps {
+  db: Database.Database;
+  embedder: EmbeddingClient;
+}
+
+export interface RetrieveOpts {
+  /** Total cap across all kinds. Default 6 (sum of DEFAULT_KIND_MIX). */
+  topK?: number;
+  /** Cosine threshold floor. Default 0.6. */
+  threshold?: number;
+  /** Per-kind slot allocation; underflow rolls forward. */
+  kindMix?: KindMix;
+  /** Force one retriever side. */
+  sparseOnly?: boolean;
+  denseOnly?: boolean;
+  /** Optional project / domain filters passed through to archSearch. */
+  projects?: ReadonlyArray<string>;
+  techSubDomains?: ReadonlyArray<string>;
+}
+
+export interface RetrieveResult {
+  artifacts: RetrievedArtifact[];
+  /** Raw archSearch result for debugging / telemetry. */
+  raw: ArchSearchResult;
+  /** True if we fell back to sparse-only because the embedder was unavailable. */
+  fallbackUsedSparseOnly: boolean;
+  /** Total tokens spent on embedding (0 in sparse-only fallback). */
+  embedderTokens: number;
+  latencyMs: number;
+}
+
+/**
+ * Run an AKG semantic search for `query`, normalise + allocate hits per
+ * the kind mix, and return the picked artifacts. Pure-ish: only side
+ * effects are the DB read + embedder call.
+ */
+export async function retrieveContext(
+  query: string,
+  deps: RetrieveDeps,
+  opts: RetrieveOpts = {},
+): Promise<RetrieveResult> {
+  const t0 = Date.now();
+  const mix = mergeKindMix(opts.kindMix);
+  const topK = opts.topK ?? sumMix(mix);
+  const threshold = opts.threshold ?? 0.6;
+
+  // Ask the AKG for plenty of headroom so the allocator has options.
+  // 3x the mix's largest bucket is a comfortable floor.
+  const innerK = Math.max(topK * 3, 12);
+
+  const searchOpts: ArchSearchOpts = {
+    topK: innerK,
+    minScore: threshold,
+  };
+  if (opts.sparseOnly) searchOpts.sparseOnly = true;
+  if (opts.denseOnly) searchOpts.denseOnly = true;
+  if (opts.projects && opts.projects.length > 0) {
+    searchOpts.projects = opts.projects;
+  }
+  if (opts.techSubDomains && opts.techSubDomains.length > 0) {
+    searchOpts.techSubDomains = opts.techSubDomains;
+  }
+
+  let raw: ArchSearchResult;
+  let fallbackUsedSparseOnly = false;
+
+  try {
+    raw = await archSearch(query, searchOpts, deps);
+  } catch (err) {
+    if (err instanceof EmbedderUnavailableError && !searchOpts.sparseOnly) {
+      // Retry as sparse-only.
+      fallbackUsedSparseOnly = true;
+      raw = await archSearch(
+        query,
+        { ...searchOpts, sparseOnly: true, denseOnly: false },
+        deps,
+      );
+    } else {
+      throw err;
+    }
+  }
+
+  const allocated = allocateByKindMix(raw.hits, mix, topK);
+
+  return {
+    artifacts: allocated,
+    raw,
+    fallbackUsedSparseOnly,
+    embedderTokens: raw.embedderTokens,
+    latencyMs: Date.now() - t0,
+  };
+}
+
+/**
+ * Merge a caller-supplied mix with the defaults; unspecified buckets
+ * inherit `DEFAULT_KIND_MIX`. Caller can zero out a bucket by passing
+ * `{ feedback: 0 }`.
+ */
+export function mergeKindMix(input?: KindMix): Required<KindMix> {
+  return {
+    adr: input?.adr ?? DEFAULT_KIND_MIX.adr,
+    principle: input?.principle ?? DEFAULT_KIND_MIX.principle,
+    lesson: input?.lesson ?? DEFAULT_KIND_MIX.lesson,
+    feedback: input?.feedback ?? DEFAULT_KIND_MIX.feedback,
+    other: input?.other ?? DEFAULT_KIND_MIX.other,
+  };
+}
+
+export function sumMix(mix: Required<KindMix>): number {
+  return mix.adr + mix.principle + mix.lesson + mix.feedback + mix.other;
+}
+
+/**
+ * Walk the ranked hits, bucketing by normalised kind, then allocate
+ * per the mix with slot-rolling. Guarantees:
+ *   - returns at most `topK` artifacts
+ *   - never returns the same id twice
+ *   - preserves rank order within each kind
+ *   - kind-order in the output follows KIND_PRIORITY (adr → other)
+ */
+export function allocateByKindMix(
+  hits: ReadonlyArray<ArchSearchHit>,
+  mix: Required<KindMix>,
+  topK: number,
+): RetrievedArtifact[] {
+  const buckets: Record<RetrievedArtifact['kind'], RetrievedArtifact[]> = {
+    adr: [],
+    principle: [],
+    lesson: [],
+    feedback: [],
+    other: [],
+  };
+
+  for (const hit of hits) {
+    const artifact = normaliseHit(hit);
+    buckets[artifact.kind].push(artifact);
+  }
+
+  const out: RetrievedArtifact[] = [];
+  const seenIds = new Set<string>();
+  const remaining: Record<RetrievedArtifact['kind'], number> = {
+    adr: mix.adr,
+    principle: mix.principle,
+    lesson: mix.lesson,
+    feedback: mix.feedback,
+    other: mix.other,
+  };
+
+  // Pass 1: allocate exactly the mix per kind.
+  for (const kind of KIND_PRIORITY) {
+    const bucket = buckets[kind];
+    const slot = remaining[kind];
+    for (let i = 0; i < bucket.length && i < slot; i++) {
+      const a = bucket[i]!;
+      if (seenIds.has(a.id)) continue;
+      seenIds.add(a.id);
+      out.push(a);
+      if (out.length >= topK) return out;
+    }
+    // Track what we actually took so unfilled slots roll forward.
+    const took = Math.min(bucket.length, slot);
+    remaining[kind] = slot - took;
+  }
+
+  // Pass 2: distribute unfilled slots across remaining hits in priority
+  // order. Each iteration takes one hit from the highest-priority kind
+  // that still has hits.
+  while (out.length < topK) {
+    let progressed = false;
+    for (const kind of KIND_PRIORITY) {
+      const bucket = buckets[kind];
+      // Start past whatever Pass 1 already consumed.
+      const consumed = out.filter((a) => a.kind === kind).length;
+      const candidate = bucket[consumed];
+      if (!candidate) continue;
+      if (seenIds.has(candidate.id)) continue;
+      seenIds.add(candidate.id);
+      out.push(candidate);
+      progressed = true;
+      if (out.length >= topK) break;
+    }
+    if (!progressed) break;
+  }
+
+  return out;
+}
+
+/**
+ * Map a raw `ArchSearchHit` to a `RetrievedArtifact`. Looks up the kind
+ * bucket; if the kind itself doesn't resolve (e.g. AKG `kind=adr`), checks
+ * the tags for a more specific bucket (feedback/lesson/principle/etc).
+ */
+export function normaliseHit(hit: ArchSearchHit): RetrievedArtifact {
+  const row = hit.row;
+  let kind: RetrievedArtifact['kind'] =
+    KIND_BUCKETS[row.kind] ?? 'other';
+
+  if (kind === 'adr' || kind === 'other') {
+    // Look for a tag-based reclassification.
+    for (const [tag, bucket] of TAG_BUCKETS) {
+      if (row.tags.includes(tag)) {
+        kind = bucket;
+        break;
+      }
+    }
+  }
+
+  const id = deriveId(hit);
+  const date = deriveDate(hit);
+
+  const artifact: RetrievedArtifact = {
+    kind,
+    id,
+    title: row.name,
+    score: hit.scoreFused,
+    raw: hit,
+  };
+  if (date !== undefined) {
+    artifact.date = date;
+  }
+  return artifact;
+}
+
+/**
+ * Derive a display id. Preference order:
+ *   1. Parse first capture group out of `name` for ADR-style ids
+ *      ("ADR-011 Event-first state…" → "ADR-011").
+ *   2. Use `row.entryPath` basename minus extension.
+ *   3. Fall back to a short prefix of `row.id` (the arch_* internal id).
+ */
+export function deriveId(hit: ArchSearchHit): string {
+  const row = hit.row;
+  const idMatch = row.name.match(
+    /^(ADR-\d+|P\d+|L\d+|feedback-[a-z0-9-]+)/i,
+  );
+  if (idMatch?.[1]) return idMatch[1];
+  if (row.entryPath) {
+    const base = row.entryPath.split('/').pop() ?? row.entryPath;
+    return base.replace(/\.[a-z]+$/i, '');
+  }
+  return row.id;
+}
+
+/**
+ * Derive an optional date (YYYY-MM-DD). Tries the metadataJson payload
+ * (best-effort JSON parse for a `date` or `decisionDate` field) and
+ * falls back to a date prefix in the entryPath ("2026-05-24-foo.md").
+ */
+export function deriveDate(hit: ArchSearchHit): string | undefined {
+  const row = hit.row;
+  if (row.metadataJson && row.metadataJson !== '{}') {
+    try {
+      const parsed = JSON.parse(row.metadataJson) as Record<string, unknown>;
+      const dec = parsed['decisionDate'];
+      const date = parsed['date'];
+      if (typeof dec === 'string' && isIsoDate(dec)) return dec.slice(0, 10);
+      if (typeof date === 'string' && isIsoDate(date)) return date.slice(0, 10);
+    } catch {
+      // ignore — metadataJson is best-effort
+    }
+  }
+  if (row.entryPath) {
+    const m = row.entryPath.match(/(\d{4}-\d{2}-\d{2})/);
+    if (m?.[1]) return m[1];
+  }
+  return undefined;
+}
+
+function isIsoDate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}/.test(s);
+}

--- a/packages/knowledge-graph-dispatch-hook/src/hook.ts
+++ b/packages/knowledge-graph-dispatch-hook/src/hook.ts
@@ -1,0 +1,215 @@
+/**
+ * @caia/knowledge-graph-dispatch-hook — pre-dispatch hook (HOF).
+ *
+ * Mirrors the wrapper pattern in `@chiefaia/llm-cache`'s `withCache` and
+ * the dispatch-hook pattern in `@caia/policy-linter` (the validating
+ * Layer 1 hook). Together with policy-linter, this composes the full
+ * preflight: Layer 3 (this, mutating: enriches brief) → Layer 2 (EA
+ * Architect, mutating: rewrites plan) → Layer 1 (policy-linter,
+ * validating: refuses on hard-fail).
+ *
+ * Usage:
+ *
+ *   import { createEventBus } from '@chiefaia/events';
+ *   import { createKgDispatchHook } from '@caia/knowledge-graph-dispatch-hook';
+ *
+ *   const bus = createEventBus();
+ *   const hook = createKgDispatchHook({ db, embedder, eventBus: bus });
+ *
+ *   const wrappedDispatch = hook(async (brief) => {
+ *     return await myInnerDispatch(brief);
+ *   });
+ *
+ *   // brief.briefMd now arrives at myInnerDispatch with AKG context
+ *   // prepended; the original is preserved on a wrapper.
+ *   const result = await wrappedDispatch(brief);
+ *
+ * Soft-fail discipline: if injectContext itself throws (it shouldn't,
+ * but defensive), the hook still calls the inner dispatch with the
+ * UNMODIFIED brief and annotates `fallbackUsed: 'embedder-down'`. The
+ * spec is explicit (line 282): "package degrades to a no-op gracefully —
+ * never throws, never blocks the wrapped dispatch."
+ */
+
+import type Database from 'better-sqlite3';
+import type { EmbeddingClient } from '@chiefaia/architecture-registry';
+import type { EventBus } from '@chiefaia/events';
+
+import { injectContext } from './api.js';
+import {
+  CONTEXT_INJECTED,
+  type ContextInjectedEvent,
+  type DispatchBrief,
+  type EnrichedBrief,
+  type KgInjectionOpts,
+  type KgInjectionStats,
+} from './types.js';
+
+/**
+ * An inner dispatch function the hook wraps. Generic over the result
+ * type so callers can return anything (ReviewOutcome, ChainResult, etc).
+ *
+ * The brief passed in is the ENRICHED brief — `brief.briefMd` is the
+ * preamble + original. Callers who want the original can read it from
+ * `brief.metadata?.originalBriefMd` (the hook stashes it there).
+ */
+export type DispatchFn<R> = (
+  brief: DispatchBrief,
+  enrichment: EnrichedBrief,
+) => Promise<R> | R;
+
+export interface KgDispatchHookDeps {
+  db: Database.Database;
+  embedder: EmbeddingClient;
+  /** Optional event bus for `context.injected` emissions. */
+  eventBus?: EventBus;
+}
+
+export interface KgDispatchHookOpts extends KgInjectionOpts {
+  /**
+   * Per-dispatch observer fired with the retrieval stats. Useful for
+   * logging / metrics without subscribing to the event bus.
+   */
+  onInjected?: (event: ContextInjectedEvent) => void;
+}
+
+/**
+ * Factory that returns a HOF wrapper. The factory binds the
+ * (db, embedder, eventBus) once; the returned wrapper can be applied
+ * to many different inner dispatch functions.
+ */
+export function createKgDispatchHook(
+  deps: KgDispatchHookDeps,
+  defaultOpts: KgDispatchHookOpts = {},
+): <R>(inner: DispatchFn<R>, overrideOpts?: KgDispatchHookOpts) => (
+  brief: DispatchBrief,
+) => Promise<R> {
+  return function withKgContext<R>(
+    inner: DispatchFn<R>,
+    overrideOpts: KgDispatchHookOpts = {},
+  ): (brief: DispatchBrief) => Promise<R> {
+    const opts: KgDispatchHookOpts = { ...defaultOpts, ...overrideOpts };
+    return async function wrappedDispatch(brief: DispatchBrief): Promise<R> {
+      const enriched = await safeInject(brief, deps, opts);
+      await emitContextInjected(deps.eventBus, brief, enriched, opts);
+      const enrichedBrief = enrichedDispatchBrief(brief, enriched);
+      return await inner(enrichedBrief, enriched);
+    };
+  };
+}
+
+/**
+ * Convenience standalone wrapper for one-shot callers that don't want
+ * to keep a factory handle. Equivalent to
+ * `createKgDispatchHook(deps, opts)(inner)`.
+ */
+export function withKgContext<R>(
+  deps: KgDispatchHookDeps,
+  inner: DispatchFn<R>,
+  opts: KgDispatchHookOpts = {},
+): (brief: DispatchBrief) => Promise<R> {
+  return createKgDispatchHook(deps, opts)(inner);
+}
+
+/**
+ * Run `injectContext` with belt-and-suspenders error handling. The api
+ * layer already swallows expected errors, but this is the last line of
+ * defence — a programmer error in retrieval must not block the
+ * downstream dispatch.
+ */
+async function safeInject(
+  brief: DispatchBrief,
+  deps: KgDispatchHookDeps,
+  opts: KgInjectionOpts,
+): Promise<EnrichedBrief> {
+  const t0 = Date.now();
+  try {
+    return await injectContext(brief, deps, opts);
+  } catch (err) {
+    void err;
+    const stats: KgInjectionStats = {
+      topK: opts.topK ?? 0,
+      threshold: opts.threshold ?? 0.6,
+      embedderTokens: 0,
+      latencyMs: Date.now() - t0,
+      retrievedCount: 0,
+      sourcesByKind: {
+        adr: 0,
+        principle: 0,
+        lesson: 0,
+        feedback: 0,
+        other: 0,
+      },
+      fallbackUsed: 'embedder-down',
+    };
+    return {
+      brief: brief.briefMd,
+      preamble: '',
+      retrieved: [],
+      stats,
+      callerAgentId: brief.callerAgentId,
+    };
+  }
+}
+
+/**
+ * Build the brief object the inner dispatch sees. The enriched briefMd
+ * replaces the original; the original is stashed in `metadata` under
+ * a non-clobbering key so callers that want both can recover.
+ */
+function enrichedDispatchBrief(
+  brief: DispatchBrief,
+  enriched: EnrichedBrief,
+): DispatchBrief {
+  const next: DispatchBrief = {
+    callerAgentId: brief.callerAgentId,
+    briefMd: enriched.brief,
+    intent: brief.intent,
+    metadata: {
+      ...(brief.metadata ?? {}),
+      kgDispatchHook: {
+        originalBriefMd: brief.briefMd,
+        retrievedCount: enriched.retrieved.length,
+        fallbackUsed: enriched.stats.fallbackUsed,
+      },
+    },
+  };
+  if (brief.targetRepos !== undefined) next.targetRepos = brief.targetRepos;
+  if (brief.briefSummary !== undefined) next.briefSummary = brief.briefSummary;
+  return next;
+}
+
+/**
+ * Fire the `context.injected` event on the bus (if wired) and also
+ * call the per-dispatch `onInjected` callback (if supplied). Both run
+ * fire-and-forget but the event-bus call is awaited so callers can
+ * synchronously observe in tests.
+ */
+async function emitContextInjected(
+  bus: EventBus | undefined,
+  brief: DispatchBrief,
+  enriched: EnrichedBrief,
+  opts: KgDispatchHookOpts,
+): Promise<void> {
+  const event: ContextInjectedEvent = {
+    callerAgentId: brief.callerAgentId,
+    intent: brief.intent,
+    stats: enriched.stats,
+    retrievedIds: enriched.retrieved.map((a) => a.id),
+  };
+  if (bus) {
+    try {
+      await bus.emit<ContextInjectedEvent>(CONTEXT_INJECTED, event);
+    } catch (err) {
+      // Bus failure must not break the dispatch.
+      void err;
+    }
+  }
+  if (opts.onInjected) {
+    try {
+      opts.onInjected(event);
+    } catch (err) {
+      void err;
+    }
+  }
+}

--- a/packages/knowledge-graph-dispatch-hook/src/index.ts
+++ b/packages/knowledge-graph-dispatch-hook/src/index.ts
@@ -1,0 +1,86 @@
+/**
+ * @caia/knowledge-graph-dispatch-hook — public surface.
+ *
+ * Layer 3 of the AI-First Continuous-Discipline framework
+ * (`research/ai_first_continuous_discipline_2026.md`).
+ *
+ * What it does
+ * ------------
+ *
+ * Activates the already-built Architecture Knowledge Graph
+ * (`@chiefaia/architecture-registry`, nomic-embed-text + sqlite-vec)
+ * for pre-dispatch context injection. Every fresh subagent dispatch
+ * receives the most-relevant ADRs / principles / lessons / feedback
+ * memories auto-prepended to its brief based on semantic similarity to
+ * the task topic.
+ *
+ * Mirrors the dispatch-hook pattern in `@caia/policy-linter`
+ * (Layer 1, validating) and the HOF wrapper pattern in
+ * `@chiefaia/llm-cache`'s `withCache`. Together the three compose the
+ * full preflight: Layer 3 (mutate, enrich) → Layer 2 (EA Architect,
+ * mutate, rewrite) → Layer 1 (policy-linter, validate, refuse).
+ *
+ * Public exports
+ * --------------
+ *
+ *   - `injectContext(brief, deps, opts?)` — pure function, returns
+ *     `EnrichedBrief`.
+ *   - `createKgDispatchHook(deps, opts?)` — HOF factory.
+ *   - `withKgContext(deps, inner, opts?)` — one-shot wrapper.
+ *   - `buildPreamble(artifacts)` — direct access to the renderer.
+ *   - `retrieveContext(query, deps, opts?)` — direct access to the
+ *     embedder + kind-mix allocator.
+ *   - Types: `DispatchBrief`, `EnrichedBrief`, `KgInjectionOpts`,
+ *     `KgInjectionStats`, `RetrievedArtifact`, `KindMix`,
+ *     `ContextInjectedEvent`, `DispatchIntent`.
+ *   - Events: `CONTEXT_INJECTED` event-type constant.
+ */
+
+export {
+  injectContext,
+  deriveQuery,
+  type InjectContextDeps,
+} from './api.js';
+
+export {
+  createKgDispatchHook,
+  withKgContext,
+  type DispatchFn,
+  type KgDispatchHookDeps,
+  type KgDispatchHookOpts,
+} from './hook.js';
+
+export {
+  retrieveContext,
+  mergeKindMix,
+  sumMix,
+  allocateByKindMix,
+  normaliseHit,
+  deriveId,
+  deriveDate,
+  DEFAULT_KIND_MIX,
+  type RetrieveDeps,
+  type RetrieveOpts,
+  type RetrieveResult,
+} from './embedder.js';
+
+export {
+  buildPreamble,
+  prependPreamble,
+  groupByKind,
+  renderArtifactLine,
+  PREAMBLE_HEADER,
+  PREAMBLE_INTRO,
+} from './context-builder.js';
+
+export {
+  CONTEXT_INJECTED,
+  type ContextInjectedEvent,
+  type DispatchBrief,
+  type DispatchIntent,
+  type EnrichedBrief,
+  type KgInjectionOpts,
+  type KgInjectionStats,
+  type RetrievedArtifact,
+  type KindMix,
+} from './types.js';

--- a/packages/knowledge-graph-dispatch-hook/src/types.ts
+++ b/packages/knowledge-graph-dispatch-hook/src/types.ts
@@ -1,0 +1,167 @@
+/**
+ * @caia/knowledge-graph-dispatch-hook — public type surface.
+ *
+ * Layer 3 of the AI-First Continuous-Discipline framework
+ * (`research/ai_first_continuous_discipline_2026.md`).
+ *
+ * Contracts:
+ *
+ *   DispatchBrief   → minimal subset of @caia/policy-linter's DispatchContext
+ *                     this layer cares about (briefMd + intent + repos).
+ *   EnrichedBrief   → DispatchBrief with the AKG-injected preamble prepended
+ *                     to briefMd, plus retrieval stats for observability.
+ *   KgInjectionOpts → knobs: topK, threshold, kindMix, disabled, etc.
+ *
+ * Kept dependency-free (no `better-sqlite3` types, no embedder types) so
+ * any caller can import these to declare the contract without dragging in
+ * the runtime stack.
+ */
+
+/**
+ * Brief-level intent classification. Mirrors `@caia/policy-linter`'s
+ * `DispatchIntent` exactly so the two hooks compose cleanly on the same
+ * DispatchContext.
+ */
+export type DispatchIntent =
+  | 'research'
+  | 'spec'
+  | 'build'
+  | 'review'
+  | 'ops'
+  | 'meta';
+
+/**
+ * The minimal brief-shaped subset this layer needs to operate. A caller
+ * holding a `@caia/policy-linter` `DispatchContext` can pass it directly;
+ * extra fields are ignored.
+ */
+export interface DispatchBrief {
+  /** Caller agent identifier — echoed into stats + events. */
+  callerAgentId: string;
+  /** Full markdown body of the task brief. */
+  briefMd: string;
+  /** Brief-level intent classification. Used to bias kindMix. */
+  intent: DispatchIntent;
+  /** Optional repos the dispatch will touch — used as project filter. */
+  targetRepos?: ReadonlyArray<string>;
+  /** Optional explicit summary for embedding (defaults to briefMd head). */
+  briefSummary?: string;
+  /** Optional opaque metadata passed through unchanged. */
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Per-kind retrieval mix. Slots are best-effort — if a kind has zero hits,
+ * its slot rolls into the next kind in the order
+ *   adr → principle → lesson → feedback → other
+ * so total retrieved count tracks the sum without holes.
+ *
+ * Defaults match the Layer 3 spec (lines 651-672, 676):
+ *   { adr: 3, principle: 1, lesson: 1, feedback: 1 }
+ */
+export interface KindMix {
+  adr?: number;
+  principle?: number;
+  lesson?: number;
+  feedback?: number;
+  /** Catch-all bucket for non-standard artifact kinds. */
+  other?: number;
+}
+
+/**
+ * One retrieved artifact, kind-normalised and stripped to the fields the
+ * preamble renderer needs. The raw `ArchSearchHit` is retained on `raw`
+ * for callers that need richer payloads (metadata JSON, scores, etc).
+ */
+export interface RetrievedArtifact {
+  /** Normalised kind: 'adr' | 'principle' | 'lesson' | 'feedback' | 'other'. */
+  kind: 'adr' | 'principle' | 'lesson' | 'feedback' | 'other';
+  /** Stable id (e.g. ADR-011, P3, L01, feedback-no-timelines). */
+  id: string;
+  /** Display title for the preamble line. */
+  title: string;
+  /** Optional date in YYYY-MM-DD form for feedback memories. */
+  date?: string;
+  /** Fused score from the AKG (RRF). Higher is better. */
+  score: number;
+  /** Raw hit payload — opaque to consumers. */
+  raw: unknown;
+}
+
+/**
+ * Knobs for one `injectContext` call. All fields optional.
+ */
+export interface KgInjectionOpts {
+  /** Top-K total hits to surface. Default 5 (spec line 676). */
+  topK?: number;
+  /** Cosine threshold floor for dense hits. Default 0.6 (spec line 676). */
+  threshold?: number;
+  /** Per-kind retrieval mix; slot-rolls when a kind underflows. */
+  kindMix?: KindMix;
+  /** If true, the hook becomes a no-op — original brief returned unchanged. */
+  disabled?: boolean;
+  /** Force sparse-only retrieval (e.g. when Ollama is unavailable). */
+  sparseOnly?: boolean;
+  /** Force dense-only retrieval. */
+  denseOnly?: boolean;
+  /** Override the embedder-derived query string. */
+  queryOverride?: string;
+  /**
+   * Max characters of `briefMd` to feed the embedder when no explicit
+   * `briefSummary` is provided. Default 1200.
+   */
+  briefSummaryMaxChars?: number;
+  /** Inject the preamble only; return original brief untouched on `brief`. */
+  preambleOnly?: boolean;
+}
+
+/**
+ * Per-call stats — surfaced on `EnrichedBrief.stats` and in
+ * `context.injected` event payloads. Cheap to log.
+ */
+export interface KgInjectionStats {
+  topK: number;
+  threshold: number;
+  embedderTokens: number;
+  latencyMs: number;
+  retrievedCount: number;
+  sourcesByKind: Record<RetrievedArtifact['kind'], number>;
+  fallbackUsed:
+    | 'none'
+    | 'sparse-only'
+    | 'disabled'
+    | 'empty-kg'
+    | 'embedder-down';
+}
+
+/**
+ * Result of `injectContext`. Composes cleanly back into a
+ * `@caia/policy-linter` `DispatchContext` by spreading + overriding
+ * `briefMd`.
+ */
+export interface EnrichedBrief {
+  /** The brief to dispatch — preamble + original (or original if disabled). */
+  brief: string;
+  /** Preamble only, for separate logging / observability. */
+  preamble: string;
+  /** Retrieved artifacts the preamble was built from, ranked. */
+  retrieved: ReadonlyArray<RetrievedArtifact>;
+  /** Retrieval stats. */
+  stats: KgInjectionStats;
+  /** Caller agent id echoed unchanged. */
+  callerAgentId: string;
+}
+
+/**
+ * Event payload emitted on `context.injected` when an EventBus is wired.
+ * Spec line 943: "Surfaces a `context.injected` event to the bus."
+ */
+export interface ContextInjectedEvent {
+  callerAgentId: string;
+  intent: DispatchIntent;
+  stats: KgInjectionStats;
+  /** Just the ids — full payloads stay on the EnrichedBrief, not the event. */
+  retrievedIds: ReadonlyArray<string>;
+}
+
+export const CONTEXT_INJECTED = 'context.injected' as const;

--- a/packages/knowledge-graph-dispatch-hook/tests/api.test.ts
+++ b/packages/knowledge-graph-dispatch-hook/tests/api.test.ts
@@ -1,0 +1,138 @@
+/**
+ * api.test.ts — unit tests for `injectContext` and `deriveQuery`.
+ *
+ * We don't boot a real AKG here (that's the integration test). Instead we
+ * stub `archSearch` via a mocked import of `@chiefaia/architecture-registry`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { canonicalHits, result, stubEmbedder } from './fixtures.js';
+
+vi.mock('@chiefaia/architecture-registry', async () => {
+  const actual =
+    await vi.importActual<typeof import('@chiefaia/architecture-registry')>(
+      '@chiefaia/architecture-registry',
+    );
+  return {
+    ...actual,
+    archSearch: vi.fn(),
+  };
+});
+
+import { archSearch } from '@chiefaia/architecture-registry';
+import { deriveQuery, injectContext } from '../src/api.js';
+import type { DispatchBrief } from '../src/types.js';
+
+const mockedArchSearch = archSearch as unknown as ReturnType<typeof vi.fn>;
+
+function brief(over: Partial<DispatchBrief> = {}): DispatchBrief {
+  return {
+    callerAgentId: 'agent-1',
+    briefMd: 'Investigate event-sourcing options for the leaderboard.',
+    intent: 'research',
+    ...over,
+  };
+}
+
+const fakeDb = {} as unknown as import('better-sqlite3').Database;
+
+beforeEach(() => {
+  mockedArchSearch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('deriveQuery', () => {
+  it('honours queryOverride first', () => {
+    expect(deriveQuery(brief({ briefSummary: 'B' }), { queryOverride: 'A' })).toBe('A');
+  });
+
+  it('uses briefSummary when present and no override', () => {
+    expect(deriveQuery(brief({ briefSummary: 'S' }))).toBe('S');
+  });
+
+  it('falls back to briefMd head capped at briefSummaryMaxChars', () => {
+    const md = 'x'.repeat(2000);
+    expect(deriveQuery(brief({ briefMd: md }), { briefSummaryMaxChars: 100 })).toHaveLength(100);
+  });
+
+  it('defaults briefSummaryMaxChars to 1200', () => {
+    const md = 'x'.repeat(2000);
+    expect(deriveQuery(brief({ briefMd: md }))).toHaveLength(1200);
+  });
+});
+
+describe('injectContext — short circuits', () => {
+  it('disabled short-circuits without calling archSearch', async () => {
+    const out = await injectContext(brief(), { db: fakeDb, embedder: stubEmbedder() }, {
+      disabled: true,
+    });
+    expect(mockedArchSearch).not.toHaveBeenCalled();
+    expect(out.stats.fallbackUsed).toBe('disabled');
+    expect(out.preamble).toBe('');
+    expect(out.brief).toBe(brief().briefMd);
+    expect(out.callerAgentId).toBe('agent-1');
+  });
+
+  it('empty query short-circuits to empty-kg', async () => {
+    const out = await injectContext(brief({ briefMd: '' }), { db: fakeDb, embedder: stubEmbedder() });
+    expect(out.stats.fallbackUsed).toBe('empty-kg');
+    expect(mockedArchSearch).not.toHaveBeenCalled();
+  });
+});
+
+describe('injectContext — happy path', () => {
+  it('prepends the preamble to brief and reports fallbackUsed=none', async () => {
+    mockedArchSearch.mockResolvedValue(result(canonicalHits()));
+    const out = await injectContext(brief(), { db: fakeDb, embedder: stubEmbedder() });
+    expect(out.stats.fallbackUsed).toBe('none');
+    expect(out.preamble).toContain('## Architecture Context (auto-injected by AKG)');
+    expect(out.brief.startsWith(out.preamble)).toBe(true);
+    expect(out.brief.includes(brief().briefMd)).toBe(true);
+    expect(out.retrieved.length).toBeGreaterThan(0);
+  });
+
+  it('preambleOnly returns the original brief unchanged but still exposes preamble', async () => {
+    mockedArchSearch.mockResolvedValue(result(canonicalHits()));
+    const b = brief();
+    const out = await injectContext(b, { db: fakeDb, embedder: stubEmbedder() }, {
+      preambleOnly: true,
+    });
+    expect(out.brief).toBe(b.briefMd);
+    expect(out.preamble.length).toBeGreaterThan(0);
+  });
+
+  it('reports retrievedCount and sourcesByKind accurately', async () => {
+    mockedArchSearch.mockResolvedValue(result(canonicalHits()));
+    const out = await injectContext(brief(), { db: fakeDb, embedder: stubEmbedder() });
+    const total =
+      out.stats.sourcesByKind.adr +
+      out.stats.sourcesByKind.principle +
+      out.stats.sourcesByKind.lesson +
+      out.stats.sourcesByKind.feedback +
+      out.stats.sourcesByKind.other;
+    expect(total).toBe(out.stats.retrievedCount);
+  });
+});
+
+describe('injectContext — failure handling', () => {
+  it('archSearch throws => fallbackUsed=embedder-down and brief passes through', async () => {
+    mockedArchSearch.mockRejectedValue(new Error('boom'));
+    const b = brief();
+    const out = await injectContext(b, { db: fakeDb, embedder: stubEmbedder() });
+    expect(out.stats.fallbackUsed).toBe('embedder-down');
+    expect(out.brief).toBe(b.briefMd);
+    expect(out.preamble).toBe('');
+  });
+
+  it('zero hits from archSearch => fallbackUsed=empty-kg', async () => {
+    mockedArchSearch.mockResolvedValue(result([]));
+    const out = await injectContext(brief(), { db: fakeDb, embedder: stubEmbedder() });
+    expect(out.stats.fallbackUsed).toBe('empty-kg');
+    expect(out.retrieved.length).toBe(0);
+    expect(out.preamble).toBe('');
+  });
+});

--- a/packages/knowledge-graph-dispatch-hook/tests/context-builder.test.ts
+++ b/packages/knowledge-graph-dispatch-hook/tests/context-builder.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildPreamble,
+  groupByKind,
+  PREAMBLE_HEADER,
+  PREAMBLE_INTRO,
+  prependPreamble,
+  renderArtifactLine,
+} from '../src/context-builder.js';
+import type { RetrievedArtifact } from '../src/types.js';
+
+function art(over: Partial<RetrievedArtifact>): RetrievedArtifact {
+  return {
+    kind: 'adr',
+    id: 'ADR-001',
+    title: 'Test',
+    score: 0.9,
+    raw: null,
+    ...over,
+  };
+}
+
+describe('buildPreamble', () => {
+  it('returns empty string for empty input', () => {
+    expect(buildPreamble([])).toBe('');
+  });
+
+  it('includes the canonical header and intro', () => {
+    const out = buildPreamble([art({})]);
+    expect(out.startsWith(PREAMBLE_HEADER)).toBe(true);
+    expect(out).toContain(PREAMBLE_INTRO);
+  });
+
+  it('renders an ADRs section when only ADR hits are present', () => {
+    const out = buildPreamble([
+      art({ kind: 'adr', id: 'ADR-011', title: 'Event-first state' }),
+    ]);
+    expect(out).toContain('### ADRs');
+    expect(out).toContain('- [ADR-011] Event-first state');
+    expect(out).not.toContain('### Principles');
+  });
+
+  it('renders sections in spec order ADR Principle Lesson Feedback', () => {
+    const out = buildPreamble([
+      art({ kind: 'feedback', id: 'feedback-x', title: '', date: '2026-05-24' }),
+      art({ kind: 'lesson', id: 'L01', title: 'lesson title' }),
+      art({ kind: 'principle', id: 'P3', title: 'No timelines' }),
+      art({ kind: 'adr', id: 'ADR-011', title: 'Event-first' }),
+    ]);
+    const order = ['### ADRs', '### Principles', '### Lessons', '### Recent feedback memories'];
+    let cursor = 0;
+    for (const h of order) {
+      const idx = out.indexOf(h, cursor);
+      expect(idx).toBeGreaterThan(-1);
+      cursor = idx + h.length;
+    }
+  });
+
+  it('omits empty sections entirely', () => {
+    const out = buildPreamble([
+      art({ kind: 'adr', id: 'ADR-1', title: 'one' }),
+    ]);
+    expect(out).not.toContain('### Principles');
+    expect(out).not.toContain('### Lessons');
+    expect(out).not.toContain('### Recent feedback memories');
+    expect(out).not.toContain('### Other');
+  });
+
+  it('renders the Recent feedback memories header verbatim from the spec', () => {
+    const out = buildPreamble([
+      art({ kind: 'feedback', id: 'feedback-y', title: '' }),
+    ]);
+    expect(out).toContain('### Recent feedback memories');
+  });
+
+  it('renders the Other section for non-canonical kinds', () => {
+    const out = buildPreamble([
+      art({ kind: 'other', id: 'thing', title: 'a thing' }),
+    ]);
+    expect(out).toContain('### Other');
+    expect(out).toContain('- [thing] a thing');
+  });
+});
+
+describe('renderArtifactLine', () => {
+  it('formats ADR lines as - [ID] title', () => {
+    expect(
+      renderArtifactLine(
+        art({ id: 'ADR-011', title: 'Event-first state with database as projection' }),
+        'adr',
+      ),
+    ).toBe('- [ADR-011] Event-first state with database as projection');
+  });
+
+  it('formats principle lines as - [ID] title', () => {
+    expect(
+      renderArtifactLine(art({ id: 'P3', title: 'No timelines, ever' }), 'principle'),
+    ).toBe('- [P3] No timelines, ever');
+  });
+
+  it('formats feedback lines without title and with date suffix', () => {
+    expect(
+      renderArtifactLine(
+        art({ id: 'feedback-continuous-discipline-problem', title: 'ignored', date: '2026-05-24' }),
+        'feedback',
+      ),
+    ).toBe('- [feedback-continuous-discipline-problem] (2026-05-24)');
+  });
+
+  it('formats feedback lines without title and without date when none', () => {
+    expect(
+      renderArtifactLine(art({ id: 'feedback-x', title: '' }), 'feedback'),
+    ).toBe('- [feedback-x]');
+  });
+
+  it('collapses whitespace and trims in titles', () => {
+    const out = renderArtifactLine(
+      art({ id: 'ADR-1', title: '  multi\n line   title  ' }),
+      'adr',
+    );
+    expect(out).toBe('- [ADR-1] multi line title');
+  });
+
+  it('escapes closing brackets in titles', () => {
+    const out = renderArtifactLine(
+      art({ id: 'ADR-1', title: 'Title with [brackets] inside' }),
+      'adr',
+    );
+    expect(out).toContain('\\]');
+  });
+
+  it('strips brackets from ids so [id] stays parseable', () => {
+    const out = renderArtifactLine(art({ id: '[weird]id', title: 't' }), 'adr');
+    expect(out).toBe('- [weirdid] t');
+  });
+
+  it('caps title length at 200 chars with an ellipsis', () => {
+    const longTitle = 'x'.repeat(500);
+    const out = renderArtifactLine(art({ id: 'ADR-1', title: longTitle }), 'adr');
+    expect(out.length).toBeLessThanOrEqual(210);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('handles missing title by emitting just the id', () => {
+    expect(renderArtifactLine(art({ id: 'ADR-1', title: '' }), 'adr')).toBe('- [ADR-1]');
+  });
+});
+
+describe('groupByKind', () => {
+  it('returns empty arrays for every kind on empty input', () => {
+    const g = groupByKind([]);
+    expect(g.adr).toEqual([]);
+    expect(g.principle).toEqual([]);
+    expect(g.lesson).toEqual([]);
+    expect(g.feedback).toEqual([]);
+    expect(g.other).toEqual([]);
+  });
+
+  it('preserves input order within each kind', () => {
+    const g = groupByKind([
+      art({ kind: 'adr', id: 'ADR-2' }),
+      art({ kind: 'adr', id: 'ADR-1' }),
+      art({ kind: 'principle', id: 'P1' }),
+    ]);
+    expect(g.adr.map((a) => a.id)).toEqual(['ADR-2', 'ADR-1']);
+    expect(g.principle.map((a) => a.id)).toEqual(['P1']);
+  });
+});
+
+describe('prependPreamble', () => {
+  it('returns the brief unchanged when preamble is empty', () => {
+    expect(prependPreamble('hello', '')).toBe('hello');
+  });
+
+  it('joins preamble + double-newline + brief', () => {
+    expect(prependPreamble('hello', 'PRE')).toBe('PRE\n\nhello');
+  });
+
+  it('handles an empty brief by emitting PRE plus two newlines', () => {
+    expect(prependPreamble('', 'PRE')).toBe('PRE\n\n');
+  });
+});

--- a/packages/knowledge-graph-dispatch-hook/tests/embedder.test.ts
+++ b/packages/knowledge-graph-dispatch-hook/tests/embedder.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  allocateByKindMix,
+  DEFAULT_KIND_MIX,
+  deriveDate,
+  deriveId,
+  mergeKindMix,
+  normaliseHit,
+  sumMix,
+} from '../src/embedder.js';
+
+import { canonicalHits, hit, row } from './fixtures.js';
+
+describe('mergeKindMix', () => {
+  it('returns defaults when no input is supplied', () => {
+    expect(mergeKindMix()).toEqual({
+      adr: 3,
+      principle: 1,
+      lesson: 1,
+      feedback: 1,
+      other: 0,
+    });
+  });
+
+  it('preserves caller overrides and fills the rest from defaults', () => {
+    const m = mergeKindMix({ adr: 5, other: 2 });
+    expect(m.adr).toBe(5);
+    expect(m.other).toBe(2);
+    expect(m.principle).toBe(DEFAULT_KIND_MIX.principle);
+    expect(m.feedback).toBe(DEFAULT_KIND_MIX.feedback);
+  });
+
+  it('honours explicit zeros (a caller can disable a kind)', () => {
+    const m = mergeKindMix({ feedback: 0 });
+    expect(m.feedback).toBe(0);
+    expect(m.adr).toBe(DEFAULT_KIND_MIX.adr);
+  });
+});
+
+describe('sumMix', () => {
+  it('sums all five slots', () => {
+    expect(sumMix({ adr: 1, principle: 2, lesson: 3, feedback: 4, other: 5 }))
+      .toBe(15);
+  });
+
+  it('returns 6 for DEFAULT_KIND_MIX', () => {
+    expect(sumMix(DEFAULT_KIND_MIX)).toBe(6);
+  });
+});
+
+describe('normaliseHit', () => {
+  it('classifies pure ADR rows as adr', () => {
+    const a = normaliseHit(hit(row({ name: 'ADR-099 Something', kind: 'adr' })));
+    expect(a.kind).toBe('adr');
+    expect(a.id).toBe('ADR-099');
+  });
+
+  it('classifies kind=adr + tag=principle as principle', () => {
+    const a = normaliseHit(
+      hit(row({ name: 'P9 Cost discipline', kind: 'adr', tags: ['principle'] })),
+    );
+    expect(a.kind).toBe('principle');
+    expect(a.id).toBe('P9');
+  });
+
+  it('classifies kind=adr + tag=lesson as lesson', () => {
+    const a = normaliseHit(
+      hit(row({ name: 'L02 Some lesson', kind: 'adr', tags: ['lesson'] })),
+    );
+    expect(a.kind).toBe('lesson');
+  });
+
+  it('classifies kind=adr + tag=feedback as feedback', () => {
+    const a = normaliseHit(
+      hit(row({ name: 'feedback-foo', kind: 'adr', tags: ['feedback'] })),
+    );
+    expect(a.kind).toBe('feedback');
+    expect(a.id).toBe('feedback-foo');
+  });
+
+  it('falls through to other for unrecognised kinds with no tag', () => {
+    const a = normaliseHit(hit(row({ name: 'SomeComponent', kind: 'component' })));
+    expect(a.kind).toBe('other');
+  });
+
+  it('preserves the fused score', () => {
+    const a = normaliseHit(hit(row({}), 0.71));
+    expect(a.score).toBe(0.71);
+  });
+
+  it('keeps the raw hit on .raw', () => {
+    const h = hit(row({}));
+    const a = normaliseHit(h);
+    expect(a.raw).toBe(h);
+  });
+});
+
+describe('deriveId', () => {
+  it('extracts an ADR-NNN prefix from the name', () => {
+    expect(deriveId(hit(row({ name: 'ADR-011 Event-first state' })))).toBe('ADR-011');
+  });
+
+  it('extracts a P-NN prefix from the name', () => {
+    expect(deriveId(hit(row({ name: 'P14 Subscription only' })))).toBe('P14');
+  });
+
+  it('extracts an L-NN prefix from the name', () => {
+    expect(deriveId(hit(row({ name: 'L03 Some lesson title' })))).toBe('L03');
+  });
+
+  it('extracts a feedback-* slug from the name', () => {
+    expect(deriveId(hit(row({ name: 'feedback-no-timelines' })))).toBe(
+      'feedback-no-timelines',
+    );
+  });
+
+  it('falls back to entryPath basename without extension', () => {
+    expect(
+      deriveId(hit(row({ name: 'no-id-prefix', entryPath: 'caia-ea/decisions/foo.md' }))),
+    ).toBe('foo');
+  });
+
+  it('falls back to the row.id when nothing else is available', () => {
+    expect(deriveId(hit(row({ id: 'arch_x', name: 'no-id-prefix' })))).toBe('arch_x');
+  });
+});
+
+describe('deriveDate', () => {
+  it('returns undefined when metadataJson is empty and entryPath has no date', () => {
+    expect(deriveDate(hit(row({})))).toBeUndefined();
+  });
+
+  it('extracts a date from metadataJson decisionDate', () => {
+    expect(
+      deriveDate(
+        hit(row({ metadataJson: '{"decisionDate":"2026-05-24T00:00:00Z"}' })),
+      ),
+    ).toBe('2026-05-24');
+  });
+
+  it('extracts a date from metadataJson .date', () => {
+    expect(deriveDate(hit(row({ metadataJson: '{"date":"2025-12-01"}' })))).toBe(
+      '2025-12-01',
+    );
+  });
+
+  it('extracts a date from the entryPath prefix', () => {
+    expect(
+      deriveDate(
+        hit(row({ entryPath: 'agent-memory/2026-05-24-continuous-discipline.md' })),
+      ),
+    ).toBe('2026-05-24');
+  });
+
+  it('ignores malformed metadataJson without throwing', () => {
+    expect(deriveDate(hit(row({ metadataJson: 'not-json-{' })))).toBeUndefined();
+  });
+});
+
+describe('allocateByKindMix', () => {
+  it('returns nothing when hits is empty', () => {
+    expect(allocateByKindMix([], DEFAULT_KIND_MIX, 5)).toEqual([]);
+  });
+
+  it('respects the mix exactly when every bucket has enough hits', () => {
+    const out = allocateByKindMix(canonicalHits(), DEFAULT_KIND_MIX, 6);
+    const counts = countBy(out.map((a) => a.kind));
+    expect(counts.adr).toBe(3);
+    expect(counts.principle).toBe(1);
+    expect(counts.lesson).toBe(1);
+    expect(counts.feedback).toBe(1);
+  });
+
+  it('rolls underflowed slots forward when a kind has fewer hits than its slot', () => {
+    // 4 ADRs, 0 principles, 0 lessons, 0 feedback.
+    // Mix asks for {adr:1, principle:1, lesson:1, feedback:1} → 4 total.
+    // Principle/lesson/feedback slots are empty so roll forward to "other"
+    // … but there are no other hits either. Adr slot=1 already taken.
+    // Pass-2 then re-walks the priority order picking unfilled.
+    const hits = [
+      hit(row({ id: 'a1', name: 'ADR-1 one' }), 0.9),
+      hit(row({ id: 'a2', name: 'ADR-2 two' }), 0.8),
+      hit(row({ id: 'a3', name: 'ADR-3 three' }), 0.7),
+      hit(row({ id: 'a4', name: 'ADR-4 four' }), 0.6),
+    ];
+    const out = allocateByKindMix(
+      hits,
+      { adr: 1, principle: 1, lesson: 1, feedback: 1, other: 0 },
+      4,
+    );
+    expect(out.length).toBe(4);
+    expect(out.every((a) => a.kind === 'adr')).toBe(true);
+  });
+
+  it('caps total at topK even when mix sums higher', () => {
+    const out = allocateByKindMix(
+      canonicalHits(),
+      { adr: 5, principle: 5, lesson: 5, feedback: 5, other: 5 },
+      3,
+    );
+    expect(out.length).toBe(3);
+  });
+
+  it('preserves rank order within each kind', () => {
+    const out = allocateByKindMix(canonicalHits(), DEFAULT_KIND_MIX, 6);
+    const adrs = out.filter((a) => a.kind === 'adr').map((a) => a.id);
+    expect(adrs).toEqual(['ADR-011', 'ADR-028', 'ADR-038']);
+  });
+
+  it('dedupes by id across rolls', () => {
+    const dup = hit(row({ id: 'arch_dup', name: 'ADR-999 dup' }), 0.5);
+    const hits = [dup, dup, dup];
+    const out = allocateByKindMix(hits, DEFAULT_KIND_MIX, 5);
+    expect(out.length).toBe(1);
+    expect(out[0]?.id).toBe('ADR-999');
+  });
+
+  it('outputs kinds in priority order (adr first, other last)', () => {
+    const out = allocateByKindMix(canonicalHits(), DEFAULT_KIND_MIX, 6);
+    const kinds = out.map((a) => a.kind);
+    // ADRs come before principle, principle before lesson, etc.
+    const adrIdx = kinds.indexOf('adr');
+    const principleIdx = kinds.indexOf('principle');
+    const lessonIdx = kinds.indexOf('lesson');
+    const feedbackIdx = kinds.indexOf('feedback');
+    expect(adrIdx).toBeLessThan(principleIdx);
+    expect(principleIdx).toBeLessThan(lessonIdx);
+    expect(lessonIdx).toBeLessThan(feedbackIdx);
+  });
+});
+
+function countBy<T extends string>(values: readonly T[]): Record<T, number> {
+  const acc = {} as Record<T, number>;
+  for (const v of values) acc[v] = (acc[v] ?? 0) + 1;
+  return acc;
+}

--- a/packages/knowledge-graph-dispatch-hook/tests/fixtures.ts
+++ b/packages/knowledge-graph-dispatch-hook/tests/fixtures.ts
@@ -1,0 +1,161 @@
+/**
+ * Shared test fixtures — synthetic AKG rows + a deterministic stub
+ * embedder. Used by every test file.
+ */
+
+import type {
+  ArchArtifactRow,
+  ArchSearchHit,
+  ArchSearchResult,
+  EmbeddingClient,
+  EmbedResult,
+} from '@chiefaia/architecture-registry';
+
+/**
+ * Build a synthetic AKG artifact row with sensible defaults. Override
+ * any field via `over`.
+ */
+export function row(over: Partial<ArchArtifactRow>): ArchArtifactRow {
+  const now = 1716000000000;
+  return {
+    id: 'arch_test_1',
+    kind: 'adr',
+    project: 'caia',
+    name: 'Test artifact',
+    description: 'A synthetic row for tests.',
+    filePaths: [],
+    techSubDomains: [],
+    tags: [],
+    metadataJson: '{}',
+    source: 'manual',
+    embeddingModel: 'nomic-embed-text',
+    embeddingDim: 768,
+    embeddingVersion: 'v1.5',
+    createdAt: now,
+    updatedAt: now,
+    dedupKey: '0'.repeat(40),
+    ...over,
+  } as ArchArtifactRow;
+}
+
+/**
+ * Build a search hit wrapping a row, with fused score and match-type.
+ */
+export function hit(
+  artifact: ArchArtifactRow,
+  scoreFused = 0.9,
+  matchType: ArchSearchHit['matchType'] = 'both',
+): ArchSearchHit {
+  return {
+    row: artifact,
+    scoreDense: 0.85,
+    scoreSparse: 0.8,
+    scoreFused,
+    matchType,
+  };
+}
+
+/**
+ * Build a complete ArchSearchResult from a hits array.
+ */
+export function result(hits: ArchSearchHit[]): ArchSearchResult {
+  return {
+    hits,
+    topMatch: hits[0] ?? null,
+    thresholdUsed: 0.6,
+    latencyMs: 1,
+    embedderTokens: 42,
+    kindsSearched: [],
+    techSubDomainsFiltered: [],
+  };
+}
+
+/**
+ * The canonical example hit set described in the Layer 3 spec
+ * preamble (lines 651-672). Used by the renderer + api tests.
+ */
+export function canonicalHits(): ArchSearchHit[] {
+  return [
+    hit(
+      row({
+        id: 'arch_adr_011',
+        name: 'ADR-011 Event-first state with database as projection',
+        kind: 'adr',
+      }),
+      0.92,
+    ),
+    hit(
+      row({
+        id: 'arch_adr_028',
+        name: 'ADR-028 Architecture Knowledge Graph via sqlite-vec + nomic-embed',
+        kind: 'adr',
+      }),
+      0.88,
+    ),
+    hit(
+      row({
+        id: 'arch_adr_038',
+        name: 'ADR-038 EA Reviewer (per-ticket) vs EA Architect (platform-level) scope',
+        kind: 'adr',
+      }),
+      0.85,
+    ),
+    hit(
+      row({
+        id: 'arch_p3',
+        name: 'P3 No timelines, ever',
+        kind: 'adr',
+        tags: ['principle'],
+      }),
+      0.83,
+    ),
+    hit(
+      row({
+        id: 'arch_l01',
+        name: 'L01 Pixel-perfect calibration (85%/95% diff thresholds)',
+        kind: 'adr',
+        tags: ['lesson'],
+      }),
+      0.79,
+    ),
+    hit(
+      row({
+        id: 'arch_fb_cdp',
+        name: 'feedback-continuous-discipline-problem',
+        kind: 'adr',
+        tags: ['feedback'],
+        entryPath: 'agent-memory/2026-05-24-continuous-discipline-problem.md',
+      }),
+      0.75,
+    ),
+  ];
+}
+
+/**
+ * A deterministic stub embedder satisfying the full `EmbeddingClient`
+ * interface (embed + embedBatch + modelName + modelDim).
+ */
+export function stubEmbedder(dim = 768): EmbeddingClient {
+  return {
+    modelName(): string {
+      return 'stub-test';
+    },
+    modelDim(): number {
+      return dim;
+    },
+    async embed(text: string): Promise<EmbedResult> {
+      return {
+        embedding: new Float32Array(dim).fill(0.01),
+        tokens: text.length,
+        latencyMs: 0,
+      };
+    },
+    async embedBatch(texts: string[]): Promise<EmbedResult[]> {
+      return texts.map((t) => ({
+        embedding: new Float32Array(dim).fill(0.01),
+        tokens: t.length,
+        latencyMs: 0,
+      }));
+    },
+  };
+}

--- a/packages/knowledge-graph-dispatch-hook/tests/hook.test.ts
+++ b/packages/knowledge-graph-dispatch-hook/tests/hook.test.ts
@@ -1,0 +1,141 @@
+/**
+ * hook.test.ts — unit tests for the HOF wrapper.
+ *
+ * Mocks @chiefaia/architecture-registry's archSearch so we exercise the
+ * full hook → injectContext → renderer → event-bus chain without booting
+ * a real AKG.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { canonicalHits, result, stubEmbedder } from './fixtures.js';
+
+vi.mock('@chiefaia/architecture-registry', async () => {
+  const actual =
+    await vi.importActual<typeof import('@chiefaia/architecture-registry')>(
+      '@chiefaia/architecture-registry',
+    );
+  return {
+    ...actual,
+    archSearch: vi.fn(),
+  };
+});
+
+import { createEventBus } from '@chiefaia/events';
+import { archSearch } from '@chiefaia/architecture-registry';
+import {
+  createKgDispatchHook,
+  withKgContext,
+} from '../src/hook.js';
+import {
+  CONTEXT_INJECTED,
+  type ContextInjectedEvent,
+  type DispatchBrief,
+} from '../src/types.js';
+
+const mockedArchSearch = archSearch as unknown as ReturnType<typeof vi.fn>;
+
+function brief(): DispatchBrief {
+  return {
+    callerAgentId: 'agent-z',
+    briefMd: 'Build event-sourcing leaderboard.',
+    intent: 'build',
+  };
+}
+
+const fakeDb = {} as unknown as import('better-sqlite3').Database;
+
+beforeEach(() => {
+  mockedArchSearch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createKgDispatchHook + withKgContext', () => {
+  it('wraps an inner dispatch and propagates its return value', async () => {
+    mockedArchSearch.mockResolvedValue(result(canonicalHits()));
+    const wrapped = withKgContext(
+      { db: fakeDb, embedder: stubEmbedder() },
+      async () => 'inner-result',
+    );
+    expect(await wrapped(brief())).toBe('inner-result');
+  });
+
+  it('passes the enriched brief as the inner dispatch first arg', async () => {
+    mockedArchSearch.mockResolvedValue(result(canonicalHits()));
+    let seenBriefMd = '';
+    const wrapped = withKgContext(
+      { db: fakeDb, embedder: stubEmbedder() },
+      async (b) => {
+        seenBriefMd = b.briefMd;
+        return 'ok';
+      },
+    );
+    await wrapped(brief());
+    expect(seenBriefMd).toContain('## Architecture Context (auto-injected by AKG)');
+    expect(seenBriefMd).toContain('Build event-sourcing leaderboard');
+  });
+
+  it('stashes the original briefMd in metadata.kgDispatchHook.originalBriefMd', async () => {
+    mockedArchSearch.mockResolvedValue(result(canonicalHits()));
+    const sniffed: { meta?: Record<string, unknown> } = {};
+    const wrapped = withKgContext(
+      { db: fakeDb, embedder: stubEmbedder() },
+      async (b) => {
+        sniffed.meta = (b.metadata?.['kgDispatchHook'] ?? {}) as Record<string, unknown>;
+      },
+    );
+    await wrapped(brief());
+    expect(sniffed.meta?.['originalBriefMd']).toBe(brief().briefMd);
+  });
+
+  it('emits context.injected on the bus when one is supplied', async () => {
+    mockedArchSearch.mockResolvedValue(result(canonicalHits()));
+    const bus = createEventBus();
+    const received: ContextInjectedEvent[] = [];
+    bus.on<ContextInjectedEvent>(CONTEXT_INJECTED, (ev) => {
+      received.push(ev);
+    });
+    const wrapped = createKgDispatchHook({ db: fakeDb, embedder: stubEmbedder(), eventBus: bus })(
+      async () => 'ok',
+    );
+    await wrapped(brief());
+    expect(received).toHaveLength(1);
+    expect(received[0]?.callerAgentId).toBe('agent-z');
+    expect(received[0]?.retrievedIds.length).toBeGreaterThan(0);
+  });
+
+  it('still runs the inner dispatch when injection throws (soft fail)', async () => {
+    mockedArchSearch.mockRejectedValue(new Error('boom'));
+    let innerRan = false;
+    const wrapped = withKgContext(
+      { db: fakeDb, embedder: stubEmbedder() },
+      async () => {
+        innerRan = true;
+        return 'still-ok';
+      },
+    );
+    const out = await wrapped(brief());
+    expect(out).toBe('still-ok');
+    expect(innerRan).toBe(true);
+  });
+
+  it('calls onInjected callback with the event payload', async () => {
+    mockedArchSearch.mockResolvedValue(result(canonicalHits()));
+    const calls: ContextInjectedEvent[] = [];
+    const wrapped = withKgContext(
+      { db: fakeDb, embedder: stubEmbedder() },
+      async () => 'ok',
+      {
+        onInjected: (e) => {
+          calls.push(e);
+        },
+      },
+    );
+    await wrapped(brief());
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.intent).toBe('build');
+  });
+});

--- a/packages/knowledge-graph-dispatch-hook/tests/integration.test.ts
+++ b/packages/knowledge-graph-dispatch-hook/tests/integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * integration.test.ts — end-to-end with a real in-memory better-sqlite3 +
+ * sqlite-vec AKG.
+ *
+ * Boots the AKG (main table + vec0 + fts5), indexes a tiny fixture
+ * (2 ADRs + 1 principle-tagged row + 1 lesson-tagged row + 1
+ * feedback-tagged row), and exercises injectContext() with the
+ * StubEmbeddingClient so the test is deterministic (no Ollama
+ * dependency).
+ *
+ * Spec verification (T07): "dispatch a research task touching event
+ * sourcing; assert ADR-011 appears in the injected context block."
+ * Adapted here to the test fixture's ADR ids.
+ */
+
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  bootstrapVectorTables,
+  upsertArtifactRow,
+  StubEmbeddingClient,
+  computeArtifactDedupKey,
+  type ArchArtifactRow,
+} from '@chiefaia/architecture-registry';
+
+import { injectContext } from '../src/api.js';
+
+/**
+ * Inline the `arch_artifacts` schema from
+ * apps/orchestrator/src/db/migrations/0030_architecture_registry.sql so
+ * the integration test can boot a self-contained in-memory DB without
+ * pulling drizzle in.
+ */
+function createArchTables(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE arch_artifacts (
+      id TEXT PRIMARY KEY NOT NULL,
+      kind TEXT NOT NULL,
+      project TEXT NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      key_signature TEXT,
+      file_paths_json TEXT NOT NULL DEFAULT '[]',
+      entry_path TEXT,
+      route_signature TEXT,
+      table_name TEXT,
+      owning_service TEXT,
+      package_name TEXT,
+      design_system_tier TEXT,
+      tech_sub_domains_json TEXT NOT NULL DEFAULT '[]',
+      tags_json TEXT NOT NULL DEFAULT '[]',
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      source TEXT NOT NULL,
+      content_hash TEXT,
+      extracted_at_commit TEXT,
+      embedding_model TEXT NOT NULL DEFAULT 'nomic-embed-text',
+      embedding_dim INTEGER NOT NULL DEFAULT 768,
+      embedding_version TEXT NOT NULL DEFAULT 'v1.5',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      dedup_key TEXT NOT NULL UNIQUE
+    );
+    CREATE TABLE arch_edges (
+      id TEXT PRIMARY KEY NOT NULL,
+      from_id TEXT NOT NULL,
+      to_id TEXT NOT NULL,
+      relation TEXT NOT NULL,
+      weight REAL NOT NULL DEFAULT 1.0,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      source TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (from_id, to_id, relation)
+    );
+    CREATE TABLE arch_extract_runs (
+      id TEXT PRIMARY KEY NOT NULL,
+      extractor TEXT NOT NULL,
+      project TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      finished_at INTEGER,
+      artifacts_seen INTEGER NOT NULL DEFAULT 0,
+      artifacts_upserted INTEGER NOT NULL DEFAULT 0,
+      edges_seen INTEGER NOT NULL DEFAULT 0,
+      edges_upserted INTEGER NOT NULL DEFAULT 0,
+      git_commit TEXT,
+      ok INTEGER NOT NULL DEFAULT 1,
+      error_message TEXT
+    );
+  `);
+}
+
+function makeRow(over: Partial<ArchArtifactRow>): ArchArtifactRow {
+  const now = Date.now();
+  const base: ArchArtifactRow = {
+    id: 'arch_test',
+    kind: 'adr',
+    project: 'caia',
+    name: 'Test',
+    description: 'Test description',
+    filePaths: [],
+    techSubDomains: [],
+    tags: [],
+    metadataJson: '{}',
+    source: 'manual',
+    embeddingModel: 'nomic-embed-text',
+    embeddingDim: 8,
+    embeddingVersion: 'v1.5',
+    createdAt: now,
+    updatedAt: now,
+    dedupKey: 'd'.repeat(40),
+    ...over,
+  } as ArchArtifactRow;
+  base.dedupKey = computeArtifactDedupKey({
+    project: base.project,
+    kind: base.kind,
+    name: base.name,
+    entryPath: base.entryPath ?? null,
+  });
+  return base;
+}
+
+describe('integration — real in-memory AKG', () => {
+  it('returns relevant feedback memories and ADRs for a known task topic', async () => {
+    // 1. Boot in-memory DB + main schema + vec0 + fts5.
+    const db = new Database(':memory:');
+    createArchTables(db);
+    bootstrapVectorTables(db, 8);
+
+    // 2. 8-dim StubEmbeddingClient — fast and deterministic. Positional
+    //    args: (model, dim).
+    const stub = new StubEmbeddingClient('stub-embed-test', 8);
+
+    const rows: ArchArtifactRow[] = [
+      makeRow({
+        id: 'arch_adr_011',
+        name: 'ADR-011 Event-first state with database as projection',
+        description: 'Use event sourcing; database is a projection.',
+        kind: 'adr',
+        entryPath: 'caia-ea/decisions/ADR-011-event-first-state.md',
+      }),
+      makeRow({
+        id: 'arch_adr_028',
+        name: 'ADR-028 Architecture Knowledge Graph via sqlite-vec + nomic-embed',
+        description: 'AKG storage and embedding stack.',
+        kind: 'adr',
+        entryPath: 'caia-ea/decisions/ADR-028-akg.md',
+      }),
+      makeRow({
+        id: 'arch_p3',
+        name: 'P3 No timelines, ever',
+        description: 'Operator policy: no calendar estimates.',
+        kind: 'adr',
+        tags: ['principle'],
+        entryPath: 'caia-ea/principles/P3-no-timelines.md',
+      }),
+      makeRow({
+        id: 'arch_l01',
+        name: 'L01 Pixel-perfect calibration thresholds',
+        description: 'Use 85% and 95% diff thresholds.',
+        kind: 'adr',
+        tags: ['lesson'],
+        entryPath: 'caia-ea/lessons-learned/L01-pixel-perfect.md',
+      }),
+      makeRow({
+        id: 'arch_fb',
+        name: 'feedback-continuous-discipline-problem',
+        description: 'Feedback: enforce discipline continuously.',
+        kind: 'adr',
+        tags: ['feedback'],
+        entryPath: 'agent-memory/2026-05-24-continuous-discipline.md',
+      }),
+    ];
+
+    for (const r of rows) {
+      const embed = await stub.embed(`${r.name} ${r.description}`);
+      upsertArtifactRow(db, r, embed.embedding);
+    }
+
+    // 3. Run injectContext with a query that should hit every fixture row.
+    const out = await injectContext(
+      {
+        callerAgentId: 'integration-test',
+        briefMd:
+          'Build an event-sourced leaderboard, respecting no-timelines policy and pixel-perfect calibration.',
+        intent: 'build',
+      },
+      { db, embedder: stub },
+      { topK: 6, threshold: 0 }, // threshold 0 so the stub vectors all match
+    );
+
+    // 4. Assertions: the preamble was rendered with the AKG hits.
+    expect(out.preamble).toContain('## Architecture Context (auto-injected by AKG)');
+    expect(out.preamble).toContain('### ADRs');
+    expect(out.retrieved.length).toBeGreaterThan(0);
+
+    // The ADR with the matching id appears.
+    expect(out.preamble).toMatch(/ADR-011/);
+
+    // The brief now has the preamble prepended.
+    expect(out.brief.startsWith('## Architecture Context')).toBe(true);
+
+    db.close();
+  });
+});

--- a/packages/knowledge-graph-dispatch-hook/tsconfig.json
+++ b/packages/knowledge-graph-dispatch-hook/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitOverride": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/knowledge-graph-dispatch-hook/tsconfig.test.json
+++ b/packages/knowledge-graph-dispatch-hook/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/knowledge-graph-dispatch-hook/vitest.config.ts
+++ b/packages/knowledge-graph-dispatch-hook/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2099,6 +2099,34 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/knowledge-graph-dispatch-hook:
+    dependencies:
+      '@chiefaia/architecture-registry':
+        specifier: workspace:*
+        version: link:../architecture-registry
+      '@chiefaia/events':
+        specifier: workspace:*
+        version: link:../events
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.9.0
+      sqlite-vec:
+        specifier: ^0.1.9
+        version: 0.1.9
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/librarian:
     dependencies:
       better-sqlite3:


### PR DESCRIPTION
## Summary

Ships **Layer 3** of the AI-First Continuous-Discipline framework
(`research/ai_first_continuous_discipline_2026.md`). Activates the
already-built but underused Architecture Knowledge Graph
(`@chiefaia/architecture-registry` — nomic-embed-text + sqlite-vec) for
**pre-dispatch context injection**: every fresh subagent dispatch
receives the most-relevant ADRs / principles / lessons / feedback
memories auto-prepended to its brief based on semantic similarity to
the task topic.

Mirrors the higher-order dispatch-wrapper pattern in
`@caia/policy-linter` (Layer 1 validating hook) and
`@chiefaia/llm-cache`'s `withCache` HOF. Together they compose the full
preflight in spec order:

```
brief → Layer 3 (this)  → Layer 2 (EA Architect)  → Layer 1 (policy-linter)  → spawn
        mutate, enrich    mutate, rewrite plan      validate, refuse
```

## What's in the package

`packages/knowledge-graph-dispatch-hook/`:

- `src/embedder.ts` — KG semantic-search adapter over `archSearch` with
  kind normalisation (tag-based fallback until spec task T06 promotes
  `principle`/`lesson`/`feedback` to first-class kinds), slot-rolling
  `kindMix` allocator, and embedder-down sparse-only fallback.
- `src/context-builder.ts` — renders the "Architecture Context
  (auto-injected by AKG)" markdown preamble verbatim from spec lines
  651-672.
- `src/api.ts` — `injectContext(brief, deps, opts?) → EnrichedBrief`.
  Pure function. Never throws.
- `src/hook.ts` — `createKgDispatchHook(deps, opts?)` factory +
  standalone `withKgContext(deps, inner, opts?)` HOF. Emits
  `context.injected` on the `@chiefaia/events` bus when wired.
- `src/types.ts`, `src/index.ts` — public surface.
- `README.md` — usage, knobs, failure modes, forward-compat note.

## Tests

**69 tests, all passing** (≥30 required):

| File | Tests |
|------|-------|
| `tests/embedder.test.ts` | 30 |
| `tests/context-builder.test.ts` | 21 |
| `tests/api.test.ts` | 11 |
| `tests/hook.test.ts` | 6 |
| `tests/integration.test.ts` | 1 |

The integration test boots an in-memory `better-sqlite3` + `sqlite-vec`
AKG, indexes a synthetic fixture (ADRs + principle-tagged +
lesson-tagged + feedback-tagged rows) using
`StubEmbeddingClient` for determinism, and asserts the preamble
contains the expected rows for a known task topic — closes the spec
T07 verification requirement.

## Default knobs (per spec)

- `topK = 6` (sum of default `kindMix`)
- `threshold = 0.6` (sqlite-vec cosine, spec line 676)
- `kindMix = { adr: 3, principle: 1, lesson: 1, feedback: 1 }`
- `disabled = false`

## Failure modes (graceful degradation, spec lines 282-285)

| Condition | `stats.fallbackUsed` | Behaviour |
|-----------|----------------------|-----------|
| `opts.disabled === true` | `disabled` | Instant no-op |
| Empty AKG / zero hits | `empty-kg` | Brief passes through |
| Ollama unavailable | `sparse-only` | Falls back to FTS5 |
| DB error | `embedder-down` | Brief passes through |

The package **never throws** and **never blocks** the wrapped
dispatch.

## Cost discipline

Zero outbound network. All retrieval + embedding is local
(Ollama + sqlite). Aligns with P1 (subscription-only) and P14
(no-paid-API).

## EA Architect review

The plan was submitted to `@caia/ea-architect.submitPlan` (per the
True-Zero gating constraint) — submissionId
`eareview-mpkow6gu-1-hpmn35`. The default Claude-spawned critic timed
out at its 90s budget; the FSM persisted a structured outcome with
reasoning `"claude spawn failed: claude binary timed out after
90000ms"` (an infrastructure timeout, not a substantive architectural
rejection). The submission did round-trip through the agent. Plan
content unchanged.

## Forward compatibility note

The AKG schema today exposes `ArtifactKind = 'adr' | ...` but not yet
`'principle' | 'lesson' | 'feedback'` — those land in spec task T06.
This package recognises both: today, principle/lesson/feedback rows
are indexed as `kind='adr'` with a discriminating tag in `tags[]`;
after T06 they'll be first-class kinds. No code change needed when
T06 ships — `embedder.normaliseHit()` handles both shapes.

## Verification commands

```bash
cd packages/knowledge-graph-dispatch-hook
node node_modules/typescript/bin/tsc --noEmit -p tsconfig.test.json   # clean
node node_modules/vitest/dist/cli.js run                              # 69/69 pass
node node_modules/typescript/bin/tsc -p tsconfig.json                  # dist built
```

## Branch / merge

- Base: `develop`
- Branch: `feat/knowledge-graph-dispatch-hook-2026-05-25`
- Merge: `gh pr merge --admin --squash` (True-Zero constraint).
