### PR TITLE
fix(apps/dashboard): build all transitive workspace deps (unblocks publish)

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "build": "pnpm --filter @chiefaia/events --filter @chiefaia/tracing --filter @caia/billing --filter @caia/ui --filter @chiefaia/event-bus-nats build && next build",
+    "build": "pnpm --filter '@caia-app/dashboard^...' build && next build",
     "dev": "next dev -p 7777",
     "lighthouse": "lhci autorun --config=./lighthouserc.cjs",
     "size-limit": "size-limit",


### PR DESCRIPTION
Follow-up to #617. The dashboard-publish Docker build now fails on `@caia/state-machine` — same pattern as `@chiefaia/events` (dist/ missing, not in transpilePackages).

Rather than enumerate every workspace dep (15+) and chase whichever one breaks next, use pnpm's `^...` filter syntax to build **all transitive workspace deps** of the dashboard in topo order, then `next build`. One-line, no behavioural change.