### PR TITLE
fix(apps/dashboard): build @chiefaia/events before @caia/billing (unblocks dashboard-publish)

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "build": "pnpm --filter @caia/billing --filter @caia/ui --filter @chiefaia/event-bus-nats --filter @chiefaia/tracing build && next build",
+    "build": "pnpm --filter @chiefaia/events --filter @chiefaia/tracing --filter @caia/billing --filter @caia/ui --filter @chiefaia/event-bus-nats build && next build",
     "dev": "next dev -p 7777",
     "lighthouse": "lhci autorun --config=./lighthouserc.cjs",
     "size-limit": "size-limit",


### PR DESCRIPTION
Follow-up to #612: the dashboard-publish workflow's Docker build was failing because `@caia/billing`'s tsc couldn't resolve `@chiefaia/events` — that package had no `dist/` tree because it wasn't in the dashboard's build filter chain.

Fix: prepend `@chiefaia/events` (and `@chiefaia/tracing` for consistency) to the filter chain so they build BEFORE downstream consumers. pnpm --filter respects workspace dep order, so events lands first.

One-line, no behavioural change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build script execution order in the dashboard package configuration to improve build performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prakashgbid/caia/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->